### PR TITLE
feat(Toggle): Pass state of toggle to slot props

### DIFF
--- a/docs/content/meta/Toggle.md
+++ b/docs/content/meta/Toggle.md
@@ -58,7 +58,17 @@
 <SlotsTable :data="[
   {
     'name': 'modelValue',
+    'description': '<p>Current model value</p>\n',
+    'type': 'boolean'
+  },
+  {
+    'name': 'pressed',
     'description': '<p>Current pressed state</p>\n',
+    'type': 'boolean'
+  },
+  {
+    'name': 'disabled',
+    'description': '<p>Current disabled state</p>\n',
     'type': 'boolean'
   }
 ]" />

--- a/docs/content/meta/Toggle.md
+++ b/docs/content/meta/Toggle.md
@@ -58,8 +58,13 @@
 <SlotsTable :data="[
   {
     'name': 'modelValue',
-    'description': '<p>Current model value</p>\n',
+    'description': '<p>Current value</p>\n',
     'type': 'boolean'
+  },
+  {
+    'name': 'state',
+    'description': '<p>Current state</p>\n',
+    'type': '\'on\' | \'off\''
   },
   {
     'name': 'pressed',

--- a/docs/content/meta/ToggleGroupItem.md
+++ b/docs/content/meta/ToggleGroupItem.md
@@ -31,8 +31,13 @@
 <SlotsTable :data="[
   {
     'name': 'modelValue',
-    'description': '<p>Current model value</p>\n',
+    'description': '<p>Current value</p>\n',
     'type': 'boolean'
+  },
+  {
+    'name': 'state',
+    'description': '<p>Current state</p>\n',
+    'type': '\'on\' | \'off\''
   },
   {
     'name': 'pressed',

--- a/docs/content/meta/ToggleGroupItem.md
+++ b/docs/content/meta/ToggleGroupItem.md
@@ -27,3 +27,21 @@
     'required': true
   }
 ]" />
+
+<SlotsTable :data="[
+  {
+    'name': 'modelValue',
+    'description': '<p>Current model value</p>\n',
+    'type': 'boolean'
+  },
+  {
+    'name': 'pressed',
+    'description': '<p>Current pressed state</p>\n',
+    'type': 'boolean'
+  },
+  {
+    'name': 'disabled',
+    'description': '<p>Current disabled state</p>\n',
+    'type': 'boolean'
+  }
+]" />

--- a/packages/core/src/Toggle/Toggle.vue
+++ b/packages/core/src/Toggle/Toggle.vue
@@ -43,8 +43,10 @@ const emits = defineEmits<ToggleEmits>()
 
 defineSlots<{
   default: (props: {
-    /** Current model value */
+    /** Current value */
     modelValue: typeof modelValue.value
+    /** Current state */
+    state: typeof dataState.value
     /** Current pressed state */
     pressed: typeof modelValue.value
     /** Current disabled state */
@@ -87,6 +89,7 @@ const isFormControl = useFormControl(currentElement)
       :model-value="modelValue"
       :disabled="disabled"
       :pressed="modelValue"
+      :state="dataState"
     />
 
     <VisuallyHiddenInput

--- a/packages/core/src/Toggle/Toggle.vue
+++ b/packages/core/src/Toggle/Toggle.vue
@@ -79,7 +79,7 @@ const isFormControl = useFormControl(currentElement)
     :disabled="disabled"
     @click="togglePressed"
   >
-    <slot :model-value="modelValue" />
+    <slot :model-value="modelValue" :disabled="disabled" :active="modelValue" />
 
     <VisuallyHiddenInput
       v-if="isFormControl && name && !toggleGroupContext"

--- a/packages/core/src/Toggle/Toggle.vue
+++ b/packages/core/src/Toggle/Toggle.vue
@@ -43,8 +43,12 @@ const emits = defineEmits<ToggleEmits>()
 
 defineSlots<{
   default: (props: {
-    /** Current pressed state */
+    /** Current model value */
     modelValue: typeof modelValue.value
+    /** Current pressed state */
+    pressed: typeof modelValue.value
+    /** Current disabled state */
+    disabled: boolean
   }) => any
 }>()
 
@@ -79,7 +83,11 @@ const isFormControl = useFormControl(currentElement)
     :disabled="disabled"
     @click="togglePressed"
   >
-    <slot :model-value="modelValue" :disabled="disabled" :active="modelValue" />
+    <slot
+      :model-value="modelValue"
+      :disabled="disabled"
+      :pressed="modelValue"
+    />
 
     <VisuallyHiddenInput
       v-if="isFormControl && name && !toggleGroupContext"

--- a/packages/core/src/ToggleGroup/ToggleGroupItem.vue
+++ b/packages/core/src/ToggleGroup/ToggleGroupItem.vue
@@ -42,8 +42,9 @@ const { forwardRef } = useForwardExpose()
       :disabled="disabled"
       :model-value="pressed"
       @update:model-value="rootContext.changeModelValue(value)"
+      v-slot="toggleState"
     >
-      <slot />
+      <slot v-bind="toggleState" />
     </Toggle>
   </component>
 </template>

--- a/packages/core/src/ToggleGroup/ToggleGroupItem.vue
+++ b/packages/core/src/ToggleGroup/ToggleGroupItem.vue
@@ -39,12 +39,12 @@ const { forwardRef } = useForwardExpose()
     <Toggle
       v-bind="props"
       :ref="forwardRef"
+      v-slot="slotProps"
       :disabled="disabled"
       :model-value="pressed"
       @update:model-value="rootContext.changeModelValue(value)"
-      v-slot="toggleState"
     >
-      <slot v-bind="toggleState" />
+      <slot v-bind="slotProps" />
     </Toggle>
   </component>
 </template>


### PR DESCRIPTION
The state of the toggle should be accessible within slot props, not just within CSS.