### PR TITLE
fix(core): export missing shared types to prevent TS2742 in consumer projects

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,7 +96,14 @@ export {
 } from './shared/color'
 export {
   type AcceptableValue,
+  type DataOrientation,
+  type Direction,
+  type FormFieldProps,
   type GenericComponentInstance,
+  type ScrollBodyOption,
+  type SingleOrMultipleProps,
+  type SingleOrMultipleType,
+  type StringOrNumber,
 } from './shared/types'
 export * from './Slider'
 export * from './Splitter'


### PR DESCRIPTION
### 🔗 Linked issue

N/A (new report)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Several shared types (`DataOrientation`, `Direction`, `StringOrNumber`, `FormFieldProps`, `ScrollBodyOption`, `SingleOrMultipleProps`, `SingleOrMultipleType`) are used in public component prop interfaces (e.g. `SeparatorProps`, `TabsRootProps`, `AccordionRootProps`, `SliderRootProps`, etc.) but are not re-exported from the main `src/index.ts` entry point.

During bundling, `tsdown`'s `advancedChunks` places these types in an auto-generated internal chunk (e.g. `index3.d.ts`), which is not listed in the package's `exports` map. This causes **TS2742** errors in consumer projects that use `vue-tsc` with `declaration: true`:

```
error TS2742: The inferred type of '__VLS_export' cannot be named without a reference to
'reka-ui/dist/index3'. This is likely not portable. A type annotation is necessary.
```

**Affected components** include (but are not limited to): `Separator`, `Tabs`, `Accordion`, `Slider`, `RadioGroup`, `ToggleGroup`, `Toolbar`, `Stepper`, `ColorSlider`, `Listbox`, and all other components whose props reference `DataOrientation`, `Direction`, or `StringOrNumber`.

**Fix**: Re-export the missing types from `src/index.ts` so they become part of the main `index.d.ts` declaration file, making them resolvable without referencing internal chunks.

### Reproduction

1. Create a Vue 3 project with `declaration: true` in `tsconfig.json`
2. Install `reka-ui@2.9.5`
3. Create a component wrapper for `<Separator>` or `<TabsRoot>` using `defineProps<SeparatorProps>()`
4. Run `vue-tsc --noEmit` → TS2742 error

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded public type exports to provide additional type definitions for better type safety and improved developer experience when using the library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->