### PR TITLE
fix warning link to documentation

### DIFF
--- a/packages/core/src/Dialog/utils.ts
+++ b/packages/core/src/Dialog/utils.ts
@@ -24,7 +24,7 @@ export function useWarning({
 
 If you want to hide the \`${titleName}\`, you can wrap it with our VisuallyHidden component.
 
-For more information, see https://www.reka.com/components/${componentLink}`
+For more information, see https://reka-ui.com/docs/components/${componentLink}`
 
   const DESCRIPTION_MESSAGE = `Warning: Missing \`Description\` or \`aria-describedby="undefined"\` for ${contentName}.`
 


### PR DESCRIPTION
![Screenshot 2025-02-27 at 16 00 31](https://github.com/user-attachments/assets/11dcd6ba-925c-40e2-8923-50e55d8af696)

Warning util provides non-correct url to documentation. Quick fix of it