### PR TITLE
feat(Number Field): add startingValue prop for increment/decrement

### DIFF
--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -91,6 +91,22 @@ describe('numberField', () => {
     expect(input.value).toBe('0')
   })
 
+  it('should start at starting value on increment/decrement, when no value present', async () => {
+    const { input, increment, decrement } = setup({ step: 3, startingValue: 40 })
+    expect(input.value).toBe('')
+
+    await userEvent.click(increment)
+    expect(input.value).toBe('40')
+    await userEvent.click(increment)
+    expect(input.value).toBe('43')
+
+    await userEvent.clear(input)
+    await userEvent.click(decrement)
+    expect(input.value).toBe('40')
+    await userEvent.click(decrement)
+    expect(input.value).toBe('37')
+  })
+
   it('should increase and decrease based on keyboard navigation on input', async () => {
     const { input } = setup({ defaultValue: 0, min: 0, max: 10 })
 

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -121,7 +121,7 @@ function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
     return
   const currentInputValue = numberParser.parse(inputEl.value?.value ?? '')
   if (isNaN(currentInputValue)) {
-    modelValue.value = startingValue.value ?? min.value ?? 0
+    modelValue.value = clampInputValue(startingValue.value ?? min.value ?? 0)
   }
   else {
     if (type === 'increase')

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -33,6 +33,8 @@ export interface NumberFieldRootProps extends PrimitiveProps, FormFieldProps {
   invertWheelChange?: boolean
   /** Id of the element */
   id?: string
+  /** The value at which increment/decrement starts at when no value is given. */
+  startingValue?: number
 }
 
 export type NumberFieldRootEmits = {
@@ -81,7 +83,7 @@ const props = withDefaults(defineProps<NumberFieldRootProps>(), {
   focusOnChange: true,
 })
 const emits = defineEmits<NumberFieldRootEmits>()
-const { disabled, readonly, disableWheelChange, invertWheelChange, min, max, step, stepSnapping, formatOptions, id, locale: propLocale } = toRefs(props)
+const { disabled, readonly, disableWheelChange, invertWheelChange, min, max, step, stepSnapping, formatOptions, id, locale: propLocale, startingValue } = toRefs(props)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue,
@@ -119,7 +121,7 @@ function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
     return
   const currentInputValue = numberParser.parse(inputEl.value?.value ?? '')
   if (isNaN(currentInputValue)) {
-    modelValue.value = min.value ?? 0
+    modelValue.value = startingValue.value ?? min.value ?? 0
   }
   else {
     if (type === 'increase')

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -121,7 +121,7 @@ function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
     return
   const currentInputValue = numberParser.parse(inputEl.value?.value ?? '')
   if (isNaN(currentInputValue)) {
-    modelValue.value = clampInputValue(startingValue.value ?? min.value ?? 0)
+    modelValue.value = startingValue.value !== undefined ? clampInputValue(startingValue.value) : min.value ?? 0
   }
   else {
     if (type === 'increase')


### PR DESCRIPTION
### 🔗 Linked issue
(https://github.com/unovue/reka-ui/issues/2627)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

**Added new prop 'startingValue' to Number Field**
When no value is present and startingValue is given, increment/decrement will fill the startingValue. If startingValue is not present it will fallback to previous behavior, min value or zero. 

See the issue for an useful example.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Number fields gain an optional starting value. When empty, the first increment or decrement begins from this configured starting value instead of the minimum or zero.

* **Tests**
  * Added test coverage ensuring increment/decrement sequences respect the configured starting value, including clearing and subsequent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->