### PR TITLE
fix: do not call useId() conditionally

### DIFF
--- a/packages/core/src/RovingFocus/RovingFocusItem.vue
+++ b/packages/core/src/RovingFocus/RovingFocusItem.vue
@@ -24,7 +24,8 @@ const props = withDefaults(defineProps<RovingFocusItemProps>(), {
 })
 
 const context = injectRovingFocusGroupContext()
-const id = computed(() => props.tabStopId || useId())
+const randomId = useId()
+const id = computed(() => props.tabStopId || randomId)
 const isCurrentTabStop = computed(
   () => context.currentTabStopId.value === id.value,
 )


### PR DESCRIPTION
Calling `useId()` conditionally leads to issues when using Reka's based RadioGroup in [Historie](https://histoire.dev/):

```
runtime-core.esm-bundler.js:1488 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
    at useId (useId.ts:22:29)
    at ComputedRefImpl.fn (RovingFocusItem.vue:27:46)
    at ComputedRefImpl.fn (RovingFocusItem.vue:29:47)
```

This also happens in Reka's Historie. To reproduce:
- Start Historie
- Open RadioGroup story
- Open another story
- Go back to RadioGroup
- See error in console
