### PR TITLE
fix(DatePicker): reset time after clearing value

### DIFF
--- a/packages/core/src/DatePicker/DatePicker.test.ts
+++ b/packages/core/src/DatePicker/DatePicker.test.ts
@@ -26,7 +26,7 @@ function getTimeSegments(getByTestId: (...args: any[]) => HTMLElement) {
   }
 }
 
-function setup(props: { datePickerProps?: DatePickerRootProps, emits?: { 'onUpdate:modelValue'?: (data: DateValue) => void } } = {}) {
+function setup(props: { datePickerProps?: DatePickerRootProps, emits?: { 'onUpdate:modelValue'?: (data: DateValue | undefined) => void } } = {}) {
   const user = userEvent.setup()
   const returned = render(DatePicker, { props })
   const month = returned.getByTestId('month')
@@ -250,6 +250,37 @@ describe('datePicker', async () => {
     expect(calendar.querySelector('[data-selected]')).toBeInTheDocument()
     await user.click(targetCell)
     expect(calendar.querySelector('[data-selected]')).not.toBeInTheDocument()
+  })
+
+  it('resets time when selecting a date after the model value is cleared', async () => {
+    const emittedValues: (DateValue | undefined)[] = []
+    const { user, trigger, getByTestId, rerender } = setup({
+      datePickerProps: {
+        modelValue: calendarDateTime,
+        granularity: 'minute',
+      },
+      emits: {
+        'onUpdate:modelValue': value => emittedValues.push(value),
+      },
+    })
+
+    await rerender({
+      datePickerProps: {
+        modelValue: undefined,
+        granularity: 'minute',
+      },
+      emits: {
+        'onUpdate:modelValue': value => emittedValues.push(value),
+      },
+    })
+
+    await user.click(trigger)
+    await user.click(getByTestId('date-1-1'))
+
+    const selectedValue = emittedValues.at(-1)
+    expect(selectedValue).toBeInstanceOf(CalendarDateTime)
+    expect((selectedValue as CalendarDateTime).hour).toBe(0)
+    expect((selectedValue as CalendarDateTime).minute).toBe(0)
   })
 
   it('should close the picker on select when `closeOnSelect` is true', async () => {

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -140,6 +140,13 @@ const open = useVModel(props, 'open', emits, {
 
 const dateFieldRef = ref<InstanceType<typeof DateFieldRoot> | undefined>()
 
+function resetTime(date: DateValue) {
+  if (!('hour' in date))
+    return date
+
+  return date.set({ hour: 0, minute: 0, second: 0 })
+}
+
 watch(modelValue, (value) => {
   if (value && value.compare(placeholder.value) !== 0) {
     placeholder.value = value.copy()
@@ -178,8 +185,11 @@ provideDatePickerRootContext({
   dir,
   step,
   onDateChange(date: DateValue | undefined) {
-    if (!date || !modelValue.value) {
-      modelValue.value = date?.copy() ?? undefined
+    if (!date) {
+      modelValue.value = undefined
+    }
+    else if (!modelValue.value) {
+      modelValue.value = resetTime(date).copy()
     }
     else if (!preventDeselect.value && date && modelValue.value.compare(date) === 0) {
       modelValue.value = undefined

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -140,6 +140,9 @@ const open = useVModel(props, 'open', emits, {
 
 const dateFieldRef = ref<InstanceType<typeof DateFieldRoot> | undefined>()
 
+/**
+ * Reset time fields on DateValue instances that support time granularity.
+ */
 function resetTime(date: DateValue) {
   if (!('hour' in date))
     return date


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Closes #2599

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`DatePickerRoot` could preserve a previously selected time after its model value was cleared. When a user selected a new date through the calendar with time granularity enabled, the calendar emitted a value based on the placeholder that still contained the old time.

This resets the time fields to `00:00:00` when selecting a date while the current model value is empty, and adds a regression test covering the clear-then-select flow.

Closes #2599

### 📸 Screenshots (if appropriate)

N/A

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Time fields now reset to 00:00 when clearing the date picker and selecting a date again.

* **Tests**
  * Added a test verifying time fields reset to 00:00 when the picker value is cleared and a new date is selected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2635)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->