### PR TITLE
fix(ComboboxRoot): properly initialize defaultValue

### DIFF
--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -94,7 +94,7 @@ const dir = useDirection(propDir)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   // @ts-expect-error ignore the type error here
-  defaultValue: props.defaultValue ?? multiple.value ? [] : undefined,
+  defaultValue: props.defaultValue ?? (multiple.value ? [] : undefined),
   passive: (props.modelValue === undefined) as false,
   deep: true,
 }) as Ref<T | T[]>


### PR DESCRIPTION
The default value of combobox does not work.

The concrete problem seems to be operator precedence, since the null coalescing operator has higher precedence (3) than the ternary operator (2). [[1](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table)]

So if you would supply a `defaultValue` of `"some value"` and leave `multiple` to be `false`, then it would evaluate to:
```js
"some value" ?? false ? [] : undefined
// outputs []
// but it should be "some value"
```

With this pull request, the evaluation would change to:
```js
"some value" ?? (false ? [] : undefined)
// outputs "some value"
```

Also see implementation of `SelectRoot.vue`, where `defaultValue` works:
https://github.com/unovue/reka-ui/blob/1f685625029187943ec456764756394e2d399520/packages/core/src/Select/SelectRoot.vue#L93

#### References
[1]\: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table