### PR TITLE
docs: Update DocCommunity.vue

### DIFF
--- a/docs/.vitepress/components/DocCommunity.vue
+++ b/docs/.vitepress/components/DocCommunity.vue
@@ -27,7 +27,7 @@ const links = computed(() => [
           :key="link.label"
           :href="link.url"
           target="_blank"
-          class="inline-flex gap-2 items-center font-medium text-muted-foreground hover:text-white text-sm"
+          class="inline-flex gap-2 items-center font-medium text-muted-foreground hover:text-foreground text-sm"
         >
           <Icon
             class="text-xl"


### PR DESCRIPTION
Fix hover style for light mode theme. When in light mode theme, the original hover color is white, if you hover on the link, you will see nothing.