### PR TITLE
fix: export CollapsibleContentEmits type

### DIFF
--- a/packages/core/src/Collapsible/index.ts
+++ b/packages/core/src/Collapsible/index.ts
@@ -11,4 +11,5 @@ export {
 export {
   default as CollapsibleContent,
   type CollapsibleContentProps,
+  type CollapsibleContentEmits,
 } from './CollapsibleContent.vue'


### PR DESCRIPTION
Exported missing `CollapsibleContentEmits` type from its Vue component for improved type safety and usage consistency.

Fixes Issue #1694