### PR TITLE
fix(Tabs): defer indicator render until mounted to avoid hydration mismatch

### DIFF
--- a/packages/core/src/Tabs/TabsIndicator.vue
+++ b/packages/core/src/Tabs/TabsIndicator.vue
@@ -8,7 +8,7 @@ export interface TabsIndicatorProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { useResizeObserver } from '@vueuse/core'
+import { useMounted, useResizeObserver } from '@vueuse/core'
 import { Primitive } from '@/Primitive'
 
 const props = defineProps<TabsIndicatorProps>()
@@ -17,6 +17,8 @@ defineExpose({
   updateIndicatorStyle,
 })
 useForwardExpose()
+
+const isMounted = useMounted()
 
 interface IndicatorStyle {
   size: number | null
@@ -61,7 +63,7 @@ function updateIndicatorStyle() {
 
 <template>
   <Primitive
-    v-if="typeof indicatorStyle.size === 'number'"
+    v-if="isMounted && typeof indicatorStyle.size === 'number'"
     v-bind="props"
     :style="{
       '--reka-tabs-indicator-size': `${indicatorStyle.size}px`,


### PR DESCRIPTION
## 🔗 Linked Issue

Closes [nuxt/ui#5525](https://github.com/nuxt/ui/issues/5525) (the surfacing report — Nuxt UI consumes Reka Tabs unmodified, so the bug is here).

## 🐛 The bug

`TabsIndicator.vue` gates its primitive on a measured value:

```vue
<Primitive
  v-if="typeof indicatorStyle.size === 'number'"
  :style="{
    '--reka-tabs-indicator-size': `${indicatorStyle.size}px`,
    '--reka-tabs-indicator-position': `${indicatorStyle.position}px`,
  }"
>
```

`indicatorStyle.size` is `null` on the server (no DOM, so `updateIndicatorStyle()` returns early). SSR therefore emits `<!--v-if-->` and no indicator div.

On the client, the indicator has two paths that can mutate `indicatorStyle` during the hydration commit:

```ts
watch(() => [context.modelValue.value, context?.dir.value], () => {
  updateIndicatorStyle()
}, { immediate: true, flush: 'post' })

useResizeObserver(computed(() => [context.tabsList.value, ...tabs.value]), updateIndicatorStyle)
```

When `v-model`/`defaultValue` is set, an active tab exists by the time the post-flush callback fires, so `offsetWidth`/`offsetLeft` return real numbers, `indicatorStyle.size` flips from `null` to a number, and the v-if becomes truthy mid-hydration. Vue then logs a hydration mismatch on the indicator's parent (the `[data-slot="list"]` `<div role="tablist">`).

The combo from the Nuxt UI report:
- `v-model` or `defaultValue` set → active tab exists → measurement succeeds
- `dir="rtl"` → second watch dep (`context.dir.value`) resolves differently between server and client when `dir` isn't explicitly passed (it falls back to `ConfigProvider`/document context), which forces the post-flush callback to actually do work

## ✅ The fix

Gate the indicator's `v-if` on `useMounted()` in addition to the size check. SSR and the initial client render both emit `<!--v-if-->` deterministically, then `isMounted` flips after `onMounted` and the indicator appears via a normal post-hydration reactive update.

```diff
+const isMounted = useMounted()
…
-  v-if="typeof indicatorStyle.size === 'number'"
+  v-if="isMounted && typeof indicatorStyle.size === 'number'"
```

This is the same pattern Reka already uses for SSR-safe conditional rendering in:
- `packages/core/src/Slider/SliderThumbImpl.vue`
- `packages/core/src/Teleport/Teleport.vue`

## 🔁 Behavior change

None for the rendered output. The indicator was already invisible on first paint (the v-if was false until measurement). Now it stays invisible until `onMounted` *plus* measurement, instead of being able to flip during hydration. Visually identical, animation timing unchanged — the post-mount measurement still drives the first appearance.

## 🧪 Repro

A minimal Nuxt 4 project with:

```vue
<UTabs v-model="value" :items="items" dir="rtl" />
```

…and `value: ref('tab2')` produces the hydration warning on every page load. With this patch applied via local link/pnpm-override, the warning is gone.

I can put together a Stackblitz repro if helpful — flagging it here so you don't have to take my word for the conditions.

## 🔖 Checklist

- [x] Read [contribution guide](https://reka-ui.com/docs/overview/contribution.html).
- [x] Code is properly formatted (no formatter changes — only added one import, one ref, and one `&&` clause to an existing `v-if`).
- [x] Pattern matches existing `useMounted()` usage elsewhere in the repo.
- [ ] Tests added — happy to add a hydration regression test if you'd like (would need `renderToString` from `@vue/server-renderer` plus a small ssr setup, since current Tabs tests are jsdom-only). Wanted to keep the diff minimal and confirm the approach first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Tabs indicator rendering to ensure the indicator displays correctly during component initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->