### PR TITLE
fix(Toast): announce title and description as text, not JSON

### DIFF
--- a/packages/core/src/Toast/Toast.test.ts
+++ b/packages/core/src/Toast/Toast.test.ts
@@ -41,6 +41,31 @@ describe('given a default Toast', () => {
     expect(await axe(document.body)).toHaveNoViolations()
   })
 
+  it('should announce title and description as plain text (not JSON)', async () => {
+    await fireEvent.click(trigger.element)
+    await findByText(document.body, 'Scheduled: Catch up')
+
+    // ToastAnnounce renders the live region on the next animation frame
+    // (see ToastAnnounce.vue's useRafFn) — wait for two RAFs so it's
+    // guaranteed to be in the DOM.
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
+
+    const liveRegion = document.querySelector('[role="alert"][aria-live]')
+    expect(liveRegion).toBeTruthy()
+    const text = liveRegion!.textContent ?? ''
+
+    // Vue's `{{ array }}` would JSON-stringify the announceTextContent
+    // array — guard against that regression by asserting the live region
+    // does not contain JSON syntax characters.
+    expect(text).not.toMatch(/[[\]"]/)
+
+    // The toast title and description must both be part of the announced
+    // text so screen-reader users actually hear the toast.
+    expect(text).toContain('Scheduled: Catch up')
+  })
+
   describe('after clicking the trigger', () => {
     beforeEach(async () => {
       fireEvent.click(trigger.element)

--- a/packages/core/src/Toast/ToastRootImpl.vue
+++ b/packages/core/src/Toast/ToastRootImpl.vue
@@ -183,7 +183,20 @@ provideToastRootContext({ onClose: handleClose })
     role="alert"
     :aria-live="type === 'foreground' ? 'assertive' : 'polite'"
   >
-    {{ announceTextContent }}
+    <!--
+      Render each chunk as its own text node so screen readers get the
+      natural pause break between nodes (see comment in utils.ts).
+      Interpolating the array directly with `{{ announceTextContent }}`
+      would route through Vue's `toDisplayString`, which JSON-stringifies
+      arrays — the live region would then announce literal `[`, quotes
+      and commas instead of the toast title and description.
+    -->
+    <template
+      v-for="(text, i) in announceTextContent"
+      :key="i"
+    >
+      {{ text }}
+    </template>
   </ToastAnnounce>
 
   <Teleport


### PR DESCRIPTION
## Summary

The Toast aria-live region announced its content as a JSON-stringified array — screen reader users heard literal `[`, quotation marks, commas and the word `null` instead of the toast title and description.

`getAnnounceTextContent` (in [`packages/core/src/Toast/utils.ts`](https://github.com/unovue/reka-ui/blob/v2/packages/core/src/Toast/utils.ts)) returns a `string[]` on purpose, with this comment:

```ts
// We return a collection of text rather than a single concatenated string.
// This allows SR VO to naturally pause break between nodes while announcing.
```

The corresponding template in [`ToastRootImpl.vue`](https://github.com/unovue/reka-ui/blob/v2/packages/core/src/Toast/ToastRootImpl.vue) interpolated that array directly with `{{ announceTextContent }}`. In Vue 3 that runs through `toDisplayString`, which JSON-stringifies arrays:

```js
isArray(val) ? JSON.stringify(val, replacer, 2) : ...
```

So a toast with a `ToastTitle` of `"Hello"` and a `ToastDescription` of `"World"` was announced as the literal string:

```
Notification [
  "Hello",
  "World"
]
```

The pattern was ported 1:1 from Radix React, where `{children}` of a `string[]` happens to render as concatenated text nodes.

This switches the template to `<template v-for>` over the array, so each chunk is rendered as its own text node — which preserves the *natural pause break between nodes* the comment in `utils.ts` already calls out as the intent.

## Changes

- `packages/core/src/Toast/ToastRootImpl.vue`: replace `{{ announceTextContent }}` with `<template v-for>` and add a comment explaining why the array can't be interpolated directly.
- `packages/core/src/Toast/Toast.test.ts`: add a regression test that opens the toast, waits two animation frames for `ToastAnnounce` to mount, and asserts the live region's `textContent` contains the toast title and does not contain JSON syntax characters (`[`, `]`, `"`).

## Test plan

- [x] `pnpm --filter reka-ui test Toast.test` passes — 6/6 (was 5/5 before, +1 new regression test).
- [x] Verified the new test fails on the unfixed `ToastRootImpl.vue` (stashed the fix locally and re-ran: 1 failure, exactly the `[role="alert"][aria-live]` text content assertion).
- [x] ESLint clean on both touched files.

## Related

Closes #2613

🤖 Generated with [Claude Code](https://claude.com/claude-code)