### PR TITLE
fix(accordion-content): pass `as` prop down to CollapsibleContent

### DIFF
--- a/packages/core/src/Accordion/AccordionContent.vue
+++ b/packages/core/src/Accordion/AccordionContent.vue
@@ -22,6 +22,7 @@ useForwardExpose()
   <CollapsibleContent
     role="region"
     :as-child="props.asChild"
+    :as="as"
     :force-mount="props.forceMount"
     :aria-labelledby="itemContext.triggerId"
     :data-state="itemContext.dataState.value"


### PR DESCRIPTION
Fix: https://github.com/unovue/reka-ui/issues/1768

I think the problem is just the prop not being passed down to the underlying component.