### PR TITLE
fix(TagsInput): fix comparing model values when looking for current item index in TagsInputItemDelete

### DIFF
--- a/packages/core/src/TagsInput/TagsInputItemDelete.vue
+++ b/packages/core/src/TagsInput/TagsInputItemDelete.vue
@@ -4,6 +4,7 @@ import { injectTagsInputItemContext } from './TagsInputItem.vue'
 import { injectTagsInputRootContext } from './TagsInputRoot.vue'
 import { computed } from 'vue'
 import { useForwardExpose } from '@/shared'
+import { isEqual } from 'ohash'
 
 export interface TagsInputItemDeleteProps extends PrimitiveProps {}
 </script>
@@ -24,7 +25,7 @@ const disabled = computed(() => itemContext.disabled?.value || context.disabled.
 function handleDelete() {
   if (disabled.value)
     return
-  const index = context.modelValue.value.findIndex(i => i === itemContext.value.value)
+  const index = context.modelValue.value.findIndex(i => isEqual(i, itemContext.value.value))
   context.onRemoveValue(index)
 }
 </script>


### PR DESCRIPTION
Since `modelValue` is somehow deeply wrapped when using `useVModel` it might not be the same reference as the `value` props passed to `TagsInputItem`. 

We found this the hard way when following [Combobox with TagsInput](https://reka-ui.com/examples/combobox-tags-input) example:

```
<template>
  <ComboboxRoot
    v-model="values"
  >
    <ComboboxAnchor>
      <TagsInputRoot
        v-model="values"
        delimiter=""
      >
        <TagsInputItem
          v-for="item in values"
          :key="item"
          :value="item"  <-- this item is no longer the same reference as i.e. values[0]
```