### PR TITLE
fix(NavigationMenu): ignore inactive content dismiss

### DIFF
--- a/packages/core/src/NavigationMenu/NavigationMenu.test.ts
+++ b/packages/core/src/NavigationMenu/NavigationMenu.test.ts
@@ -112,11 +112,20 @@ describe('given default NavigationMenu', () => {
 
     expect(wrapper.find('[data-testid="model-value"]').text()).toBe('one')
 
-    await fireEvent.pointerDown(wrapper.find('[data-testid="inside-one"]').element)
+    // Open second content; first stays mounted but becomes inactive
+    await wrapper.find('[data-testid="trigger-two"]').trigger('click')
     await wrapper.vm.$nextTick()
     await sleep(0)
 
-    expect(wrapper.find('[data-testid="model-value"]').text()).toBe('one')
+    expect(wrapper.find('[data-testid="model-value"]').text()).toBe('two')
+
+    // Click inside active content-two; inactive content-one should not interfere
+    await fireEvent.pointerDown(wrapper.find('[data-testid="inside-two"]').element)
+    await wrapper.vm.$nextTick()
+    await sleep(0)
+
+    // Content-two should remain open (content-one's dismiss handler returned early)
+    expect(wrapper.find('[data-testid="model-value"]').text()).toBe('two')
 
     wrapper.unmount()
   })

--- a/packages/core/src/NavigationMenu/NavigationMenu.test.ts
+++ b/packages/core/src/NavigationMenu/NavigationMenu.test.ts
@@ -7,8 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
 import { sleep } from '@/test'
-import NavigationMenuItem from './NavigationMenuItem.vue'
+import NavigationMenuUnmountOnHideFalse from './__test__/NavigationMenuUnmountOnHideFalse.vue'
 
+import NavigationMenuItem from './NavigationMenuItem.vue'
 import NavigationMenu from './story/_NavigationMenu.vue'
 
 vi.mock('@vueuse/core', async () => {
@@ -100,6 +101,24 @@ describe('given default NavigationMenu', () => {
     //     expect(wrapper.find('[data-dismissable-layer]').exists()).toBe(false)
     //   })
     // })
+  })
+
+  it('keeps active content open when clicking inside with unmountOnHide disabled', async () => {
+    const wrapper = mount(NavigationMenuUnmountOnHideFalse, { attachTo: document.body })
+
+    await wrapper.find('[data-testid="trigger-one"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await sleep(0)
+
+    expect(wrapper.find('[data-testid="model-value"]').text()).toBe('one')
+
+    await fireEvent.pointerDown(wrapper.find('[data-testid="inside-one"]').element)
+    await wrapper.vm.$nextTick()
+    await sleep(0)
+
+    expect(wrapper.find('[data-testid="model-value"]').text()).toBe('one')
+
+    wrapper.unmount()
   })
 
   describe('menu triggers', () => {

--- a/packages/core/src/NavigationMenu/NavigationMenuContentImpl.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuContentImpl.vue
@@ -180,6 +180,9 @@ function handleKeydown(ev: KeyboardEvent) {
 }
 
 function handleDismiss() {
+  if (menuContext.modelValue.value !== itemContext.value)
+    return
+
   const rootContentDismissEvent = new Event(EVENT_ROOT_CONTENT_DISMISS, {
     bubbles: true,
     cancelable: true,

--- a/packages/core/src/NavigationMenu/__test__/NavigationMenuUnmountOnHideFalse.vue
+++ b/packages/core/src/NavigationMenu/__test__/NavigationMenuUnmountOnHideFalse.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  NavigationMenuContent,
+  NavigationMenuItem,
+  NavigationMenuList,
+  NavigationMenuRoot,
+  NavigationMenuTrigger,
+} from '..'
+
+const modelValue = ref('')
+</script>
+
+<template>
+  <NavigationMenuRoot
+    v-model="modelValue"
+    :unmount-on-hide="false"
+    :disable-hover-trigger="true"
+  >
+    <span data-testid="model-value">{{ modelValue }}</span>
+    <NavigationMenuList>
+      <NavigationMenuItem value="one">
+        <NavigationMenuTrigger data-testid="trigger-one">
+          One
+        </NavigationMenuTrigger>
+        <NavigationMenuContent data-testid="content-one">
+          <button data-testid="inside-one">
+            Inside one
+          </button>
+        </NavigationMenuContent>
+      </NavigationMenuItem>
+
+      <NavigationMenuItem value="two">
+        <NavigationMenuTrigger data-testid="trigger-two">
+          Two
+        </NavigationMenuTrigger>
+        <NavigationMenuContent data-testid="content-two">
+          <button data-testid="inside-two">
+            Inside two
+          </button>
+        </NavigationMenuContent>
+      </NavigationMenuItem>
+    </NavigationMenuList>
+  </NavigationMenuRoot>
+</template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Closes #2608

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes an issue where `NavigationMenu` can dismiss the currently active content incorrectly when `unmountOnHide` is set to `false`.

With `unmountOnHide={false}`, multiple `NavigationMenuContent` instances can remain mounted at the same time. An inactive content’s `DismissableLayer` can still dispatch a dismiss event, which causes the root menu state to clear even though the event did not come from the active item.

This PR updates the dismiss handler so inactive `NavigationMenuContent` instances ignore dismiss events. Only the currently active item is allowed to trigger the root dismiss behavior.

It also adds a regression fixture and test covering the multiple-mounted-content case.

### 📸 Screenshots (if appropriate)

N/A — behavior-only bug fix covered by regression test.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incorrect menu dismissals by ensuring the active menu content isn’t closed when switching items in certain configurations, improving menu stability.

* **Tests**
  * Added a new test fixture and test to validate menu behavior when content is preserved (unmount-on-hide disabled), ensuring reliable interactions across menu switches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2637)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->