### PR TITLE
fix(Listbox): include `disabled` in ListboxItem v-memo deps

### DIFF
--- a/packages/core/src/Listbox/Listbox.test.ts
+++ b/packages/core/src/Listbox/Listbox.test.ts
@@ -2,9 +2,10 @@ import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
-import { nextTick } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 import { useKbd } from '@/shared'
 import { handleSubmit } from '@/test'
+import { ListboxItem, ListboxRoot } from '.'
 import Listbox from './story/_Listbox.vue'
 
 describe('given default Listbox', () => {
@@ -316,6 +317,45 @@ describe('given horizontal Listbox', () => {
         })
       })
     })
+  })
+})
+
+// Regression test for https://github.com/unovue/reka-ui/issues/2644
+// `v-memo` on ListboxItem must invalidate when `disabled` (or
+// `rootContext.focusable.value`) changes, otherwise `data-disabled` / `disabled`
+// attributes go stale and the item still participates in keyboard navigation.
+describe('given ListboxItem with reactive `disabled` prop', () => {
+  it('should update DOM attributes when `disabled` toggles without highlight/selection change', async () => {
+    const isDisabled = ref(false)
+    const ReactiveDisabledListbox = defineComponent({
+      setup() {
+        return () =>
+          h(ListboxRoot, null, {
+            default: () => [
+              h(ListboxItem, { value: { id: 1 }, disabled: isDisabled.value }, () => 'toggleable'),
+              h(ListboxItem, { value: { id: 2 } }, () => 'other'),
+            ],
+          })
+      },
+    })
+
+    const wrapper = mount(ReactiveDisabledListbox, { attachTo: document.body })
+    const items = wrapper.findAll('[role=option]')
+
+    expect(items[0].attributes('data-disabled')).toBeUndefined()
+    expect(items[0].attributes('disabled')).toBeUndefined()
+
+    isDisabled.value = true
+    await nextTick()
+
+    expect(items[0].attributes('data-disabled')).toBe('')
+    expect(items[0].attributes('disabled')).toBe('')
+
+    isDisabled.value = false
+    await nextTick()
+
+    expect(items[0].attributes('data-disabled')).toBeUndefined()
+    expect(items[0].attributes('disabled')).toBeUndefined()
   })
 })
 

--- a/packages/core/src/Listbox/ListboxItem.vue
+++ b/packages/core/src/Listbox/ListboxItem.vue
@@ -76,7 +76,7 @@ provideListboxItemContext({
       :id="id"
       v-bind="$attrs"
       :ref="forwardRef"
-      v-memo="[isHighlighted, isSelected]"
+      v-memo="[isHighlighted, isSelected, disabled, rootContext.focusable.value]"
       role="option"
       :tabindex="rootContext.focusable.value ? isHighlighted ? '0' : '-1' : -1"
       :aria-selected="isSelected"


### PR DESCRIPTION
## Summary

- Adds `disabled` and `rootContext.focusable.value` to the `v-memo` dependency list on `ListboxItem`'s rendered `Primitive`.
- Adds a regression test that toggles `:disabled` reactively without touching highlight/selection and asserts the DOM attributes update.

## Problem

`ListboxItem` cached its VNode with `v-memo="[isHighlighted, isSelected]"`, but the cached expression also reads `disabled` (for the `disabled` and `data-disabled` attributes) and `rootContext.focusable.value` (for the `tabindex` ternary). `v-memo` skips re-render when none of the listed deps change, so flipping `:disabled` at runtime left `data-disabled` / `disabled` stale on the DOM until something *also* changed the highlight or selection for that item.

Because `Listbox.getCollectionItem()` filters the navigable collection by reading `dataset.disabled !== ''` from the live DOM, a stale attribute kept disabled items in the keyboard-navigable set. In `<ComboboxRoot>` with a dynamic item set, this surfaced as "every other ArrowDown jumps back to the originally selected item" (issue reporter's downstream symptom in NuxtUI `InputMenu`).

## Fix

```diff
-      v-memo="[isHighlighted, isSelected]"
+      v-memo="[isHighlighted, isSelected, disabled, rootContext.focusable.value]"
```

This is the only `v-memo` usage in `packages/core/src` (grepped), so the scope is limited to this single file.

## Test plan

- [x] New regression test in `Listbox.test.ts` toggles `disabled` reactively and asserts `data-disabled` / `disabled` are reflected on the DOM both ways — confirmed red before the fix, green after.
- [x] All 32 existing Listbox tests still pass (`pnpm vitest run src/Listbox/Listbox.test.ts`).

Fixes #2644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Listbox component to properly handle disabled state changes, ensuring DOM attributes update correctly when toggling item disabled status without affecting focus or selection state.

## Tests
* Added regression test for issue `#2644` to verify disabled state behavior in Listbox items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->