### PR TITLE
fix(Menu): remove data-highlighted when pointer leaves MenuItem (#2596)

### DIFF
--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -24,7 +24,7 @@ import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 
 export interface MenuContentContext {
   onItemEnter: (event: PointerEvent) => boolean
-  onItemLeave: (event: PointerEvent) => void
+  onItemLeave: (event: PointerEvent) => boolean
   onTriggerLeave: (event: PointerEvent) => boolean
   searchRef: Ref<string>
   highlightedElement: Ref<HTMLElement | undefined>
@@ -303,13 +303,14 @@ provideMenuContentContext({
   },
   onItemLeave: (event) => {
     if (isPointerMovingToSubmenu(event))
-      return
+      return true
 
     const isInputFocused = ['INPUT', 'TEXTAREA'].includes(getActiveElement()?.tagName || '')
     if (!isInputFocused)
       contentElement.value?.focus()
 
     currentItemId.value = null
+    return false
   },
   onTriggerLeave: (event) => {
     // event.preventDefault() we can't prevent pointerLeave event

--- a/packages/core/src/Menu/MenuItemImpl.vue
+++ b/packages/core/src/Menu/MenuItemImpl.vue
@@ -60,7 +60,10 @@ async function handlePointerLeave(event: PointerEvent) {
   if (!isMouseEvent(event))
     return
 
-  contentContext.onItemLeave(event)
+  const isMovingToSubmenu = contentContext.onItemLeave(event)
+  // When the pointer leaves this item to empty space (not another item or a submenu), clear the highlight.
+  if (!isMovingToSubmenu && contentContext.highlightedElement.value === currentElement.value)
+    contentContext.highlightedElement.value = undefined
 }
 </script>
 

--- a/packages/core/src/Menu/MenuItemImpl.vue
+++ b/packages/core/src/Menu/MenuItemImpl.vue
@@ -60,8 +60,13 @@ async function handlePointerLeave(event: PointerEvent) {
   if (!isMouseEvent(event))
     return
 
+  // If the highlight was already claimed by another element (e.g. the pointer moved
+  // directly onto another item, whose synchronous `pointermove` ran before this
+  // `nextTick` resolved), this leave is stale and must not reset focus/roving state.
+  if (contentContext.highlightedElement.value !== currentElement.value)
+    return
+
   const isMovingToSubmenu = contentContext.onItemLeave(event)
-  // When the pointer leaves this item to empty space (not another item or a submenu), clear the highlight.
   if (!isMovingToSubmenu && contentContext.highlightedElement.value === currentElement.value)
     contentContext.highlightedElement.value = undefined
 }


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#2596

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #2596

When user moves pointer outside of `Dropdown` its item stays highlighted. 

It is a regression after pr #2405. This pr changed how `data-highlighted` is computed on `MenuItemImpl` - it is being set on `pointermove`, but nothing ever clears it on `pointerleave`. 

The fix is to clear `highlightedElement` on `pointerleave` — but only when the pointer is not moving to a submenu, and only if another item hasn't already claimed `highlightedElement` via its own `pointermove`.

Changes: 
1. `MenuContentImpl`: made `onItemLeave` return a boolean (same pattern already used by `onItemEnter`/`onTriggerLeave`), so callers can tell whether the pointer is heading into a submenu.
2. `MenuItemImpl`:  clear the stale highlight after `onItemLeave`

This covers `DropdownMenu`, `ContextMenu`, `Menubar`, and submenus.

P.S.
The `highlightedElement === currentElement` check is important because `handlePointerLeave` is async (`await nextTick()`), so by the time it runs a neighboring item's synchronous `pointermove` may have already pointed `highlightedElement` at itself — in which case we must not clear it.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu pointer behavior during submenu navigation: highlights remain when moving into submenus and are reliably cleared when leaving, preventing stale or flickering highlights and ensuring consistent visual feedback across pointer interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->