### PR TITLE
fix(Dialog): restore focus to trigger after overlay click

### DIFF
--- a/packages/core/src/Dialog/Dialog.test.ts
+++ b/packages/core/src/Dialog/Dialog.test.ts
@@ -134,5 +134,31 @@ describe('given a default Dialog', () => {
         expect(document.activeElement).toBe(trigger.element)
       })
     })
+
+    describe('when clicking the overlay', () => {
+      beforeEach(async () => {
+        // Wait for the document-level pointerdown listener to be registered
+        // (registered via setTimeout(0) inside DismissableLayer).
+        await new Promise(resolve => setTimeout(resolve, 0))
+        // Find the overlay: the only element with data-state="open" that
+        // isn't the trigger button or the dialog content.
+        const overlayEl = Array.from(
+          document.querySelectorAll('[data-state="open"]'),
+        ).find(el => el.tagName === 'DIV' && !el.getAttribute('role')) as HTMLElement
+        await fireEvent.pointerDown(overlayEl)
+        await nextTick()
+        await nextTick()
+        // setTimeout(0) inside FocusScope cleanup
+        await new Promise(resolve => setTimeout(resolve, 10))
+      })
+
+      it('should close the content', () => {
+        expect(document.body.innerHTML).not.toContain(closeButton.innerHTML)
+      })
+
+      it('should focus trigger', () => {
+        expect(document.activeElement).toBe(trigger.element)
+      })
+    })
   })
 })

--- a/packages/core/src/Dialog/DialogOverlayImpl.vue
+++ b/packages/core/src/Dialog/DialogOverlayImpl.vue
@@ -23,6 +23,7 @@ useForwardExpose()
     :as-child="asChild"
     :data-state="rootContext.open.value ? 'open' : 'closed'"
     style="pointer-events: auto"
+    @pointerdown.left.prevent
   >
     <slot />
   </Primitive>


### PR DESCRIPTION
### 🔗 Linked issue

closes #2649

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When the dialog is closed via the overlay click, focus falls to `<body>` instead of returning to the trigger. Escape and the close button work fine; only the overlay click is affected.

**Root cause:** the sequence is `pointerdown` → `dismiss` → `DialogContent` unmounts → `FocusScope` restores focus to the trigger. The browser then dispatches the compatibility `mousedown` event, but the overlay is already gone, so `mousedown` fires on `<body>`. The browser's default `mousedown` behavior on a non-focusable element blurs the just-focused trigger — focus falls to body.

**Fix:** add `@pointerdown.left.prevent` to `DialogOverlayImpl`. Per the Pointer Events spec, preventing default on `pointerdown` suppresses the corresponding compatibility `mousedown`, so no blur happens. The `.left` modifier scopes the prevention to primary button so right-click context menus still work.

### 🧪 Verification

Reproduced the bug in headless Chromium against `docs/components/dialog`:

```
pointerdown DIV.bg-blackA9         active=INPUT#name
focusout <- INPUT relatedTarget=BUTTON   (trigger gets focus)
focusin -> BUTTON Edit profile
mousedown BODY                            ← compat mousedown on body
focusout <- BUTTON relatedTarget=null     ← blurs trigger
final: BODY
```

After the fix, `mousedown` is suppressed and focus stays on the trigger.

Manually verified in the browser:
- ✅ Overlay click: focus returns to trigger
- ✅ Escape: focus returns to trigger (unchanged)
- ✅ Close button: focus returns to trigger (unchanged)
- ✅ Right-click on overlay: dialog stays open, no regression
- ✅ Click inside dialog (inputs, buttons): focus works normally

Added a regression test for the overlay-click path; full suite (1,635 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)