### PR TITLE
fix(Tabs): only force-mount TabsContent during SSR

### DIFF
--- a/packages/core/src/Tabs/TabsContent.vue
+++ b/packages/core/src/Tabs/TabsContent.vue
@@ -18,6 +18,7 @@ export interface TabsContentProps extends PrimitiveProps {
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { Presence } from '@/Presence'
 import { Primitive } from '@/Primitive'
+import { isBrowser } from '@/shared/browser'
 import { injectTabsRootContext } from './TabsRoot.vue'
 import { makeContentId, makeTriggerId } from './utils'
 
@@ -48,7 +49,7 @@ onBeforeUnmount(() => {
   <Presence
     v-slot="{ present }"
     :present="forceMount || isSelected"
-    force-mount
+    :force-mount="!isBrowser || forceMount"
   >
     <Primitive
       :id="contentId"


### PR DESCRIPTION
Fixes https://github.com/unovue/reka-ui/issues/2476

The Presence component inside TabsContent has force-mount hardcoded, keeping all inactive tab panels in the DOM. You can see this either by inspecting the DOM or when CSS display property (e.g. display:flex) is set on TabsContent, as it overrides the hidden attribute's display:none.

This change conditionally applies force-mount only during SSR (when document is undefined) or when the user explicitly passes the forceMount prop, using the existing isBrowser utility.

<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#2476

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Detects if running in SSR/SPA; respects the desire to hydrate all TabsContent in SSR but also respects documented behaviour for SPA 

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering compatibility for tab components. Fixed content mounting behavior to properly handle both server-side and client-side rendering. Tabs now correctly mount and display content in server environments while maintaining user-defined mounting controls in the browser, ensuring consistent rendering across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->