### PR TITLE
In NavigationMenu, allow disabling trigger close on link click

### DIFF
--- a/packages/core/src/NavigationMenu/NavigationMenu.test.ts
+++ b/packages/core/src/NavigationMenu/NavigationMenu.test.ts
@@ -10,6 +10,7 @@ import { sleep } from '@/test'
 import NavigationMenuItem from './NavigationMenuItem.vue'
 
 import { useDebounceFn } from '@vueuse/core'
+import NavigationMenuLink from './NavigationMenuLink.vue'
 
 vi.mock('@vueuse/core', async () => {
   const actual = await vi.importActual('@vueuse/core')
@@ -109,6 +110,8 @@ describe('given default NavigationMenu', () => {
 
     const findLinkContent = () => wrapper.find('[data-dismissable-layer]')
 
+    const findLink = () => wrapper.findComponent(NavigationMenuLink)
+
     it('should open menu on click by default', async () => {
       const button = findTriggerButton()
 
@@ -158,6 +161,23 @@ describe('given default NavigationMenu', () => {
       const content = findLinkContent()
 
       expect(content.exists()).toBeFalsy()
+    })
+
+    it('should not close content on link click', async () => {
+      await wrapper.setProps({ disableLinkClickClose: true })
+      const button = findTriggerButton()
+
+      button.trigger('click', { pointerType: 'mouse' })
+
+      await wrapper.vm.$nextTick()
+
+      const link = findLink()
+
+      link.trigger('click', { pointerType: 'mouse' })
+
+      await wrapper.vm.$nextTick()
+
+      expect(button.element.getAttribute('data-state')).toEqual('open')
     })
   })
 })

--- a/packages/core/src/NavigationMenu/NavigationMenuLink.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuLink.vue
@@ -20,6 +20,7 @@ export interface NavigationMenuLinkProps extends PrimitiveProps {
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
 import { EVENT_ROOT_CONTENT_DISMISS, LINK_SELECT } from './utils'
+import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
 
 const props = withDefaults(defineProps<NavigationMenuLinkProps>(), {
   as: 'a',
@@ -29,6 +30,8 @@ const emits = defineEmits<NavigationMenuLinkEmits>()
 
 const { CollectionItem } = useCollection({ key: 'NavigationMenu' })
 useForwardExpose()
+
+const menuContext = injectNavigationMenuContext()
 
 async function handleClick(ev: MouseEvent) {
   const linkSelectEvent = new CustomEvent(LINK_SELECT, {
@@ -40,7 +43,7 @@ async function handleClick(ev: MouseEvent) {
   })
   emits('select', linkSelectEvent)
 
-  if (!linkSelectEvent.defaultPrevented && !ev.metaKey) {
+  if (!linkSelectEvent.defaultPrevented && !ev.metaKey && !menuContext.disableLinkClickClose.value) {
     const rootContentDismissEvent = new CustomEvent(
       EVENT_ROOT_CONTENT_DISMISS,
       {

--- a/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
@@ -49,6 +49,11 @@ export interface NavigationMenuRootProps extends PrimitiveProps {
    * @defaultValue false
    */
   disablePointerLeaveClose?: boolean
+  /**
+   * If `true`, menu will not close by click on link
+   * @defaultValue false
+   */
+  disableLinkClickClose?: boolean
 
   /**
    * When `true`, the element will be unmounted on closed state.
@@ -71,6 +76,7 @@ export interface NavigationMenuContext {
   orientation: Orientation
   disableClickTrigger: Ref<boolean>
   disableHoverTrigger: Ref<boolean>
+  disableLinkClickClose: Ref<boolean>
   unmountOnHide: Ref<boolean>
   rootNavigationMenu: Ref<HTMLElement | undefined>
   activeTrigger: Ref<HTMLElement | undefined>
@@ -109,6 +115,8 @@ const props = withDefaults(defineProps<NavigationMenuRootProps>(), {
   orientation: 'horizontal',
   disableClickTrigger: false,
   disableHoverTrigger: false,
+  disablePointerLeaveClose: false,
+  disableLinkClickClose: false,
   unmountOnHide: true,
   as: 'nav',
 })
@@ -135,7 +143,7 @@ const activeTrigger = ref<HTMLElement>()
 
 const { getItems, CollectionSlot } = useCollection({ key: 'NavigationMenu', isProvider: true })
 
-const { delayDuration, skipDelayDuration, dir: propDir, disableClickTrigger, disableHoverTrigger, unmountOnHide } = toRefs(props)
+const { delayDuration, skipDelayDuration, dir: propDir, disableClickTrigger, disableHoverTrigger, disableLinkClickClose, unmountOnHide } = toRefs(props)
 const dir = useDirection(propDir)
 
 const isDelaySkipped = refAutoReset(false, skipDelayDuration)
@@ -171,6 +179,7 @@ provideNavigationMenuContext({
   baseId: useId(undefined, 'reka-navigation-menu'),
   disableClickTrigger,
   disableHoverTrigger,
+  disableLinkClickClose,
   dir,
   unmountOnHide,
   orientation: props.orientation,

--- a/packages/core/src/NavigationMenu/story/_NavigationMenu.vue
+++ b/packages/core/src/NavigationMenu/story/_NavigationMenu.vue
@@ -15,11 +15,13 @@ import NavigationMenuListItem from './_NavigationMenuListItem.vue'
 export interface TestProps {
   disableClickTrigger?: boolean
   disableHoverTrigger?: boolean
+  disableLinkClickClose?: boolean
 }
 
 const props = withDefaults(defineProps<TestProps>(), {
   disableClickTrigger: false,
   disableHoverTrigger: false,
+  disableLinkClickClose: false,
 })
 
 const currentTrigger = ref('')
@@ -35,7 +37,7 @@ const currentTrigger = ref('')
       <NavigationMenuList
         class="center shadow-blackA7 m-0 flex list-none rounded-[6px] bg-white p-1 shadow-[0_2px_10px]"
       >
-        <NavigationMenuItem>
+        <NavigationMenuItem value="learn">
           <NavigationMenuTrigger
             class="text-grass11 hover:bg-green3 focus:shadow-green7 group flex select-none items-center justify-between gap-[2px] rounded-[4px] px-3 py-2 text-[15px] font-medium leading-none outline-none focus:shadow-[0_0_0_2px]"
           >
@@ -52,7 +54,6 @@ const currentTrigger = ref('')
                   href="/"
                   target="_blank"
                   class="focus:shadow-green7 from-green9 to-teal9 flex h-full w-full select-none flex-col justify-end rounded-[6px] bg-gradient-to-b p-[25px] no-underline outline-none focus:shadow-[0_0_0_2px]"
-                  @select.prevent
                 >
                   <svg
                     alt="logo"
@@ -103,7 +104,7 @@ const currentTrigger = ref('')
           </NavigationMenuContent>
         </NavigationMenuItem>
 
-        <NavigationMenuItem>
+        <NavigationMenuItem value="overview">
           <NavigationMenuTrigger
             class="text-grass11 hover:bg-green3 focus:shadow-green7 group flex select-none items-center justify-between gap-[2px] rounded-[4px] px-3 py-2 text-[15px] font-medium leading-none outline-none focus:shadow-[0_0_0_2px]"
           >


### PR DESCRIPTION
When a `NavigationMenuLink` is clicked inside a `NavigationMenuContent`, it closes the opened menu item. This feature allows disabling this functionality with a `disableLinkClickClose` prop on `NavigationMenuRoot`, similarly to the other props to disable functionality.