### PR TITLE
feat(Select): add nullableValue prop

### DIFF
--- a/docs/content/meta/SelectRoot.md
+++ b/docs/content/meta/SelectRoot.md
@@ -45,6 +45,13 @@
     'required': false
   },
   {
+    'name': 'nullableValue',
+    'description': '<p>The value of the hidden native select option when the model value is nullish.</p>\n',
+    'type': 'string',
+    'required': false,
+    'default': '\'\''
+  },
+  {
     'name': 'multiple',
     'description': '<p>Whether multiple options can be selected or not.</p>\n',
     'type': 'boolean',
@@ -110,6 +117,7 @@
 | `dir` | The reading direction of the combobox when applicable. <br> If omitted, inherits globally from ConfigProvider or assumes LTR (left-to-right) reading mode. | `"ltr" \| "rtl"` | No | - |
 | `disabled` | When true, prevents the user from interacting with Select | `boolean` | No | - |
 | `modelValue` | The controlled value of the Select. Can be bind as v-model. | `AcceptableValue \| AcceptableValue[]` | No | - |
+| `nullableValue` | The value of the hidden native select option when the model value is nullish. | `string` | No | `""` |
 | `multiple` | Whether multiple options can be selected or not. | `boolean` | No | - |
 | `name` | The name of the field. Submitted with its owning form as part of a name/value pair. | `string` | No | - |
 | `open` | The controlled open state of the Select. Can be bind as v-model:open. | `boolean` | No | - |

--- a/packages/core/src/Select/Select.test.ts
+++ b/packages/core/src/Select/Select.test.ts
@@ -265,6 +265,18 @@ describe('given Select in a form', async () => {
     expect(wrapper.find('select').exists()).toBe(true)
   })
 
+  it('should use the nullableValue for the hidden select when the value is nullish', async () => {
+    const wrapper = mount({
+      components: { Select },
+      template: '<form><Select name="test" nullable-value="null" /></form>',
+    }, {
+      attachTo: document.body,
+    })
+
+    const options = wrapper.findAll('select option')
+    expect((options[0].element as HTMLOptionElement).value).toBe('null')
+  })
+
   describe('after selecting option and clicking submit button', () => {
     beforeEach(async () => {
       await wrapper.find('button').trigger('pointerdown', {

--- a/packages/core/src/Select/SelectRoot.vue
+++ b/packages/core/src/Select/SelectRoot.vue
@@ -14,6 +14,8 @@ export interface SelectRootProps<T = AcceptableValue> extends FormFieldProps {
   defaultValue?: T | Array<T>
   /** The controlled value of the Select. Can be bind as `v-model`. */
   modelValue?: T | Array<T>
+  /** The value of the hidden native select option when the model value is nullish. */
+  nullableValue?: string
   /** Use this to compare objects by a particular field, or pass your own comparison function for complete control over how objects are compared. */
   by?: string | ((a: T, b: T) => boolean)
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
@@ -75,6 +77,7 @@ defineOptions({
 const props = withDefaults(defineProps<SelectRootProps<T>>(), {
   modelValue: undefined,
   open: undefined,
+  nullableValue: '',
 })
 const emits = defineEmits<SelectRootEmits<T>>()
 
@@ -214,7 +217,7 @@ provideSelectRootContext({
     >
       <option
         v-if="isNullish(modelValue)"
-        value=""
+        :value="nullableValue"
       />
       <option
         v-for="option in Array.from(optionsSet)"


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1975

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a `nullableValue` prop to `SelectRoot` so consumers can customize the hidden native select option value used when `modelValue` is nullish.

This keeps the existing default behavior (`""`) while allowing forms to submit another sentinel value such as `"null"` for server-side type handling.

- Adds `nullableValue?: string` to `SelectRootProps`
- Defaults `nullableValue` to an empty string for backward compatibility
- Uses `nullableValue` for the nullish hidden `<option>` in the native bubble select
- Documents the new prop in `docs/content/meta/SelectRoot.md`
- Adds regression coverage for the hidden select option value

### 📸 Screenshots (if appropriate)

N/A

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `nullableValue` prop to the Select component, allowing customization of the value assigned when no selection is made. Defaults to an empty string to maintain backward compatibility.

* **Documentation**
  * Updated SelectRoot prop documentation to include the new `nullableValue` prop.

* **Tests**
  * Added test validation for nullable value behavior in form contexts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2641)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->