### PR TITLE
feat(splitter): expose `resetGroup` method for reseting the group

### DIFF
--- a/packages/core/src/Splitter/SplitterGroup.vue
+++ b/packages/core/src/Splitter/SplitterGroup.vue
@@ -717,6 +717,17 @@ function panelDataHelper(
     pivotIndices,
   }
 }
+
+defineExpose({
+  /** Function to reset the state of the group. */
+  resetGroup: () => {
+    for (const panelData of eagerValuesRef.value.panelDataArray) {
+      unregisterPanel(panelData)
+
+      registerPanel(panelData)
+    }
+  },
+})
 </script>
 
 <template>

--- a/packages/core/src/Splitter/story/SplitterReset.story.vue
+++ b/packages/core/src/Splitter/story/SplitterReset.story.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from '..'
+
+const splitterMain = ref<InstanceType<typeof SplitterGroup>>()
+const splitterNested = ref<InstanceType<typeof SplitterGroup>>()
+</script>
+
+<template>
+  <Story
+    title="Splitter/Reset"
+    :layout="{ type: 'single', iframe: false }"
+  >
+    <Variant title="default">
+      <div class="flex mx-2 gap-2 mb-3 justify-center">
+        <button
+          class=" border p-3 flex items-center justify-center rounded bg-card hover:bg-muted disabled:opacity-50"
+          @click="() => splitterMain?.resetGroup()"
+        >
+          Reset main Splitter
+        </button>
+        <button
+          class=" border p-3 flex items-center justify-center rounded bg-card hover:bg-muted disabled:opacity-50"
+
+          @click="() => splitterNested?.resetGroup()"
+        >
+          Reset nested Splitter
+        </button>
+      </div>
+
+      <div class="w-full h-48">
+        <SplitterGroup
+          ref="splitterMain"
+          direction="horizontal"
+        >
+          <SplitterPanel class="flex items-center justify-center bg-blackA8 rounded-lg">
+            Panel A
+          </SplitterPanel>
+          <SplitterResizeHandle class="w-2 data-[state=active]:bg-white transition" />
+          <SplitterPanel class="flex items-center justify-center rounded-lg">
+            <SplitterGroup
+              ref="splitterNested"
+              direction="vertical"
+            >
+              <SplitterPanel class="flex items-center justify-center bg-blackA8 rounded-lg">
+                Panel B1
+              </SplitterPanel>
+              <SplitterResizeHandle class="h-2 data-[state=active]:bg-white transition" />
+              <SplitterPanel class="flex items-center justify-center bg-blackA8 rounded-lg">
+                Panel B2
+              </SplitterPanel>
+            </SplitterGroup>
+          </SplitterPanel>
+          <SplitterResizeHandle class="w-2 data-[state=active]:bg-white transition" />
+          <SplitterPanel
+            :max-size="20"
+            class="flex items-center justify-center bg-blackA8 rounded-lg"
+          >
+            Panel C
+          </SplitterPanel>
+        </SplitterGroup>
+      </div>
+    </Variant>
+  </Story>
+</template>


### PR DESCRIPTION
Fix https://github.com/unovue/reka-ui/issues/1824

The issue does not answer all the possibilities the reset could allow to do, here is the list of features that come to my mind but are not implemented in this PR, atleast not yet.

- Reset all nested Splitters when calling the reset method
- Reset a specific panel only (probably by order as a param)