### PR TITLE
chore(Tabs): fix css example still relying on tailwind classes

### DIFF
--- a/docs/components/demo/Tabs/css/index.vue
+++ b/docs/components/demo/Tabs/css/index.vue
@@ -13,10 +13,7 @@ import './styles.css'
       aria-label="Manage your account"
     >
       <TabsIndicator class="TabsIndicator">
-        <div
-          style="width: 100%; height: 100%"
-          class="bg-grass8 w-full h-full"
-        />
+        <div class="TabsIndicatorContent"/>
       </TabsIndicator>
       <TabsTrigger
         class="TabsTrigger"

--- a/docs/components/demo/Tabs/css/styles.css
+++ b/docs/components/demo/Tabs/css/styles.css
@@ -37,6 +37,12 @@ input {
   transition-duration: 300ms;
 }
 
+.TabsIndicatorContent {
+  background-color: var(--grass-8);
+  height: 100%;
+  width: 100%;
+}
+
 .TabsTrigger {
   font-family: inherit;
   background-color: white;


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

None, but the issue is the CSS example of "Tabs" still linking to tailwind classes. Pretty straight-forwards.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

Pretty much a docs/chore as it doesn't change runtime/build output.

### 📚 Description

I'm a lazy-ass dude that always rely on reka-ui to build my own components based on solid a11y foundations (thanks lads). I'm not a tailwind hater but… i hate tailwind!  Whenever I quickstart a project I end up copy/pasting  demos' source code and their relevant CSS styles I just adapt based on my needs. The `Tabs` component's CSS version still includes some of those tailwind (subjectively) awful classes when they should probably not. This annoyed me a several times so ended up opening this simple PR, feel free to ignore if irrelevant :-)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
