### PR TITLE
improve date components tree-shaking

### DIFF
--- a/packages/core/src/Calendar/CalendarRoot.vue
+++ b/packages/core/src/Calendar/CalendarRoot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { type DateValue, isEqualDay, isSameDay } from '@internationalized/date'
+import { type Calendar, type DateValue, GregorianCalendar, isEqualDay, isSameDay } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
@@ -85,6 +85,7 @@ interface BaseCalendarRootProps extends PrimitiveProps {
   nextPage?: (placeholder: DateValue) => DateValue
   /** A function that returns the previous page of the calendar. It receives the current placeholder as an argument inside the component. */
   prevPage?: (placeholder: DateValue) => DateValue
+  calendar?: Calendar
 }
 
 export interface MultipleCalendarRootProps extends BaseCalendarRootProps {
@@ -135,6 +136,7 @@ const props = withDefaults(defineProps<CalendarRootProps>(), {
   placeholder: undefined,
   isDateDisabled: undefined,
   isDateUnavailable: undefined,
+  calendar: () => new GregorianCalendar(),
 })
 const emits = defineEmits<CalendarRootEmits>()
 defineSlots<{
@@ -193,6 +195,7 @@ const defaultDate = getDefaultDate({
   defaultPlaceholder: props.placeholder,
   defaultValue: modelValue.value,
   locale: props.locale,
+  calendar: props.calendar,
 })
 
 const placeholder = useVModel(props, 'placeholder', emits, {

--- a/packages/core/src/DateField/DateFieldRoot.vue
+++ b/packages/core/src/DateField/DateFieldRoot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { DateValue } from '@internationalized/date'
+import { type Calendar, type DateValue, GregorianCalendar } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
@@ -63,6 +63,7 @@ export interface DateFieldRootProps extends PrimitiveProps, FormFieldProps {
   id?: string
   /** The reading direction of the date field when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
+  calendar?: Calendar
 }
 
 export type DateFieldRootEmits = {
@@ -92,6 +93,7 @@ const props = withDefaults(defineProps<DateFieldRootProps>(), {
   readonly: false,
   placeholder: undefined,
   isDateUnavailable: undefined,
+  calendar: () => new GregorianCalendar(),
 })
 const emits = defineEmits<DateFieldRootEmits>()
 defineSlots<{
@@ -128,6 +130,7 @@ const defaultDate = getDefaultDate({
   granularity: granularity.value,
   defaultValue: modelValue.value,
   locale: props.locale,
+  calendar: props.calendar,
 })
 
 const placeholder = useVModel(props, 'placeholder', emits, {

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { DateValue } from '@internationalized/date'
+import { type DateValue, GregorianCalendar } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import { computed, ref, toRefs, watch } from 'vue'
@@ -77,6 +77,7 @@ const props = withDefaults(defineProps<DatePickerRootProps>(), {
   locale: 'en',
   isDateDisabled: undefined,
   isDateUnavailable: undefined,
+  calendar: () => new GregorianCalendar(),
 })
 const emits = defineEmits<DatePickerRootEmits & PopoverRootEmits>()
 const {
@@ -117,6 +118,7 @@ const defaultDate = computed(() => getDefaultDate({
   granularity: props.granularity,
   defaultValue: modelValue.value,
   locale: props.locale,
+  calendar: props.calendar,
 }))
 
 const placeholder = useVModel(props, 'placeholder', emits, {

--- a/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
+++ b/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { DateValue } from '@internationalized/date'
+import { type Calendar, type DateValue, GregorianCalendar } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
@@ -77,6 +77,7 @@ export interface DateRangeFieldRootProps extends PrimitiveProps, FormFieldProps 
   id?: string
   /** The reading direction of the date field when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
   dir?: Direction
+  calendar?: Calendar
 }
 
 export type DateRangeFieldRootEmits = {
@@ -106,6 +107,7 @@ const props = withDefaults(defineProps<DateRangeFieldRootProps>(), {
   readonly: false,
   placeholder: undefined,
   isDateUnavailable: undefined,
+  calendar: () => new GregorianCalendar(),
 })
 const emits = defineEmits<DateRangeFieldRootEmits>()
 const { disabled, readonly, isDateUnavailable: propsIsDateUnavailable, dir: propDir, locale: propLocale } = toRefs(props)
@@ -131,6 +133,7 @@ const defaultDate = getDefaultDate({
   granularity: props.granularity,
   defaultValue: modelValue.value?.start,
   locale: props.locale,
+  calendar: props.calendar,
 })
 
 const placeholder = useVModel(props, 'placeholder', emits, {

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { DateValue } from '@internationalized/date'
+import { type DateValue, GregorianCalendar } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import { createContext, useDirection } from '@/shared'
@@ -83,6 +83,7 @@ const props = withDefaults(defineProps<DateRangePickerRootProps>(), {
   isDateDisabled: undefined,
   isDateUnavailable: undefined,
   allowNonContiguousRanges: false,
+  calendar: () => new GregorianCalendar(),
 })
 const emits = defineEmits<DateRangePickerRootEmits & PopoverRootEmits>()
 const {
@@ -123,6 +124,7 @@ const defaultDate = getDefaultDate({
   granularity: props.granularity,
   defaultValue: modelValue.value?.start,
   locale: props.locale,
+  calendar: props.calendar,
 })
 
 const placeholder = useVModel(props, 'placeholder', emits, {

--- a/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { type DateValue, isEqualDay } from '@internationalized/date'
+import { type Calendar, type DateValue, GregorianCalendar, isEqualDay } from '@internationalized/date'
 
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
@@ -97,6 +97,7 @@ export interface RangeCalendarRootProps extends PrimitiveProps {
   nextPage?: (placeholder: DateValue) => DateValue
   /** A function that returns the previous page of the calendar. It receives the current placeholder as an argument inside the component. */
   prevPage?: (placeholder: DateValue) => DateValue
+  calendar?: Calendar
 }
 
 export type RangeCalendarRootEmits = {
@@ -133,6 +134,7 @@ const props = withDefaults(defineProps<RangeCalendarRootProps>(), {
   isDateDisabled: undefined,
   isDateUnavailable: undefined,
   allowNonContiguousRanges: false,
+  calendar: () => new GregorianCalendar(),
 })
 const emits = defineEmits<RangeCalendarRootEmits>()
 
@@ -197,6 +199,7 @@ const defaultDate = getDefaultDate({
   defaultPlaceholder: props.placeholder,
   defaultValue: currentModelValue.value.start,
   locale: props.locale,
+  calendar: props.calendar,
 })
 
 const startValue = ref(currentModelValue.value.start) as Ref<DateValue | undefined>

--- a/packages/core/src/shared/date/comparators.ts
+++ b/packages/core/src/shared/date/comparators.ts
@@ -2,7 +2,7 @@
   * Implementation ported from https://github.com/melt-ui/melt-ui/blob/develop/src/lib/internal/helpers/date/utils.ts
 */
 
-import { CalendarDate, CalendarDateTime, DateFormatter, type DateValue, Time, type ZonedDateTime, createCalendar, toCalendar } from '@internationalized/date'
+import { type Calendar, CalendarDate, CalendarDateTime, type DateValue, Time, type ZonedDateTime, toCalendar } from '@internationalized/date'
 
 export type TimeValue = Time | CalendarDateTime | ZonedDateTime
 
@@ -14,6 +14,7 @@ type GetDefaultDateProps = {
   defaultPlaceholder?: DateValue | undefined
   granularity?: Granularity
   locale?: string
+  calendar: Calendar
 }
 
 /**
@@ -27,7 +28,7 @@ type GetDefaultDateProps = {
  *
  */
 export function getDefaultDate(props: GetDefaultDateProps): DateValue {
-  const { defaultValue, defaultPlaceholder, granularity = 'day', locale = 'en' } = props
+  const { defaultValue, defaultPlaceholder, granularity = 'day', calendar } = props
 
   if (Array.isArray(defaultValue) && defaultValue.length)
     return defaultValue.at(-1)!.copy()
@@ -43,9 +44,6 @@ export function getDefaultDate(props: GetDefaultDateProps): DateValue {
   const month = date.getMonth() + 1
   const day = date.getDate()
   const calendarDateTimeGranularities = ['hour', 'minute', 'second']
-
-  const defaultFormatter = new DateFormatter(locale)
-  const calendar = createCalendar(defaultFormatter.resolvedOptions().calendar)
 
   if (calendarDateTimeGranularities.includes(granularity ?? 'day'))
     return toCalendar(new CalendarDateTime(year, month, day, 0, 0, 0), calendar)


### PR DESCRIPTION
Hi

While using the new `Calendar` component, I noticed that the resulting bundle contained all calendars from `@internationalized/date` instead of one Gregorian that is used #1676 

I tried to remove `createCalendar` function call that uses all calendars, and instead pass the calendar on my own (if user wants another calendar system, calendar instance can be passed as a property), it should allow bundler to tree shake all other calendar systems

Is it something you would consider implementing? Let me know so I can clean this up a little and add a documentation!