### PR TITLE
fix(Calendar,RangeCalendar): null-safe range, fixedWeeks, highlight fixes

### DIFF
--- a/packages/core/src/RangeCalendar/RangeCalendar.test.ts
+++ b/packages/core/src/RangeCalendar/RangeCalendar.test.ts
@@ -2,7 +2,7 @@ import type { DateValue } from '@internationalized/date'
 import type { RangeCalendarRootProps } from './RangeCalendarRoot.vue'
 import { CalendarDate, CalendarDateTime, toZoned } from '@internationalized/date'
 import userEvent from '@testing-library/user-event'
-import { render } from '@testing-library/vue'
+import { fireEvent, render, waitFor } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
@@ -39,6 +39,10 @@ const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 
 
 function getSelectedDays(calendar: HTMLElement) {
   return Array.from(calendar.querySelectorAll<HTMLElement>('[data-selected]'))
+}
+
+function getHighlightedDays(calendar: HTMLElement) {
+  return Array.from(calendar.querySelectorAll<HTMLElement>('[data-highlighted]'))
 }
 
 function setup(props: { calendarProps?: RangeCalendarRootProps, emits?: { 'onUpdate:modelValue'?: (data: DateValue) => void } } = {}) {
@@ -95,6 +99,20 @@ describe('rangeCalendar', () => {
 
     const heading = getByTestId('heading')
     expect(heading).toHaveTextContent('January 1980')
+  })
+
+  it('does not crash when modelValue is null', async () => {
+    const { calendar, rerender } = setup({ calendarProps: { modelValue: null } })
+
+    expect(getSelectedDays(calendar)).toHaveLength(0)
+
+    await rerender({
+      calendarProps: {
+        modelValue: zonedDateTimeRange,
+      },
+    })
+
+    expect(getSelectedDays(calendar)).toHaveLength(6)
   })
 
   it('resets range on select when a range is already selected', async () => {
@@ -158,6 +176,39 @@ describe('rangeCalendar', () => {
     expect(calendar.querySelector('[data-selection-end]')).not.toBeInTheDocument()
   })
 
+  it('keeps controlled end when parent preserves it after start edit', async () => {
+    const preservedEnd = new CalendarDate(1980, 1, 28)
+    const controlledRange = {
+      start: new CalendarDate(1980, 1, 20),
+      end: preservedEnd,
+    }
+
+    const { getByTestId, calendar, user, rerender } = setup({
+      calendarProps: { modelValue: controlledRange },
+      emits: {
+        'onUpdate:modelValue': (data: any) => {
+          rerender({
+            calendarProps: {
+              modelValue: {
+                start: data.start ?? controlledRange.start,
+                end: data.end ?? preservedEnd,
+              },
+            },
+          })
+        },
+      },
+    })
+
+    const twentyFourthDay = getByTestId('date-1-24')
+    await user.click(twentyFourthDay)
+
+    expect(getByTestId('date-1-24')).toHaveAttribute('data-selection-start')
+    expect(getByTestId('date-1-28')).toHaveAttribute('data-selection-end')
+    expect(getByTestId('date-1-25')).toHaveAttribute('data-selected')
+    expect(getByTestId('date-1-27')).toHaveAttribute('data-selected')
+    expect(getSelectedDays(calendar)).toHaveLength(5)
+  })
+
   it('resets range selection when pressing Escape', async () => {
     const { getByTestId, calendar, user, rerender } = setup({
       calendarProps: { modelValue: calendarDateRange },
@@ -190,6 +241,46 @@ describe('rangeCalendar', () => {
 
     expect(startValue).toHaveTextContent(String(calendarDateRange.start.day))
     expect(endValue).toHaveTextContent(String(calendarDateRange.end.day))
+  })
+
+  it('caps highlighted range to maximumDays (forward)', async () => {
+    const { getByTestId, calendar, user } = setup({
+      calendarProps: {
+        placeholder: new CalendarDate(1980, 1, 20),
+        maximumDays: 5,
+      },
+    })
+
+    await user.click(getByTestId('date-1-20'))
+    await fireEvent.mouseEnter(getByTestId('date-1-24'))
+
+    await waitFor(() => {
+      expect(getHighlightedDays(calendar)).toHaveLength(5)
+    })
+
+    expect(getByTestId('date-1-20')).toHaveAttribute('data-highlighted-start')
+    expect(getByTestId('date-1-24')).toHaveAttribute('data-highlighted-end')
+    expect(getByTestId('date-1-25')).not.toHaveAttribute('data-highlighted')
+  })
+
+  it('caps highlighted range to maximumDays (backward)', async () => {
+    const { getByTestId, calendar, user } = setup({
+      calendarProps: {
+        placeholder: new CalendarDate(1980, 1, 20),
+        maximumDays: 5,
+      },
+    })
+
+    await user.click(getByTestId('date-1-20'))
+    await fireEvent.mouseEnter(getByTestId('date-1-16'))
+
+    await waitFor(() => {
+      expect(getHighlightedDays(calendar)).toHaveLength(5)
+    })
+
+    expect(getByTestId('date-1-16')).toHaveAttribute('data-highlighted-start')
+    expect(getByTestId('date-1-20')).toHaveAttribute('data-highlighted-end')
+    expect(getByTestId('date-1-15')).not.toHaveAttribute('data-highlighted')
   })
 
   it('navigates the months forward using the next button', async () => {

--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -103,21 +103,23 @@ function changeDate(e: MouseEvent | KeyboardEvent, date: DateValue) {
   if (rootContext.isDateDisabled(date) || rootContext.isDateUnavailable?.(date))
     return
 
-  rootContext.lastPressedDateValue.value = date.copy()
-
   if (rootContext.startValue.value && rootContext.highlightedRange.value === null) {
     if (isSameDay(date, rootContext.startValue.value) && !rootContext.preventDeselect.value && !rootContext.endValue.value) {
       rootContext.startValue.value = undefined
       rootContext.onPlaceholderChange(date)
+      rootContext.lastPressedDateValue.value = date.copy()
       return
     }
     else if (!rootContext.endValue.value) {
       e.preventDefault()
       if (rootContext.lastPressedDateValue.value && isSameDay(rootContext.lastPressedDateValue.value, date))
         rootContext.startValue.value = date.copy()
+      rootContext.lastPressedDateValue.value = date.copy()
       return
     }
   }
+
+  rootContext.lastPressedDateValue.value = date.copy()
 
   if (
     rootContext.startValue.value

--- a/packages/core/src/RangeCalendar/RangeCalendarGrid.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarGrid.vue
@@ -26,6 +26,7 @@ const readonly = computed(() => rootContext.readonly.value ? true : undefined)
     :aria-disabled="disabled"
     :data-readonly="readonly && ''"
     :data-disabled="disabled && ''"
+    @mouseleave="rootContext.focusedValue.value = undefined"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
@@ -226,9 +226,12 @@ const isEditing = ref(false)
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue ?? { start: undefined, end: undefined },
   passive: (props.modelValue === undefined) as false,
-}) as Ref<DateRange>
+}) as Ref<DateRange | null>
 
-const validModelValue = ref(modelValue.value) as Ref<DateRange>
+const normalizeRange = (value?: DateRange | null): DateRange => value ?? { start: undefined, end: undefined }
+const normalizedModelValue = computed(() => normalizeRange(modelValue.value))
+
+const validModelValue = ref(normalizeRange(modelValue.value)) as Ref<DateRange>
 
 watch(validModelValue, (value) => {
   emits('update:validModelValue', value)
@@ -236,14 +239,14 @@ watch(validModelValue, (value) => {
 
 const defaultDate = getDefaultDate({
   defaultPlaceholder: props.placeholder,
-  defaultValue: modelValue.value.start,
+  defaultValue: normalizeRange(modelValue.value).start,
   locale: props.locale,
 })
 
-const startValue = ref(modelValue.value.start) as Ref<
+const startValue = ref(normalizeRange(modelValue.value).start) as Ref<
   DateValue | undefined
 >
-const endValue = ref(modelValue.value.end) as Ref<DateValue | undefined>
+const endValue = ref(normalizeRange(modelValue.value).end) as Ref<DateValue | undefined>
 
 const placeholder = useVModel(props, 'placeholder', emits, {
   defaultValue: props.defaultPlaceholder ?? defaultDate.copy(),
@@ -307,23 +310,21 @@ const {
   maximumDays,
 })
 
-watch(modelValue, (_modelValue, _prevValue) => {
-  if (
-    (!_prevValue?.start && _modelValue?.start)
-    || !_modelValue
-    || !_modelValue.start
-    || (startValue.value && !isEqualDay(_modelValue.start, startValue.value))
-  ) {
-    startValue.value = _modelValue?.start?.copy?.()
+watch(modelValue, (_modelValue) => {
+  const next = normalizeRange(_modelValue)
+
+  const isStartSynced = (!next.start && !startValue.value)
+    || (!!next.start && !!startValue.value && isEqualDay(next.start, startValue.value))
+
+  if (!isStartSynced) {
+    startValue.value = next.start?.copy?.()
   }
 
-  if (
-    (!_prevValue?.end && _modelValue.end)
-    || !_modelValue
-    || !_modelValue.end
-    || (endValue.value && !isEqualDay(_modelValue.end, endValue.value))
-  ) {
-    endValue.value = _modelValue?.end?.copy?.()
+  const isEndSynced = (!next.end && !endValue.value)
+    || (!!next.end && !!endValue.value && isEqualDay(next.end, endValue.value))
+
+  if (!isEndSynced) {
+    endValue.value = next.end?.copy?.()
   }
 })
 
@@ -381,7 +382,7 @@ provideRangeCalendarRootContext({
   startValue,
   endValue,
   formatter,
-  modelValue,
+  modelValue: normalizedModelValue,
   placeholder,
   disabled,
   initialFocus,
@@ -469,7 +470,7 @@ onMounted(() => {
       :week-starts-on="weekStartsOn"
       :locale="locale"
       :fixed-weeks="fixedWeeks"
-      :model-value="modelValue"
+      :model-value="normalizedModelValue"
     />
   </Primitive>
 </template>

--- a/packages/core/src/RangeCalendar/useRangeCalendar.ts
+++ b/packages/core/src/RangeCalendar/useRangeCalendar.ts
@@ -41,7 +41,7 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
   const isInvalid = computed(
     () => {
       if (isStartInvalid.value || isEndInvalid.value)
-        return false
+        return true
       if (props.start.value && props.end.value && isBefore(props.end.value, props.start.value))
         return true
       return false
@@ -71,12 +71,10 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
     return false
   }
 
-  // Check if a date exceeds maximum days limit from the start date
   const rangeIsDateDisabled = (date: DateValue) => {
     if (props.isDateDisabled(date))
       return true
 
-    // Check if exceeds maximum days limit
     if (props.maximumDays?.value) {
       if (props.start.value && props.end.value) {
         if (props.fixedDate.value) {
@@ -96,9 +94,6 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
         return !isBetween(date, minDate, maxDate)
       }
     }
-
-    if (!props.start.value || props.end.value || isSameDay(props.start.value, date))
-      return false
 
     return false
   }
@@ -126,17 +121,17 @@ export function useRangeCalendarState(props: UseRangeCalendarProps) {
       }
     }
 
-    // If maximum days is set and the range exceeds it, limit the highlight
-    // We only apply this when we're in the middle of a selection (no end date yet)
     if (props.maximumDays?.value && !props.end.value) {
-      // Determine the direction of selection and limit to maximum days
-      const cappedEnd = isStartBeforeFocused
-        ? start.add({ days: props.maximumDays.value - 1 })
-        : start.subtract({ days: props.maximumDays.value })
+      const maximumDays = props.maximumDays.value
+      const anchor = props.start.value
 
-      return {
-        start,
-        end: cappedEnd,
+      if (isStartBeforeFocused) {
+        const maxEnd = anchor.add({ days: maximumDays - 1 })
+        return { start: anchor, end: maxEnd }
+      }
+      else {
+        const minStart = anchor.subtract({ days: maximumDays - 1 })
+        return { start: minStart, end: anchor }
       }
     }
 


### PR DESCRIPTION
## Summary

- **RangeCalendar**: null-safe `modelValue` handling with `normalizeRange()` + watcher rewrite for controlled range sync
- **RangeCalendarCellTrigger**: move `lastPressedDateValue` assignment after early returns
- **RangeCalendarGrid**: `@mouseleave` clears `focusedValue` to fix stale highlight
- **useRangeCalendar**: fix `isInvalid` returning `false` instead of `true`, rewrite `highlightedRange` maximumDays logic

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [reka-ui-2453](https://stackblitz.com/github/onmax/repros/tree/repro/reka-ui-2453/reka-ui-2453?startScript=dev) | ❌ Crashes on mount (`Cannot read properties of null`) |
| Fix | [reka-ui-2453-fix](https://stackblitz.com/github/onmax/repros/tree/repro/reka-ui-2453/reka-ui-2453-fix?startScript=dev) | ✅ All demos render correctly |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/reka-ui-2453 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set reka-ui-2453
cd reka-ui-2453 && pnpm i && pnpm dev
```

### Verify fix

```bash
git sparse-checkout add reka-ui-2453-fix
cd ../reka-ui-2453-fix && pnpm i && pnpm dev
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Test plan
- 2 new tests: null modelValue, controlled range sync
- Existing RangeCalendar tests pass