### PR TITLE
fix(Toast): replace useRafFn with one-shot rAF in ToastAnnounce

### DIFF
--- a/packages/core/src/Toast/ToastAnnounce.vue
+++ b/packages/core/src/Toast/ToastAnnounce.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useTimeout } from '@vueuse/shared'
+import { isClient, useTimeout } from '@vueuse/shared'
 import { onScopeDispose, ref } from 'vue'
 import { VisuallyHidden } from '@/VisuallyHidden'
 import { injectToastProviderContext } from './ToastProvider.vue'
@@ -11,16 +11,19 @@ const renderAnnounceText = ref(false)
 
 // Render text content in the next frame to ensure toast is announced in NVDA.
 // Double rAF mirrors Radix UI's `useNextFrame` behavior.
+let raf1 = 0
 let raf2 = 0
-const raf1 = requestAnimationFrame(() => {
-  raf2 = requestAnimationFrame(() => {
-    renderAnnounceText.value = true
+if (isClient) {
+  raf1 = requestAnimationFrame(() => {
+    raf2 = requestAnimationFrame(() => {
+      renderAnnounceText.value = true
+    })
   })
-})
-onScopeDispose(() => {
-  cancelAnimationFrame(raf1)
-  cancelAnimationFrame(raf2)
-})
+  onScopeDispose(() => {
+    cancelAnimationFrame(raf1)
+    cancelAnimationFrame(raf2)
+  })
+}
 </script>
 
 <template>

--- a/packages/core/src/Toast/ToastAnnounce.vue
+++ b/packages/core/src/Toast/ToastAnnounce.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { useRafFn } from '@vueuse/core'
 import { useTimeout } from '@vueuse/shared'
-import { ref } from 'vue'
+import { onScopeDispose, ref } from 'vue'
 import { VisuallyHidden } from '@/VisuallyHidden'
 import { injectToastProviderContext } from './ToastProvider.vue'
 
@@ -10,8 +9,17 @@ const providerContext = injectToastProviderContext()
 const isAnnounced = useTimeout(1000)
 const renderAnnounceText = ref(false)
 
-useRafFn(() => {
-  renderAnnounceText.value = true
+// Render text content in the next frame to ensure toast is announced in NVDA.
+// Double rAF mirrors Radix UI's `useNextFrame` behavior.
+let raf2 = 0
+const raf1 = requestAnimationFrame(() => {
+  raf2 = requestAnimationFrame(() => {
+    renderAnnounceText.value = true
+  })
+})
+onScopeDispose(() => {
+  cancelAnimationFrame(raf1)
+  cancelAnimationFrame(raf2)
 })
 </script>
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2619

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`ToastAnnounce` used [`useRafFn`](https://vueuse.org/core/useRafFn/) to defer setting `renderAnnounceText = true` by one animation frame:

```ts
useRafFn(() => {
  renderAnnounceText.value = true
})
```

But `useRafFn` keeps the callback running on **every animation frame** for the entire lifetime of the component — meaning every mounted toast was reassigning the same `true` value to the ref ~60 times per second. The intent was clearly a "next frame" deferral (see Radix UI's [`useNextFrame`](https://github.com/radix-ui/primitives/blob/main/packages/react/toast/src/toast.tsx#L895-L902)), not a per-frame loop.

This PR replaces it with a one-shot double `requestAnimationFrame` (matching Radix UI's behavior, which exists to ensure NVDA reliably announces the toast) and cancels any pending frames on scope dispose.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] Existing Toast tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable screen reader announcements for toast notifications; fixes timing issues so messages are announced consistently and avoids stray or duplicated announcements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->