### PR TITLE
fix(ComboboxRoot): fix ignored type error

### DIFF
--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -92,8 +92,7 @@ const { multiple, disabled, ignoreFilter, resetSearchTermOnSelect, dir: propDir 
 
 const dir = useDirection(propDir)
 
-const modelValue = useVModel(props, 'modelValue', emits, {
-  // @ts-expect-error ignore the type error here
+const modelValue = useVModel(props as ComboboxRootProps<T>, 'modelValue', emits, {
   defaultValue: props.defaultValue ?? (multiple.value ? [] : undefined),
   passive: (props.modelValue === undefined) as false,
   deep: true,


### PR DESCRIPTION
This pull request removes the `@ts-expect-error` from here:

https://github.com/unovue/reka-ui/blob/c9f4a2a2161f82fd1f6250c4a378ded535a7c641/packages/core/src/Combobox/ComboboxRoot.vue#L95-L100

And converts it to the following:
https://github.com/unovue/reka-ui/blob/69da1b1597c076cbb9263a2f6cbf05c761101a14/packages/core/src/Combobox/ComboboxRoot.vue#L95-L99

I hope this is acceptable.

### Reasoning

In order to understand this change, we need to have a look at how `useVModel` infers the type of the `defaultValue` option.

The `useVModel` function takes 3 generic parameters, of which the first two are important in this case, since they are used for the type of the `defaultValue` option:
1. `P extends object`
2. `K extends keyof P`
3. `Name extends string` (unimportant in this case, but included for completion)

`useVModel` uses `P` and `K` in order to set the first generic parameter of `UseVModelOptions` to `P[K]`. And the first generic parameter of `UseVModelOptions` is used to set the type of the `defaultValue` option.

The generic parameter `P` will be infered to `typeof props`, since we pass it the `props` object. And the `K` parameter will be infered to `'modelValue'`, since we pass it the `'modelValue'` string. And we know that the `defaultValue` option has the type `P[K]` in the generic case, so in this specific case it would have the type `(typeof props)['modelValue']`.

Now when setting the `defaultValue` option (type `(typeof props)['modelValue']`) to `props.defaultValue` (type `T | T[] | undefined` from `ComboboxRootProps['defaultValue']`), we get the following type mismatch error:
![2025-03-15_17-53](https://github.com/user-attachments/assets/b0851af6-6e1c-41cc-a96c-b343a1795774)
(Note: I used a temporary variable here with the same type as `defaultValue` option, in order to make the error message more clear)

So it seems, that the type of `(typeof props)['modelValue']` is not `T | T[] | undefined` like we would expect, but rather `(T | T[] | undefined) & boolean`. The `& boolean` part is added here by `defineProps`, but I do not know why. Maybe it is there due to an edge case for the [boolean casting](https://vuejs.org/guide/components/props.html#boolean-casting) vue feature? I am not sure.

In any case, the `(T | T[] | undefined) & boolean` type is wrong and it should really be `T | T[] | undefined`, which is achieved by explicitly casting `props` to `ComboboxRootProps`. Then `P` would be infered to `ComboboxRootProps` and `P[K]` to `ComboboxRootProps['modelValue']`, which is exactly `T | T[] | undefined`.

There may be more solutions to this problem, but I chose the `props as ComboboxRootProps<T>` solution, because the `props` variable is really a type of `ComboboxRootProps<T>`, with a little type acrobatics added by vue's `defineProps`. But since vue's type is wrong in this case, I cast it back to `ComboboxRootProps<T>` just for the `useVModel` call.

