### PR TITLE
fix(DatePicker): reset time after clearing value

### DIFF
--- a/packages/core/src/DatePicker/DatePicker.test.ts
+++ b/packages/core/src/DatePicker/DatePicker.test.ts
@@ -252,7 +252,7 @@ describe('datePicker', async () => {
     expect(calendar.querySelector('[data-selected]')).not.toBeInTheDocument()
   })
 
-  it('resets time when selecting a date after the model value is cleared', async () => {
+  it('resets stale placeholder time when selecting a date after the model value is cleared', async () => {
     const emittedValues: (DateValue | undefined)[] = []
     const { user, trigger, getByTestId, rerender } = setup({
       datePickerProps: {
@@ -285,7 +285,7 @@ describe('datePicker', async () => {
     expect((selectedValue as CalendarDateTime).millisecond).toBe(0)
   })
 
-  it('resets ZonedDateTime time when selecting a date after the model value is cleared', async () => {
+  it('resets stale ZonedDateTime placeholder time when selecting a date after the model value is cleared', async () => {
     const emittedValues: (DateValue | undefined)[] = []
     const zonedValue = toZoned(new CalendarDateTime(1980, 1, 20, 12, 30, 45, 123), 'America/New_York')
     const { user, trigger, getByTestId, rerender } = setup({
@@ -317,6 +317,61 @@ describe('datePicker', async () => {
     expect(selectedValue?.minute).toBe(0)
     expect(selectedValue?.second).toBe(0)
     expect(selectedValue?.millisecond).toBe(0)
+  })
+
+  it('preserves typed time when typing a date after the model value is cleared', async () => {
+    const emittedValues: (DateValue | undefined)[] = []
+    let rerender: ReturnType<typeof setup>['rerender']
+    const handleUpdateModelValue = (value: DateValue | undefined) => {
+      emittedValues.push(value)
+      return rerender({
+        datePickerProps: {
+          modelValue: value,
+          granularity: 'minute',
+        },
+        emits: {
+          'onUpdate:modelValue': handleUpdateModelValue,
+        },
+      })
+    }
+
+    const view = setup({
+      datePickerProps: {
+        modelValue: calendarDateTime,
+        granularity: 'minute',
+      },
+      emits: {
+        'onUpdate:modelValue': handleUpdateModelValue,
+      },
+    })
+    rerender = view.rerender
+
+    await rerender({
+      datePickerProps: {
+        modelValue: undefined,
+        granularity: 'minute',
+      },
+      emits: {
+        'onUpdate:modelValue': handleUpdateModelValue,
+      },
+    })
+
+    await view.user.click(view.month)
+    await view.user.keyboard('{2}')
+    await view.user.click(view.day)
+    await view.user.keyboard('{3}')
+    await view.user.click(view.year)
+    await view.user.keyboard('{2020}')
+    await view.user.click(view.getByTestId('hour'))
+    await view.user.keyboard('{9}')
+    await view.user.click(view.getByTestId('minute'))
+    await view.user.keyboard('{45}')
+
+    expect(view.month).toHaveTextContent('2')
+    expect(view.day).toHaveTextContent('3')
+    expect(view.year).toHaveTextContent('2020')
+    expect(view.getByTestId('hour')).toHaveTextContent('9')
+    expect(view.getByTestId('minute')).toHaveTextContent('45')
   })
 
   it('should close the picker on select when `closeOnSelect` is true', async () => {

--- a/packages/core/src/DatePicker/DatePicker.test.ts
+++ b/packages/core/src/DatePicker/DatePicker.test.ts
@@ -26,7 +26,7 @@ function getTimeSegments(getByTestId: (...args: any[]) => HTMLElement) {
   }
 }
 
-function setup(props: { datePickerProps?: DatePickerRootProps, emits?: { 'onUpdate:modelValue'?: (data: DateValue) => void } } = {}) {
+function setup(props: { datePickerProps?: DatePickerRootProps, emits?: { 'onUpdate:modelValue'?: (data: DateValue | undefined) => void } } = {}) {
   const user = userEvent.setup()
   const returned = render(DatePicker, { props })
   const month = returned.getByTestId('month')
@@ -250,6 +250,37 @@ describe('datePicker', async () => {
     expect(calendar.querySelector('[data-selected]')).toBeInTheDocument()
     await user.click(targetCell)
     expect(calendar.querySelector('[data-selected]')).not.toBeInTheDocument()
+  })
+
+  it('resets time when selecting a date after the model value is cleared', async () => {
+    const emittedValues: (DateValue | undefined)[] = []
+    const { user, trigger, getByTestId, rerender } = setup({
+      datePickerProps: {
+        modelValue: calendarDateTime,
+        granularity: 'minute',
+      },
+      emits: {
+        'onUpdate:modelValue': value => emittedValues.push(value),
+      },
+    })
+
+    await rerender({
+      datePickerProps: {
+        modelValue: undefined,
+        granularity: 'minute',
+      },
+      emits: {
+        'onUpdate:modelValue': value => emittedValues.push(value),
+      },
+    })
+
+    await user.click(trigger)
+    await user.click(getByTestId('date-1-1'))
+
+    const selectedValue = emittedValues.at(-1)
+    expect(selectedValue).toBeInstanceOf(CalendarDateTime)
+    expect((selectedValue as CalendarDateTime).hour).toBe(0)
+    expect((selectedValue as CalendarDateTime).minute).toBe(0)
   })
 
   it('should close the picker on select when `closeOnSelect` is true', async () => {

--- a/packages/core/src/DatePicker/DatePicker.test.ts
+++ b/packages/core/src/DatePicker/DatePicker.test.ts
@@ -281,6 +281,42 @@ describe('datePicker', async () => {
     expect(selectedValue).toBeInstanceOf(CalendarDateTime)
     expect((selectedValue as CalendarDateTime).hour).toBe(0)
     expect((selectedValue as CalendarDateTime).minute).toBe(0)
+    expect((selectedValue as CalendarDateTime).second).toBe(0)
+    expect((selectedValue as CalendarDateTime).millisecond).toBe(0)
+  })
+
+  it('resets ZonedDateTime time when selecting a date after the model value is cleared', async () => {
+    const emittedValues: (DateValue | undefined)[] = []
+    const zonedValue = toZoned(new CalendarDateTime(1980, 1, 20, 12, 30, 45, 123), 'America/New_York')
+    const { user, trigger, getByTestId, rerender } = setup({
+      datePickerProps: {
+        modelValue: zonedValue,
+        granularity: 'second',
+      },
+      emits: {
+        'onUpdate:modelValue': value => emittedValues.push(value),
+      },
+    })
+
+    await rerender({
+      datePickerProps: {
+        modelValue: undefined,
+        granularity: 'second',
+      },
+      emits: {
+        'onUpdate:modelValue': value => emittedValues.push(value),
+      },
+    })
+
+    await user.click(trigger)
+    await user.click(getByTestId('date-1-1'))
+
+    const selectedValue = emittedValues.at(-1)
+    expect(selectedValue).toHaveProperty('timeZone', 'America/New_York')
+    expect(selectedValue?.hour).toBe(0)
+    expect(selectedValue?.minute).toBe(0)
+    expect(selectedValue?.second).toBe(0)
+    expect(selectedValue?.millisecond).toBe(0)
   })
 
   it('should close the picker on select when `closeOnSelect` is true', async () => {

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -147,7 +147,7 @@ function resetTime(date: DateValue) {
   if (!('hour' in date))
     return date
 
-  return date.set({ hour: 0, minute: 0, second: 0 })
+  return date.set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
 }
 
 watch(modelValue, (value) => {

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -140,6 +140,13 @@ const open = useVModel(props, 'open', emits, {
 
 const dateFieldRef = ref<InstanceType<typeof DateFieldRoot> | undefined>()
 
+function resetTime(date: DateValue) {
+  if (!('hour' in date))
+    return date
+
+  return date.set({ hour: 0, minute: 0, second: 0 })
+}
+
 watch(modelValue, (value) => {
   if (value && value.compare(placeholder.value) !== 0) {
     placeholder.value = value.copy()
@@ -178,8 +185,11 @@ provideDatePickerRootContext({
   dir,
   step,
   onDateChange(date: DateValue | undefined) {
-    if (!date || !modelValue.value) {
-      modelValue.value = date?.copy() ?? undefined
+    if (!date) {
+      modelValue.value = undefined
+    }
+    else if (!modelValue.value) {
+      modelValue.value = resetTime(date).copy()
     }
     else if (!preventDeselect.value && date && modelValue.value.compare(date) === 0) {
       modelValue.value = undefined

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -154,6 +154,9 @@ watch(modelValue, (value) => {
   if (value && value.compare(placeholder.value) !== 0) {
     placeholder.value = value.copy()
   }
+  else if (!value && 'hour' in placeholder.value) {
+    placeholder.value = resetTime(placeholder.value)
+  }
   if (closeOnSelect.value) {
     open.value = false
   }
@@ -192,7 +195,7 @@ provideDatePickerRootContext({
       modelValue.value = undefined
     }
     else if (!modelValue.value) {
-      modelValue.value = resetTime(date).copy()
+      modelValue.value = date.copy()
     }
     else if (!preventDeselect.value && date && modelValue.value.compare(date) === 0) {
       modelValue.value = undefined

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -140,6 +140,9 @@ const open = useVModel(props, 'open', emits, {
 
 const dateFieldRef = ref<InstanceType<typeof DateFieldRoot> | undefined>()
 
+/**
+ * Reset time fields on DateValue instances that support time granularity.
+ */
 function resetTime(date: DateValue) {
   if (!('hour' in date))
     return date


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Closes #2599

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`DatePickerRoot` could preserve a previously selected time after its model value was cleared. When a user selected a new date through the calendar with time granularity enabled, the calendar emitted a value based on the placeholder that still contained the old time.

This resets the time fields to `00:00:00` when selecting a date while the current model value is empty, and adds a regression test covering the clear-then-select flow.

### 📸 Screenshots (if appropriate)

N/A

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DatePicker now normalizes time to 00:00 when selecting a date after clearing the previous selection; zoned values keep their time zone while time components are reset.
* **Tests**
  * Added tests verifying time reset for calendar and zoned values after clearing, and that typing preserves user-entered hour/minute values instead of using stale placeholders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->