### PR TITLE
docs(CheckboxGroup): wrap CheckboxRoot in label so clicks toggle state

### DIFF
--- a/docs/components/examples/CheckboxGroup/index.vue
+++ b/docs/components/examples/CheckboxGroup/index.vue
@@ -17,10 +17,10 @@ const items = [
     v-model="values"
     class="flex flex-col gap-2.5"
   >
-    <div
+    <label
       v-for="item in items"
       :key="item.value"
-      class="flex items-center gap-3"
+      class="flex flex-row gap-3 items-center"
     >
       <CheckboxRoot
         :value="item.value"
@@ -33,9 +33,7 @@ const items = [
           />
         </CheckboxIndicator>
       </CheckboxRoot>
-      <label class="flex flex-row gap-4 items-center">
-        <span class="select-none dark:text-white">{{ item.label }}</span>
-      </label>
-    </div>
+      <span class="select-none dark:text-white">{{ item.label }}</span>
+    </label>
   </CheckboxGroupRoot>
 </template>


### PR DESCRIPTION
## Summary
- The CheckboxGroup example placed `<label>` as a sibling of `CheckboxRoot` with no `for`/`id` link, so clicking a label (e.g. "Soccer") did nothing.
- Wrap `CheckboxRoot` inside the `<label>` (matching the existing single-checkbox demo pattern in [docs/components/demo/Checkbox/tailwind/index.vue](docs/components/demo/Checkbox/tailwind/index.vue)) so the label click toggles the checkbox.

Closes #2652

## Test plan
- [ ] Visit the CheckboxGroup example and click each label ("Soccer", "Badminton", "Basketball"); each should toggle its checkbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CheckboxGroup example component with refined layout structure and improved spacing for better visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->