### PR TITLE
docs(Showcase): add `una-ui` to the packages section

### DIFF
--- a/docs/content/showcase.md
+++ b/docs/content/showcase.md
@@ -28,6 +28,11 @@ packages:
     description: Float UI offers all the vital building blocks you need to transform your idea into a great-looking startup.
     url: https://floatui.com/
     image: https://ph-files.imgix.net/56069229-222e-4364-88c6-8c5d4aa0c3e5.png?auto=compress&codec=mozjpeg&cs=strip&auto=format&fit=max&dpr=1
+  
+  - title: Una UI
+    description: The Atomic UI Framework for Nuxt, Powered by Unocss engine.
+    url: https://unaui.com/
+    image: https://unaui.com/hero.png
 
 projects:
   - title: UnInbox


### PR DESCRIPTION
It should be in v2 as well. I didn’t notice that the showcase button redirect is in v1. 

Reference: https://github.com/unovue/reka-ui/pull/1731.

Thanks again 💚.
