### PR TITLE
fix(NumberField): not prevent focus on input for iOS devices

### DIFF
--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -109,7 +109,8 @@ const isIncreaseDisabled = computed(() => (
 )
 
 function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
-  inputEl.value?.focus()
+  if (!/iphone|ipad|ipod/i.test(navigator.userAgent))
+    inputEl.value?.focus()
   if (props.disabled || props.readonly)
     return
   const currentInputValue = numberParser.parse(inputEl.value?.value ?? '')


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
#2200 i wrote code maybe fix it, but i don't have iphone to check it

### ❓ Type of change
change the NumberField to check is it apple phone browser if it is the focus event don't will be to work


- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [+] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
maybe Resolve the issue #2200 but i dont have iphone to check it


- [+] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.