### PR TITLE
feat(NumberField/NumberFieldRoot): add stepSnapping prop to disable snapping values to step (#1593)

### DIFF
--- a/docs/content/meta/NumberFieldRoot.md
+++ b/docs/content/meta/NumberFieldRoot.md
@@ -80,6 +80,13 @@
     'type': 'number',
     'required': false,
     'default': '1'
+  },
+  {
+    'name': 'stepSnapping',
+    'description': '<p>When <code>false</code>, prevents the value from snapping to the nearest increment of the step value.</p>\n',
+    'type': 'boolean',
+    'required': false,
+    'default': true
   }
 ]" />
 

--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -197,7 +197,7 @@ describe('numberField', () => {
     })
 
     it('should compute min-max with step correctly', async () => {
-      const { input } = setup({ min: 2, max: 21, step: 3 })
+      const { input } = setup({ min: 2, max: 21, step: 3, stepSnapping: true })
 
       expect(input.value).toBe('')
       await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 2
@@ -208,8 +208,19 @@ describe('numberField', () => {
       await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 17
       await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 20
       expect(input.value).toBe('20')
-      await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 20 (max)
+      await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 20 (max snapped to step)
       expect(input.value).toBe('20')
+    })
+
+    it('should compute min-max with step correctly when stepSnapping false', async () => {
+      const { input } = setup({ min: 17, max: 21, step: 3, stepSnapping: false })
+
+      expect(input.value).toBe('')
+      await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 17
+      await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 20
+      expect(input.value).toBe('20')
+      await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 21 (max not snapped to step)
+      expect(input.value).toBe('21')
     })
   })
 

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -14,6 +14,8 @@ export interface NumberFieldRootProps extends PrimitiveProps, FormFieldProps {
   max?: number
   /** The amount that the input value changes with each increment or decrement "tick". */
   step?: number
+  /** When `false`, prevents the value from snapping to the nearest increment of the step value */
+  stepSnapping?: boolean
   /** Formatting options for the value displayed in the number field. This also affects what characters are allowed to be typed by the user. */
   formatOptions?: Intl.NumberFormatOptions
   /** The locale to use for formatting dates */
@@ -63,9 +65,10 @@ const props = withDefaults(defineProps<NumberFieldRootProps>(), {
   as: 'div',
   defaultValue: undefined,
   step: 1,
+  stepSnapping: true,
 })
 const emits = defineEmits<NumberFieldRootEmits>()
-const { disabled, min, max, step, formatOptions, id, locale: propLocale } = toRefs(props)
+const { disabled, min, max, step, stepSnapping, formatOptions, id, locale: propLocale } = toRefs(props)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue,
@@ -147,7 +150,7 @@ function setInputValue(val: string) {
 function clampInputValue(val: number) {
   // Clamp to min and max, round to the nearest step, and round to specified number of digits
   let clampedValue: number
-  if (step.value === undefined || isNaN(step.value))
+  if (step.value === undefined || isNaN(step.value) || !stepSnapping.value)
     clampedValue = clamp(val, min.value, max.value)
   else
     clampedValue = snapValueToStep(val, min.value, max.value, step.value)


### PR DESCRIPTION
When a `step` prop is defined (which is generally the case, since it has a default of `1`) for `NumberFieldRoot` component, the value is automatically snapped to an increment of that step. This can be problematic when the step value is intended as a shortcut to help the user make changes, but not necessarily a requirement of the field.

For example, it is commonly desired for a number field to use a step of `1` if whole integers are the most common input, but still allow a user to enter a value such as `1.5` if necessary.

This pull request adds a new prop called `stepSnapping` which controls whether this value to step snapping occurs. The default value is `true` for backwards compatibility, but can be set to `false` to disable the snapping behaviour (does not affect snapping/clamping to min/max values).

Addresses #1593 