### PR TITLE
fix(NumberField/NumberFieldRoot): emit update:modelValue events after child input event (#1720)

### DIFF
--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -298,6 +298,29 @@ describe('numberField', () => {
       await fireEvent.keyDown(input, { key: kbd.ENTER })
       expect(input.value).toBe('EUR 7.00')
     })
+
+    it('should correctly update model value independently of formatting', async () => {
+      const { input, emitted } = setup({
+        defaultValue: 100,
+      })
+
+      // after update, both internal and displayed value are not formatted
+      await fireEvent.update(input, '1000')
+      expect(input.value).toBe('1000')
+      expect(emitted('update:model-value')[0]).toEqual([1000])
+      // update:model-value fired after each consecutive update
+      await fireEvent.update(input, '10000')
+      expect(input.value).toBe('10000')
+      expect(emitted('update:model-value')[1]).toEqual([10000])
+      // on 'enter' key press formatting is applied to text, model value does not change
+      await fireEvent.keyDown(input, { key: kbd.ENTER })
+      expect(input.value).toBe('10,000')
+      expect(emitted('update:model-value').length).toBe(2)
+      // update:model-value always sends non-formatted value even if current text is formatted
+      await fireEvent.update(input, '10,001')
+      expect(input.value).toBe('10,001')
+      expect(emitted('update:model-value')[2]).toEqual([10001])
+    })
   })
 })
 

--- a/packages/core/src/NumberField/NumberFieldInput.vue
+++ b/packages/core/src/NumberField/NumberFieldInput.vue
@@ -96,6 +96,7 @@ function handleChange() {
     @input="(event: InputEvent) => {
       const target = event.target as HTMLInputElement
       inputValue = target.value
+      rootContext.applyInputValue(target.value, false)
     }"
     @change="handleChange"
     @keydown.enter="rootContext.applyInputValue($event.target?.value)"

--- a/packages/core/src/NumberField/story/_NumberField.vue
+++ b/packages/core/src/NumberField/story/_NumberField.vue
@@ -4,6 +4,7 @@ import { NumberFieldDecrement, NumberFieldIncrement, NumberFieldInput, NumberFie
 import { Icon } from '@iconify/vue'
 
 const props = defineProps<NumberFieldRootProps>()
+const emit = defineEmits(['update:model-value'])
 </script>
 
 <template>
@@ -12,6 +13,7 @@ const props = defineProps<NumberFieldRootProps>()
     id="number-field"
     data-testid="root"
     class="text-sm flex items-center border bg-blackA7 border-blackA9 rounded-md text-white"
+    @update:model-value="emit('update:model-value', $event)"
   >
     <label
       for="number-field"


### PR DESCRIPTION
Previously, the NumberFieldRoot component would only emit `update:modelValue` events when the child input element emitted a `change` event, which only occurs after the user has finished making changes and leaves the field. This is not consistent with the behaviour you would see on a native input where the value changes after every `input` event, after each keypress and intermediary value entered.

This PR makes changes to how the text value is displayed and how the model value is emitted, allowing the model value to emit more frequently as the user types (after an `input` event occurs), while not affecting the existing behaviour of when any formatting, clamping, or snapping is applied to the displayed value.

Additionally, the emitted model value pre-calculates any clamping or snapping to ensure that it reflects what the displayed text value will change to if the user were to hit 'enter' or leave the field.

This is done by removing the existing `computed` property which tied the displayed text value firmly to the current model value, and instead uses a watcher which can react to changes in any prop values that affect the text value, but selectively ignore a change when it is known to be caused by a user input which may not yet be fully complete.

Addresses #1720 