### PR TITLE
fix: correct direction for PageUp/PageDown when slider is vertical inverted

### DIFF
--- a/packages/core/src/Slider/Slider.test.ts
+++ b/packages/core/src/Slider/Slider.test.ts
@@ -52,6 +52,240 @@ describe('given default Slider', () => {
     })
   })
 
+  describe('when inverted', () => {
+    beforeEach(async () => {
+      await wrapper.setProps({ inverted: true })
+    })
+
+    describe('after pressing navigation key', () => {
+      let slider: DOMWrapper<HTMLElement>
+
+      beforeEach(() => {
+        slider = wrapper.find('[role="slider"]')
+      })
+
+      it('arrowRight should decrease by 1', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'ArrowRight' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('49')
+        expect(diff).toBe(-1)
+      })
+
+      it('arrowLeft should increase by 1', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'ArrowLeft' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('51')
+        expect(diff).toBe(1)
+      })
+
+      it('arrowUp should increase by 1', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'ArrowUp' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('51')
+        expect(diff).toBe(1)
+      })
+
+      it('arrowDown should decrease by 1', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'ArrowDown' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('49')
+        expect(diff).toBe(-1)
+      })
+
+      it('pageUp should increase by 10', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'PageUp' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('60')
+        expect(diff).toBe(10)
+      })
+
+      it('pageDown should decrease by 10', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'PageDown' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('40')
+        expect(diff).toBe(-10)
+      })
+
+      it('home should set value to 0', async () => {
+        await slider.trigger('keydown', { key: 'Home' })
+        expect(slider.attributes('aria-valuenow')).toBe('0')
+      })
+
+      it('end should set value to max', async () => {
+        await slider.trigger('keydown', { key: 'End' })
+        expect(slider.attributes('aria-valuenow')).toBe('100')
+      })
+    })
+  })
+
+  describe('when vertical', () => {
+    beforeEach(async () => {
+      await wrapper.setProps({ orientation: 'vertical' })
+    })
+
+    describe('when inverted', () => {
+      beforeEach(async () => {
+        await wrapper.setProps({ inverted: true })
+      })
+
+      describe('after pressing navigation key', () => {
+        let slider: DOMWrapper<HTMLElement>
+
+        beforeEach(() => {
+          slider = wrapper.find('[role="slider"]')
+        })
+
+        it('arrowRight should increase by 1', async () => {
+          const currentValue = slider.attributes('aria-valuenow')
+          await slider.trigger('keydown', { key: 'ArrowRight' })
+          const newValue = slider.attributes('aria-valuenow')
+          const diff = Number(newValue) - Number(currentValue)
+          expect(slider.attributes('aria-valuenow')).toBe('51')
+          expect(diff).toBe(1)
+        })
+
+        it('arrowLeft should decrease by 1', async () => {
+          const currentValue = slider.attributes('aria-valuenow')
+          await slider.trigger('keydown', { key: 'ArrowLeft' })
+          const newValue = slider.attributes('aria-valuenow')
+          const diff = Number(newValue) - Number(currentValue)
+          expect(slider.attributes('aria-valuenow')).toBe('49')
+          expect(diff).toBe(-1)
+        })
+
+        it('arrowUp should decrease by 1', async () => {
+          const currentValue = slider.attributes('aria-valuenow')
+          await slider.trigger('keydown', { key: 'ArrowUp' })
+          const newValue = slider.attributes('aria-valuenow')
+          const diff = Number(newValue) - Number(currentValue)
+          expect(slider.attributes('aria-valuenow')).toBe('49')
+          expect(diff).toBe(-1)
+        })
+
+        it('arrowDown should increase by 1', async () => {
+          const currentValue = slider.attributes('aria-valuenow')
+          await slider.trigger('keydown', { key: 'ArrowDown' })
+          const newValue = slider.attributes('aria-valuenow')
+          const diff = Number(newValue) - Number(currentValue)
+          expect(slider.attributes('aria-valuenow')).toBe('51')
+          expect(diff).toBe(1)
+        })
+
+        it('pageUp should decrease by 10', async () => {
+          const currentValue = slider.attributes('aria-valuenow')
+          await slider.trigger('keydown', { key: 'PageUp' })
+          const newValue = slider.attributes('aria-valuenow')
+          const diff = Number(newValue) - Number(currentValue)
+          expect(slider.attributes('aria-valuenow')).toBe('40')
+          expect(diff).toBe(-10)
+        })
+
+        it('pageDown should increase by 10', async () => {
+          const currentValue = slider.attributes('aria-valuenow')
+          await slider.trigger('keydown', { key: 'PageDown' })
+          const newValue = slider.attributes('aria-valuenow')
+          const diff = Number(newValue) - Number(currentValue)
+          expect(slider.attributes('aria-valuenow')).toBe('60')
+          expect(diff).toBe(10)
+        })
+
+        it('home should set value to 100', async () => {
+          await slider.trigger('keydown', { key: 'Home' })
+          expect(slider.attributes('aria-valuenow')).toBe('0')
+        })
+
+        it('end should set value to 0', async () => {
+          await slider.trigger('keydown', { key: 'End' })
+          expect(slider.attributes('aria-valuenow')).toBe('100')
+        })
+      })
+    })
+
+    describe('after pressing navigation key', () => {
+      let slider: DOMWrapper<HTMLElement>
+
+      beforeEach(() => {
+        slider = wrapper.find('[role="slider"]')
+      })
+
+      it('arrowRight should increase by 1', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'ArrowRight' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('51')
+        expect(diff).toBe(1)
+      })
+
+      it('arrowLeft should decrease by 1', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'ArrowLeft' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('49')
+        expect(diff).toBe(-1)
+      })
+
+      it('arrowUp should increase by 1', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'ArrowUp' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('51')
+        expect(diff).toBe(1)
+      })
+
+      it('arrowDown should decrease by 1', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'ArrowDown' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('49')
+        expect(diff).toBe(-1)
+      })
+
+      it('pageUp should increase by 10', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'PageUp' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('60')
+        expect(diff).toBe(10)
+      })
+
+      it('pageDown should decrease by 10', async () => {
+        const currentValue = slider.attributes('aria-valuenow')
+        await slider.trigger('keydown', { key: 'PageDown' })
+        const newValue = slider.attributes('aria-valuenow')
+        const diff = Number(newValue) - Number(currentValue)
+        expect(slider.attributes('aria-valuenow')).toBe('40')
+        expect(diff).toBe(-10)
+      })
+
+      it('home should set value to 0', async () => {
+        await slider.trigger('keydown', { key: 'Home' })
+        expect(slider.attributes('aria-valuenow')).toBe('0')
+      })
+
+      it('end should set value to max', async () => {
+        await slider.trigger('keydown', { key: 'End' })
+        expect(slider.attributes('aria-valuenow')).toBe('100')
+      })
+    })
+  })
+
   describe('after pointerdown event on slider-impl', () => {
     let sliderImpl: VueWrapper<InstanceType<typeof SliderImpl>>
     beforeEach(async () => {
@@ -108,6 +342,24 @@ describe('given default Slider', () => {
     it('arrowLeft should decrease by 1', async () => {
       const currentValue = slider.attributes('aria-valuenow')
       await slider.trigger('keydown', { key: 'ArrowLeft' })
+      const newValue = slider.attributes('aria-valuenow')
+      const diff = Number(newValue) - Number(currentValue)
+      expect(slider.attributes('aria-valuenow')).toBe('49')
+      expect(diff).toBe(-1)
+    })
+
+    it('arrowUp should increase by 1', async () => {
+      const currentValue = slider.attributes('aria-valuenow')
+      await slider.trigger('keydown', { key: 'ArrowUp' })
+      const newValue = slider.attributes('aria-valuenow')
+      const diff = Number(newValue) - Number(currentValue)
+      expect(slider.attributes('aria-valuenow')).toBe('51')
+      expect(diff).toBe(1)
+    })
+
+    it('arrowDown should decrease by 1', async () => {
+      const currentValue = slider.attributes('aria-valuenow')
+      await slider.trigger('keydown', { key: 'ArrowDown' })
       const newValue = slider.attributes('aria-valuenow')
       const diff = Number(newValue) - Number(currentValue)
       expect(slider.attributes('aria-valuenow')).toBe('49')

--- a/packages/core/src/Slider/SliderHorizontal.vue
+++ b/packages/core/src/Slider/SliderHorizontal.vue
@@ -18,8 +18,8 @@ const { forwardRef, currentElement: sliderElement } = useForwardExpose()
 const rootContext = injectSliderRootContext()
 
 const offsetPosition = ref<number>()
-const rectRef = ref<ClientRect>()
-const isSlidingFromLeft = computed(() => (dir?.value === 'ltr' && !inverted.value) || (dir?.value !== 'ltr' && inverted.value))
+const rectRef = ref<DOMRect>()
+const isSlidingFromLeft = computed(() => (dir?.value !== 'rtl' && !inverted.value) || (dir?.value !== 'ltr' && inverted.value))
 
 function getValueFromPointerEvent(event: PointerEvent, slideStart?: boolean) {
   const rect = rectRef.value || sliderElement.value!.getBoundingClientRect()
@@ -46,10 +46,14 @@ function getValueFromPointerEvent(event: PointerEvent, slideStart?: boolean) {
   return value(position)
 }
 
+const startEdge = computed(() => isSlidingFromLeft.value ? 'left' : 'right')
+const endEdge = computed(() => isSlidingFromLeft.value ? 'right' : 'left')
+const direction = computed(() => isSlidingFromLeft.value ? 1 : -1)
+
 provideSliderOrientationContext({
-  startEdge: isSlidingFromLeft.value ? 'left' : 'right',
-  endEdge: isSlidingFromLeft.value ? 'right' : 'left',
-  direction: isSlidingFromLeft.value ? 1 : -1,
+  startEdge,
+  endEdge,
+  direction,
   size: 'width',
 })
 </script>

--- a/packages/core/src/Slider/SliderRange.vue
+++ b/packages/core/src/Slider/SliderRange.vue
@@ -31,8 +31,8 @@ const offsetEnd = computed(() => 100 - Math.max(...percentages.value, 0))
     :as-child="asChild"
     :as="as"
     :style="{
-      [orientation!.startEdge]: `${offsetStart}%`,
-      [orientation!.endEdge]: `${offsetEnd}%`,
+      [orientation!.startEdge.value]: `${offsetStart}%`,
+      [orientation!.endEdge.value]: `${offsetEnd}%`,
     }"
   >
     <slot />

--- a/packages/core/src/Slider/SliderThumbImpl.vue
+++ b/packages/core/src/Slider/SliderThumbImpl.vue
@@ -37,7 +37,7 @@ const thumbInBoundsOffset = computed(() => {
     return 0
   }
   else {
-    return getThumbInBoundsOffset(orientationSize.value, percent.value, orientation!.direction)
+    return getThumbInBoundsOffset(orientationSize.value, percent.value, orientation!.direction.value)
   }
 })
 
@@ -70,7 +70,7 @@ onUnmounted(() => {
       :style="{
         transform: 'var(--reka-slider-thumb-transform)',
         position: 'absolute',
-        [orientation!.startEdge]: `calc(${percent}% + ${thumbInBoundsOffset}px)`,
+        [orientation!.startEdge.value]: `calc(${percent}% + ${thumbInBoundsOffset}px)`,
         /**
          * There will be no value on initial render while we work out the index so we hide thumbs
          * without a value, otherwise SSR will render them in the wrong position before they

--- a/packages/core/src/Slider/SliderVertical.vue
+++ b/packages/core/src/Slider/SliderVertical.vue
@@ -15,7 +15,7 @@ const rootContext = injectSliderRootContext()
 const { forwardRef, currentElement: sliderElement } = useForwardExpose()
 
 const offsetPosition = ref<number>()
-const rectRef = ref<ClientRect>()
+const rectRef = ref<DOMRect>()
 const isSlidingFromBottom = computed(() => !inverted.value)
 
 function getValueFromPointerEvent(event: PointerEvent, slideStart?: boolean) {
@@ -43,11 +43,15 @@ function getValueFromPointerEvent(event: PointerEvent, slideStart?: boolean) {
   return value(position)
 }
 
+const startEdge = computed(() => isSlidingFromBottom.value ? 'bottom' : 'top')
+const endEdge = computed(() => isSlidingFromBottom.value ? 'top' : 'bottom')
+const direction = computed(() => isSlidingFromBottom.value ? 1 : -1)
+
 provideSliderOrientationContext({
-  startEdge: isSlidingFromBottom.value ? 'bottom' : 'top',
-  endEdge: isSlidingFromBottom.value ? 'top' : 'bottom',
+  startEdge,
+  endEdge,
+  direction,
   size: 'height',
-  direction: isSlidingFromBottom.value ? 1 : -1,
 })
 </script>
 

--- a/packages/core/src/Slider/utils.ts
+++ b/packages/core/src/Slider/utils.ts
@@ -1,3 +1,4 @@
+import type { ComputedRef } from 'vue'
 import { clamp, createContext } from '@/shared'
 
 export interface SliderOrientationPrivateProps {
@@ -130,16 +131,15 @@ export const BACK_KEYS: Record<SlideDirection, string[]> = {
   'from-left': ['Home', 'PageDown', 'ArrowDown', 'ArrowLeft'],
   'from-right': ['Home', 'PageDown', 'ArrowDown', 'ArrowRight'],
   'from-bottom': ['Home', 'PageDown', 'ArrowDown', 'ArrowLeft'],
-  'from-top': ['Home', 'PageDown', 'ArrowUp', 'ArrowLeft'],
-
+  'from-top': ['Home', 'PageUp', 'ArrowUp', 'ArrowLeft'],
 }
 
 type Side = 'top' | 'right' | 'bottom' | 'left'
 interface SliderOrientation {
-  startEdge: Side
-  endEdge: Side
+  startEdge: ComputedRef<Side>
+  endEdge: ComputedRef<Side>
+  direction: ComputedRef<1 | -1>
   size: 'width' | 'height'
-  direction: number
 }
 
 export const [injectSliderOrientationContext, provideSliderOrientationContext]

--- a/packages/core/src/shared/useForwardProps.ts
+++ b/packages/core/src/shared/useForwardProps.ts
@@ -1,4 +1,4 @@
-import { type MaybeRefOrGetter, camelize, computed, getCurrentInstance, toRef } from 'vue'
+import { type MaybeRefOrGetter, camelize, computed, getCurrentInstance, toRef, toRefs } from 'vue'
 
 interface PropOptions {
   type?: any
@@ -25,6 +25,7 @@ export function useForwardProps<T extends Record<string, any>>(props: MaybeRefOr
 
   const refProps = toRef(props)
   return computed(() => {
+    const propsAsRefs = toRefs(refProps.value)
     const preservedProps = {} as T
     const assignedProps = vm?.vnode.props ?? {}
 
@@ -34,8 +35,9 @@ export function useForwardProps<T extends Record<string, any>>(props: MaybeRefOr
 
     // Only return value from the props parameter
     return Object.keys({ ...defaultProps, ...preservedProps }).reduce((prev, curr) => {
-      if (refProps.value[curr] !== undefined)
-        prev[curr as keyof T] = refProps.value[curr]
+      const val = propsAsRefs[curr]?.value
+      if (val !== undefined)
+        prev[curr as keyof T] = val
       return prev
     }, {} as T)
   })


### PR DESCRIPTION
Also added relevant tests, made useForwardProps a tad bit more robust when props are added (which I think is only affecting testing QoL), and made Slider able to react to prop changes.