### PR TITLE
perf(primitive): don't redeclare SELF_CLOSING_TAGS in each instance

### DIFF
--- a/packages/core/src/Primitive/Primitive.ts
+++ b/packages/core/src/Primitive/Primitive.ts
@@ -35,6 +35,9 @@ export interface PrimitiveProps {
   as?: AsTag | Component
 }
 
+// For self closing tags, don't provide default slots because of hydration issue
+const SELF_CLOSING_TAGS = ['area', 'img', 'input']
+
 export const Primitive = defineComponent({
   name: 'Primitive',
   inheritAttrs: false,
@@ -50,9 +53,7 @@ export const Primitive = defineComponent({
   },
   setup(props, { attrs, slots }) {
     const asTag = props.asChild ? 'template' : props.as
-
-    // For self closing tags, don't provide default slots because of hydration issue
-    const SELF_CLOSING_TAGS = ['area', 'img', 'input']
+    
     if (typeof asTag === 'string' && SELF_CLOSING_TAGS.includes(asTag))
       return () => h(asTag, attrs)
 


### PR DESCRIPTION
Probably not a big deal, but it could save some performance along the way.