### PR TITLE
fix(usePresence): handle undefined animation name in presence hook

### DIFF
--- a/packages/core/src/Presence/usePresence.ts
+++ b/packages/core/src/Presence/usePresence.ts
@@ -53,7 +53,7 @@ export function usePresence(
             dispatchCustomEvent('after-enter')
         }
         else if (
-          currentAnimationName === 'none'
+          currentAnimationName === 'none' || currentAnimationName === 'undefined'
           || stylesRef.value?.display === 'none'
         ) {
           // If there is no exit animation or the element is hidden, animations won't run


### PR DESCRIPTION
I found that getAnimationName(node.value) returns the string 'undefined', which prevents isPresent from properly updating to false.