### PR TITLE
fix(NavigationMenu): allow viewport unmount to set menuContext viewport to null

### DIFF
--- a/packages/core/src/NavigationMenu/NavigationMenuViewport.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuViewport.vue
@@ -45,8 +45,7 @@ const position = ref<{ left: number, top: number }>()
 const open = computed(() => !!menuContext.modelValue.value)
 
 watch(currentElement, () => {
-  if (currentElement.value)
-    menuContext.onViewportChange(currentElement.value)
+  menuContext.onViewportChange(currentElement.value)
 })
 
 const content = ref<HTMLElement>()


### PR DESCRIPTION
If `NavigationMenuViewport` is dynamically unmounted, the `NavigationMenuRoot` is never updated in consequence. This pull request resolves this.

I need this in my project to allow my menu to show it's menu item content differently depending if the menu is collapsed or not. I implemented it by having a `v-if` on my `NavigationMenuViewport` bound to the `collapsed` prop.