### PR TITLE
fix(Select): clean up delayed presence update

### DIFF
--- a/packages/core/src/Select/Select.test.ts
+++ b/packages/core/src/Select/Select.test.ts
@@ -1,10 +1,11 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
 import { handleSubmit } from '@/test'
+import SelectUnmountCleanup from './__test__/SelectUnmountCleanup.vue'
 import Select from './story/_SelectTest.vue'
 
 beforeAll(() => {
@@ -248,6 +249,35 @@ describe('given Select with object type', async () => {
         expect(group.exists()).toBeFalsy()
       })
     })
+  })
+})
+
+describe('given SelectContent cleanup', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should clear delayed presence updates when unmounted after closing', async () => {
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+    const wrapper = mount(SelectUnmountCleanup, { attachTo: document.body })
+
+    await nextTick()
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+
+    const timerCountAfterClose = vi.getTimerCount()
+    expect(timerCountAfterClose).toBeGreaterThan(0)
+
+    await wrapper.findAll('button')[1].trigger('click')
+    await nextTick()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBeLessThan(timerCountAfterClose)
   })
 })
 

--- a/packages/core/src/Select/SelectContent.vue
+++ b/packages/core/src/Select/SelectContent.vue
@@ -3,7 +3,7 @@ import type {
   SelectContentImplEmits,
   SelectContentImplProps,
 } from './SelectContentImpl.vue'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 export type SelectContentEmits = SelectContentImplEmits
 
@@ -44,15 +44,31 @@ const presenceRef = ref<InstanceType<typeof Presence>>()
 const present = computed(() => props.forceMount || rootContext.open.value)
 const renderPresence = ref(present.value)
 
-watch(present, () => {
+let renderPresenceTimeout: ReturnType<typeof setTimeout> | undefined
+
+function clearRenderPresenceTimeout() {
+  if (renderPresenceTimeout) {
+    clearTimeout(renderPresenceTimeout)
+    renderPresenceTimeout = undefined
+  }
+}
+
+watch(present, (_value, _oldValue, onCleanup) => {
   // Toggle render presence after a delay (nextTick is not enough)
   // to allow children to re-render with the latest state.
   // Otherwise, they would remain in the old state during the transition,
   // which would prevent the animation that depend on state (e.g., data-[state=closed])
   // from being applied accurately.
   // @see https://github.com/unovue/reka-ui/issues/1865
-  setTimeout(() => renderPresence.value = present.value)
+  clearRenderPresenceTimeout()
+  renderPresenceTimeout = setTimeout(() => {
+    renderPresence.value = present.value
+    renderPresenceTimeout = undefined
+  })
+  onCleanup(clearRenderPresenceTimeout)
 })
+
+onUnmounted(clearRenderPresenceTimeout)
 </script>
 
 <template>

--- a/packages/core/src/Select/__test__/SelectUnmountCleanup.vue
+++ b/packages/core/src/Select/__test__/SelectUnmountCleanup.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  SelectContent,
+  SelectItem,
+  SelectItemText,
+  SelectPortal,
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from '..'
+
+const open = ref(true)
+const mounted = ref(true)
+</script>
+
+<template>
+  <button @click="open = false">
+    Close
+  </button>
+  <button @click="mounted = false">
+    Unmount
+  </button>
+
+  <SelectRoot
+    v-if="mounted"
+    v-model:open="open"
+  >
+    <SelectTrigger aria-label="Fruit">
+      <SelectValue placeholder="Please select a fruit" />
+    </SelectTrigger>
+    <SelectPortal>
+      <SelectContent position="popper">
+        <SelectViewport>
+          <SelectItem value="apple">
+            <SelectItemText>Apple</SelectItemText>
+          </SelectItem>
+        </SelectViewport>
+      </SelectContent>
+    </SelectPortal>
+  </SelectRoot>
+</template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Closes #2367

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a potential cleanup issue in `SelectContent` that can retain stale delayed presence updates after the select content is closed or unmounted.

`SelectContent` delays syncing `renderPresence` with `present` using `setTimeout` so children can re-render with the latest state before transition-related attributes are applied. However, the scheduled timeout was not explicitly cleared when `present` changed again or when the component was unmounted.

In forms or pages that repeatedly mount, close, reset, or re-render multiple `Select` instances, those stale queued callbacks can retain component state longer than necessary and contribute to detached nodes/listeners being held in memory.

This PR makes the delayed presence update disposable by clearing the pending timeout when the watcher invalidates and when the component unmounts.

This preserves the existing delayed-render behavior added for transition correctness while avoiding stale pending callbacks after cleanup.

### 📸 Screenshots (if appropriate)

N/A — lifecycle cleanup fix covered by tests.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Select component unmount cleanup to prevent lingering timeout operations that could trigger stale render updates.

* **Tests**
  * Added comprehensive test coverage for Select component cleanup behavior when unmounting after state changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2638)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->