### PR TITLE
fix(components): VisuallyHiddenInput fails Axe tests inside of form element

### DIFF
--- a/packages/core/src/RadioGroup/RadioGroup.test.ts
+++ b/packages/core/src/RadioGroup/RadioGroup.test.ts
@@ -101,6 +101,10 @@ describe('given radio in a form', async () => {
     props: { handleSubmit },
   })
 
+  it('should pass axe accessibility tests', async () => {
+    expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+
   it('should have hidden input field', async () => {
     expect(wrapper.find('[type="Radio"]').exists()).toBe(true)
   })


### PR DESCRIPTION
In my project while using Axe I encountered an issue when using RadioGroup inside of a form element. It complains about the hidden input not having a label, but I'm not sure what is the best way to handle this.

This is most likely affecting other component as well.