### PR TITLE
fix(focus-scope): add data-focus-scope-unmounting attribute during focus restoration

### DIFF
--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -185,6 +185,10 @@ watchEffect(async (cleanupFn) => {
     container.addEventListener(AUTOFOCUS_ON_UNMOUNT, unmountEventHandler)
     container.dispatchEvent(unmountEvent)
 
+    // Signal that blur events fired below are system-initiated (focus trap
+    // cleanup), not user-initiated. Consumers can use this to skip validation.
+    container.setAttribute('data-focus-scope-unmounting', '')
+
     setTimeout(() => {
       if (!unmountEvent.defaultPrevented)
         focus(previouslyFocusedElement ?? document.body, { select: true })
@@ -193,6 +197,7 @@ watchEffect(async (cleanupFn) => {
       container.removeEventListener(AUTOFOCUS_ON_UNMOUNT, unmountEventHandler)
 
       focusScopesStack.remove(focusScope)
+      container.removeAttribute('data-focus-scope-unmounting')
     }, 0)
   })
 })


### PR DESCRIPTION


### 🔗 Linked issue

closes #2630 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a Dialog is closed, `FocusScope` calls `focus(previouslyFocusedElement)`
   to restore focus to the trigger. The browser synchronously fires a `blur`
  event on whichever input was focused inside the dialog as a side-effect. Form
   validation libraries (vee-validate, FormKit) that run on `blur` by default
  focus to the trigger. The browser synchronously fires a `blur` event on whichever input
  was focused inside the dialog as a side-effect. Form validation libraries (vee-validate,
  FormKit) that run on `blur` by default show validation errors on fields the user never
  intentionally blurred.

  This adds a `data-focus-scope-unmounting` attribute to the container for the duration of
  When a Dialog is closed, `FocusScope` calls `focus(previouslyFocusedElement)` to restore
  focus to the trigger. The browser synchronously fires a `blur` event on whichever input
  was focused inside the dialog as a side-effect. Form validation libraries (vee-validate,
  FormKit) that run on `blur` by default show validation errors on fields the user never
  intentionally blurred.

  This adds a `data-focus-scope-unmounting` attribute to the container for the duration of
  focus restoration, giving consumers a reliable signal to distinguish system-initiated
  blurs from user-initiated ones.

  ## Change

  ```ts
  // Before setTimeout:
  container.setAttribute('data-focus-scope-unmounting', '')

  // Inside setTimeout, after focus() returns:
  container.removeAttribute('data-focus-scope-unmounting')
  ```

  Why the timing is correct

  focus() fires blur synchronously on the focused input. The attribute is set before the
  setTimeout, so it is already present when blur fires inside it. It is removed after
  focus() returns, so it does not affect subsequent events.

  Consumer usage
  
```ts
  function handleBlur(event: FocusEvent) {
    if ((event.target as Element).closest('[data-focus-scope-unmounting]')) return
    // run validation
  }
```
No breaking changes. Purely additive — consumers opt in by checking the attribute.


### 📸 Screenshots (if appropriate)



### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus scope unmount behavior to properly signal state transitions and ensure correct focus handling when components are removed from the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->