### PR TITLE
#1374 Fix SelectItem focus in tests

### DIFF
--- a/packages/core/src/Select/SelectItem.vue
+++ b/packages/core/src/Select/SelectItem.vue
@@ -99,7 +99,7 @@ async function handlePointerMove(event: PointerEvent) {
   else {
     // even though safari doesn't support this option, it's acceptable
     // as it only means it might scroll a few pixels when using the pointer.
-    (event.currentTarget as HTMLElement).focus({ preventScroll: true })
+    (event.currentTarget as HTMLElement | null)?.focus({ preventScroll: true })
   }
 }
 


### PR DESCRIPTION
As reported in #1374, `SelectItem` fails inside tests. The fix seems quite straightforward, and I have tested that it works.