### PR TITLE
feat(select): allow modality customization

### DIFF
--- a/packages/core/src/Select/SelectContentImpl.vue
+++ b/packages/core/src/Select/SelectContentImpl.vue
@@ -4,7 +4,7 @@ import type {
   Ref,
 } from 'vue'
 import type { PopperContentProps } from '@/Popper'
-import type { PointerDownOutsideEvent } from '@/DismissableLayer'
+import type { DismissableLayerProps, PointerDownOutsideEvent } from '@/DismissableLayer'
 import {
   createContext,
   useFocusGuards,
@@ -74,6 +74,18 @@ export interface SelectContentImplProps extends PopperContentProps {
    * @defaultValue true
    */
   bodyLock?: boolean
+  /**
+   * When `true`, hover/focus/click interactions will be disabled on elements outside
+   * the `DismissableLayer`. Users will need to click twice on outside elements to
+   * interact with them: once to close the `DismissableLayer`, and again to trigger the element.
+   */
+  disableOutsidePointerEvents?: DismissableLayerProps['disableOutsidePointerEvents']
+  /**
+   * Whether focus should be trapped within the `SelectContent`
+   * @defaultValue true
+   */
+  trapFocus?: FocusScopeProps['trapped']
+
 }
 
 export const [injectSelectContentContext, provideSelectContentContext]
@@ -91,7 +103,7 @@ import { unrefElement } from '@vueuse/core'
 import { injectSelectRootContext } from './SelectRoot.vue'
 import SelectItemAlignedPosition from './SelectItemAlignedPosition.vue'
 import SelectPopperPosition from './SelectPopperPosition.vue'
-import { FocusScope } from '@/FocusScope'
+import { FocusScope, type FocusScopeProps } from '@/FocusScope'
 import { DismissableLayer } from '@/DismissableLayer'
 import { focusFirst } from '@/Menu/utils'
 
@@ -273,6 +285,7 @@ provideSelectContentContext({
   <CollectionSlot>
     <FocusScope
       as-child
+      :trapped="trapFocus"
       @mount-auto-focus.prevent
       @unmount-auto-focus="
         (event) => {
@@ -285,7 +298,7 @@ provideSelectContentContext({
     >
       <DismissableLayer
         as-child
-        disable-outside-pointer-events
+        :disable-outside-pointer-events="disableOutsidePointerEvents"
         @focus-outside.prevent
         @dismiss="rootContext.onOpenChange(false)"
         @escape-key-down="emits('escapeKeyDown', $event)"

--- a/packages/core/src/Select/SelectContentModal.vue
+++ b/packages/core/src/Select/SelectContentModal.vue
@@ -3,12 +3,10 @@ import type {
   SelectContentImplEmits,
   SelectContentImplProps,
 } from './SelectContentImpl.vue'
-import SelectContentModal from './SelectContentModal.vue'
-import SelectContentNonModal from './SelectContentNonModal.vue'
 
 export type SelectContentEmits = SelectContentImplEmits
 
-export interface SelectContentProps extends Omit<SelectContentImplProps, 'disableOutsidePointerEvents' | 'trapFocus' > {
+export interface SelectContentProps extends SelectContentImplProps {
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
@@ -19,6 +17,7 @@ export interface SelectContentProps extends Omit<SelectContentImplProps, 'disabl
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import SelectContentImpl from './SelectContentImpl.vue'
 import { injectSelectRootContext } from './SelectRoot.vue'
 import { Presence } from '@/Presence'
 import { useForwardPropsEmits } from '@/shared'
@@ -50,18 +49,11 @@ const renderPresence = computed(() => props.forceMount || rootContext.open.value
     ref="presenceRef"
     :present="true"
   >
-    <SelectContentModal
-      v-if="rootContext.modal.value"
+    <SelectContentImpl
       v-bind="{ ...forwarded, ...$attrs }"
     >
       <slot />
-    </SelectContentModal>
-    <SelectContentNonModal
-      v-else
-      v-bind="{ ...forwarded, ...$attrs }"
-    >
-      <slot />
-    </SelectContentNonModal>
+    </SelectContentImpl>
   </Presence>
 
   <div v-else-if="!presenceRef?.present && fragment">

--- a/packages/core/src/Select/SelectContentNonModal.vue
+++ b/packages/core/src/Select/SelectContentNonModal.vue
@@ -3,12 +3,10 @@ import type {
   SelectContentImplEmits,
   SelectContentImplProps,
 } from './SelectContentImpl.vue'
-import SelectContentModal from './SelectContentModal.vue'
-import SelectContentNonModal from './SelectContentNonModal.vue'
 
 export type SelectContentEmits = SelectContentImplEmits
 
-export interface SelectContentProps extends Omit<SelectContentImplProps, 'disableOutsidePointerEvents' | 'trapFocus' > {
+export interface SelectContentProps extends SelectContentImplProps {
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
@@ -19,6 +17,7 @@ export interface SelectContentProps extends Omit<SelectContentImplProps, 'disabl
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import SelectContentImpl from './SelectContentImpl.vue'
 import { injectSelectRootContext } from './SelectRoot.vue'
 import { Presence } from '@/Presence'
 import { useForwardPropsEmits } from '@/shared'
@@ -50,18 +49,11 @@ const renderPresence = computed(() => props.forceMount || rootContext.open.value
     ref="presenceRef"
     :present="true"
   >
-    <SelectContentModal
-      v-if="rootContext.modal.value"
-      v-bind="{ ...forwarded, ...$attrs }"
+    <SelectContentImpl
+      v-bind="{ ...forwarded, ...$attrs, bodyLock: false, trapFocus: false, disableOutsidePointerEvents: false }"
     >
       <slot />
-    </SelectContentModal>
-    <SelectContentNonModal
-      v-else
-      v-bind="{ ...forwarded, ...$attrs }"
-    >
-      <slot />
-    </SelectContentNonModal>
+    </SelectContentImpl>
   </Presence>
 
   <div v-else-if="!presenceRef?.present && fragment">

--- a/packages/core/src/Select/SelectRoot.vue
+++ b/packages/core/src/Select/SelectRoot.vue
@@ -24,6 +24,12 @@ export interface SelectRootProps<T = AcceptableValue> extends FormFieldProps {
   autocomplete?: string
   /** When `true`, prevents the user from interacting with Select */
   disabled?: boolean
+  /**
+   * The modality of the select.
+   *
+   * When set to `true`, interaction with outside elements will be disabled and only menu content will be visible to screen readers.
+   */
+  modal?: boolean
 }
 
 export type SelectRootEmits<T = AcceptableValue> = {
@@ -50,6 +56,7 @@ export interface SelectRootContext<T> {
   triggerPointerDownPosRef: Ref<{ x: number, y: number } | null>
   isEmptyModelValue: Ref<boolean>
   disabled?: Ref<boolean>
+  modal: Ref<boolean>
 
   optionsSet: Ref<Set<SelectOption>>
   onOptionAdd: (option: SelectOption) => void
@@ -75,6 +82,7 @@ defineOptions({
 const props = withDefaults(defineProps<SelectRootProps>(), {
   modelValue: undefined,
   open: undefined,
+  modal: true,
 })
 const emits = defineEmits<SelectRootEmits>()
 
@@ -87,7 +95,7 @@ defineSlots<{
   }) => any
 }>()
 
-const { required, disabled, multiple, dir: propDir } = toRefs(props)
+const { required, disabled, multiple, dir: propDir, modal } = toRefs(props)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue ?? (multiple.value ? [] : undefined),
@@ -167,6 +175,7 @@ provideSelectRootContext({
   triggerPointerDownPosRef,
   disabled,
   isEmptyModelValue,
+  modal,
 
   optionsSet,
   onOptionAdd: option => optionsSet.value.add(option),

--- a/packages/core/src/Select/story/SelectNonModal.story.vue
+++ b/packages/core/src/Select/story/SelectNonModal.story.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { ref } from 'vue'
+import {
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectItemIndicator,
+  SelectItemText,
+  SelectLabel,
+  SelectPortal,
+  SelectRoot,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from '..'
+import SelectItemWrapper from './_SelectItem.vue'
+
+const fruit = ref(['Apple'])
+
+const options = ['Apple', 'Banana', 'Blueberry', 'Grapes', 'Pineapple']
+const vegetables = ['Aubergine', 'Broccoli', 'Carrot', 'Courgette', 'Leek']
+
+const POSITION = ['item-aligned', 'popper'] as const
+</script>
+
+<template>
+  <Story
+    title="Select/Non modal"
+    :layout="{ type: 'single', iframe: false }"
+  >
+    <Variant title="default">
+      <div class="flex gap-4">
+        <SelectRoot
+          v-for="position in POSITION"
+          :key="position"
+          v-model="fruit"
+          multiple
+          :modal="false"
+        >
+          <SelectTrigger
+            class="min-w-[160px] inline-flex items-center justify-between rounded px-[15px] text-[13px] leading-none h-[35px] gap-[5px] bg-white text-violet11 shadow-[0_2px_10px] shadow-black/10 hover:bg-mauve3 focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-violet9 outline-none"
+            aria-label="Customise options"
+          >
+            <SelectValue placeholder="Please select a fruit" />
+            <Icon
+              icon="radix-icons:chevron-down"
+              class="h-4 w-4"
+            />
+          </SelectTrigger>
+
+          <SelectPortal>
+            <Transition>
+              <SelectContent
+                class="min-w-[160px] bg-white overflow-hidden rounded shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]"
+                :side-offset="5"
+                :position="position"
+              >
+                <SelectScrollUpButton
+                  class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
+                >
+                  <Icon icon="radix-icons:chevron-up" />
+                </SelectScrollUpButton>
+
+                <SelectViewport class="p-[5px]">
+                  <SelectLabel
+                    class="px-[25px] text-xs leading-[25px] text-mauve11"
+                  >
+                    Fruits
+                  </SelectLabel>
+                  <SelectGroup>
+                    <SelectItemWrapper :options="options" />
+                  </SelectGroup>
+                  <SelectSeparator class="h-[1px] bg-violet6 m-[5px]" />
+                  <SelectLabel
+                    class="px-[25px] text-xs leading-[25px] text-mauve11"
+                  >
+                    Vegetables
+                  </SelectLabel>
+                  <SelectGroup>
+                    <SelectItem
+                      v-for="(option, index) in vegetables"
+                      :key="index"
+                      class="text-[13px] leading-none text-violet11 rounded-[3px] flex items-center h-[25px] pr-[35px] pl-[25px] relative select-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:outline-none data-[highlighted]:bg-violet9 data-[highlighted]:text-violet1"
+                      :value="option"
+                      :disabled="option === 'Courgette'"
+                    >
+                      <SelectItemIndicator
+                        class="absolute left-0 w-[25px] inline-flex items-center justify-center"
+                      >
+                        <Icon icon="radix-icons:check" />
+                      </SelectItemIndicator>
+                      <SelectItemText>
+                        {{ option }}
+                      </SelectItemText>
+                    </SelectItem>
+                  </SelectGroup>
+                </SelectViewport>
+
+                <SelectScrollDownButton
+                  class="flex items-center justify-center h-[25px] bg-white text-violet11 cursor-default"
+                >
+                  <Icon icon="radix-icons:chevron-down" />
+                </SelectScrollDownButton>
+              </SelectContent>
+            </Transition>
+          </SelectPortal>
+        </SelectRoot>
+      </div>
+    </Variant>
+  </Story>
+</template>
+
+<style scoped>
+.v-enter-active,
+.v-leave-active {
+  transition: opacity .3s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
Fix: https://github.com/unovue/reka-ui/issues/1545

Allowing users to set the modality goes in hand with how different components behave i.e. the `DropdownMenu`.

I have some concerns about accessibility as I'm not much educated in that regard, are there some pitfalls around the select that require the modal behavior at all times?