### PR TITLE
chore/readme: convert 'join our discord' into a link

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -50,7 +50,7 @@ For changelog, visit [releases](https://github.com/unovue/reka-ui/releases).
 
 ## Contributing
 
-We would love to have your contributions! All PRs are welcome! We need help building the core components, docs, tests, stories! Join our discord and we will get you up and running!
+We would love to have your contributions! All PRs are welcome! We need help building the core components, docs, tests, stories! [Join our discord](https://chat.unovue.com/) and we will get you up and running!
 
 ## Dev Setup
 


### PR DESCRIPTION
Convert 'Join our discord' into Unovue's Discord invite link since I think a lot of people (including myself) expected it to be that way.