### PR TITLE
fix(Collapsible): make contentId reactive to fix VoiceOver aria-controls

### DIFF
--- a/packages/core/src/Collapsible/CollapsibleContent.vue
+++ b/packages/core/src/Collapsible/CollapsibleContent.vue
@@ -32,7 +32,7 @@ const props = defineProps<CollapsibleContentProps>()
 const emits = defineEmits<CollapsibleContentEmits>()
 
 const rootContext = injectCollapsibleRootContext()
-rootContext.contentId ||= useId(undefined, 'reka-collapsible-content')
+rootContext.contentId.value ||= useId(undefined, 'reka-collapsible-content')
 
 const presentRef = ref<InstanceType<typeof Presence>>()
 const { forwardRef, currentElement } = useForwardExpose()
@@ -102,7 +102,7 @@ useEventListener(currentElement, 'beforematch', (ev) => {
   >
     <Primitive
       v-bind="$attrs"
-      :id="rootContext.contentId"
+      :id="rootContext.contentId.value"
       :ref="forwardRef"
       :as-child="props.asChild"
       :as="as"

--- a/packages/core/src/Collapsible/CollapsibleRoot.vue
+++ b/packages/core/src/Collapsible/CollapsibleRoot.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
-import { toRefs } from 'vue'
+import { ref, toRefs } from 'vue'
 import { createContext, useForwardExpose } from '@/shared'
 
 export interface CollapsibleRootProps extends PrimitiveProps {
@@ -21,7 +21,7 @@ export type CollapsibleRootEmits = {
 }
 
 interface CollapsibleRootContext {
-  contentId: string
+  contentId: Ref<string>
   disabled?: Ref<boolean>
   open: Ref<boolean>
   unmountOnHide: Ref<boolean>
@@ -58,8 +58,10 @@ const open = useVModel(props, 'open', emit, {
 
 const { disabled, unmountOnHide } = toRefs(props)
 
+const contentId = ref('')
+
 provideCollapsibleRootContext({
-  contentId: '',
+  contentId,
   disabled,
   open,
   unmountOnHide,

--- a/packages/core/src/Collapsible/CollapsibleTrigger.vue
+++ b/packages/core/src/Collapsible/CollapsibleTrigger.vue
@@ -22,7 +22,7 @@ const rootContext = injectCollapsibleRootContext()
     :type="as === 'button' ? 'button' : undefined"
     :as="as"
     :as-child="props.asChild"
-    :aria-controls="rootContext.contentId"
+    :aria-controls="rootContext.contentId.value"
     :aria-expanded="rootContext.open.value"
     :data-state="rootContext.open.value ? 'open' : 'closed'"
     :data-disabled="rootContext.disabled?.value ? '' : undefined"


### PR DESCRIPTION
## Summary

- `contentId` in `CollapsibleRootContext` was a plain `string`, not a reactive `Ref<string>`, so when `CollapsibleContent` set the ID on mount, `CollapsibleTrigger`'s `aria-controls` was never reactively updated
- On initial render `aria-controls=""` (empty), meaning VoiceOver had no valid element to associate with the button's expanded/collapsed state — causing it to not announce state changes
- Changed `contentId` to `Ref<string>` across `CollapsibleRoot`, `CollapsibleContent`, and `CollapsibleTrigger`

Fixes #2521

## Test Plan
- [ ] Open an accordion with VoiceOver enabled on macOS/iOS — verify "expanded" / "collapsed" is announced on toggle
- [ ] Verify `aria-controls` on the trigger correctly references the content panel's `id` from initial render
- [x] All existing Accordion and Collapsible tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component context API for improved reactivity handling in the Collapsible component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->