### PR TITLE
fix(useGraceArea): close tooltip when another grace area trigger is beneath content

### DIFF
--- a/packages/core/src/shared/useGraceArea.test.ts
+++ b/packages/core/src/shared/useGraceArea.test.ts
@@ -1,0 +1,167 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { useGraceArea } from './useGraceArea'
+
+// jsdom doesn't support PointerEvent, so we use MouseEvent with `pointerType`.
+function createPointerEvent(type: string, init: { clientX: number, clientY: number, target?: EventTarget, currentTarget?: EventTarget }) {
+  const event = new MouseEvent(type, { bubbles: true, clientX: init.clientX, clientY: init.clientY })
+  if (init.target)
+    Object.defineProperty(event, 'target', { value: init.target, writable: false })
+  if (init.currentTarget)
+    Object.defineProperty(event, 'currentTarget', { value: init.currentTarget, writable: false })
+  return event
+}
+
+function mockRect(el: HTMLElement, rect: Partial<DOMRect>) {
+  el.getBoundingClientRect = vi.fn(() => ({
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+    ...rect,
+  } as DOMRect))
+}
+
+interface SetupOptions {
+  withOtherTrigger?: boolean
+}
+
+function setup({ withOtherTrigger = false }: SetupOptions = {}) {
+  let exitCount = 0
+
+  const TestComponent = defineComponent({
+    setup() {
+      const trigger = ref<HTMLElement>()
+      const content = ref<HTMLElement>()
+
+      const { onPointerExit } = useGraceArea(trigger, content)
+      onPointerExit(() => {
+        exitCount++
+      })
+
+      return () =>
+        h('div', [
+          h(
+            'button',
+            {
+              'ref': (el: any) => {
+                trigger.value = el
+              },
+              'data-grace-area-trigger': '',
+              'data-testid': 'trigger',
+            },
+            'Trigger',
+          ),
+          withOtherTrigger
+            ? h(
+                'button',
+                {
+                  'data-grace-area-trigger': '',
+                  'data-testid': 'other-trigger',
+                },
+                'Other Trigger',
+              )
+            : null,
+          h(
+            'div',
+            {
+              'ref': (el: any) => {
+                content.value = el
+              },
+              'data-testid': 'content',
+            },
+            'Content',
+          ),
+        ])
+    },
+  })
+
+  const wrapper = mount(TestComponent, { attachTo: document.body })
+  const triggerEl = wrapper.element.querySelector('[data-testid="trigger"]') as HTMLElement
+  const contentEl = wrapper.element.querySelector('[data-testid="content"]') as HTMLElement
+  const otherTriggerEl = wrapper.element.querySelector('[data-testid="other-trigger"]') as HTMLElement | null
+
+  mockRect(triggerEl, { top: 0, left: 0, bottom: 30, right: 100, width: 100, height: 30 })
+  mockRect(contentEl, { top: 40, left: 0, bottom: 70, right: 100, width: 100, height: 30 })
+
+  return {
+    wrapper,
+    triggerEl,
+    contentEl,
+    otherTriggerEl,
+    getExitCount: () => exitCount,
+  }
+}
+
+describe('useGraceArea', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('triggers exit when cursor is over content with another grace-area-trigger underneath', async () => {
+    const { wrapper, triggerEl, contentEl, otherTriggerEl, getExitCount } = setup({ withOtherTrigger: true })
+    await nextTick()
+
+    // Create the grace area by leaving the trigger
+    triggerEl.dispatchEvent(createPointerEvent('pointerleave', { clientX: 50, clientY: 30, currentTarget: triggerEl }))
+    await nextTick()
+
+    // Simulate the tooltip content being positioned over another grace-area-trigger.
+    document.elementsFromPoint = vi.fn(() => [contentEl, otherTriggerEl!])
+
+    // Cursor moves onto the content (which sits over the other trigger).
+    document.dispatchEvent(createPointerEvent('pointermove', { clientX: 50, clientY: 55, target: contentEl }))
+    await nextTick()
+
+    expect(getExitCount()).toBe(1)
+
+    wrapper.unmount()
+  })
+
+  it('does not trigger exit when cursor is over content with no other grace-area-trigger underneath', async () => {
+    const { wrapper, triggerEl, contentEl, getExitCount } = setup()
+    await nextTick()
+
+    triggerEl.dispatchEvent(createPointerEvent('pointerleave', { clientX: 50, clientY: 30, currentTarget: triggerEl }))
+    await nextTick()
+
+    document.elementsFromPoint = vi.fn(() => [contentEl])
+
+    document.dispatchEvent(createPointerEvent('pointermove', { clientX: 50, clientY: 55, target: contentEl }))
+    await nextTick()
+
+    expect(getExitCount()).toBe(0)
+
+    wrapper.unmount()
+  })
+
+  it('keeps tracking pointer while cursor stays on content so later movement over another trigger still closes', async () => {
+    const { wrapper, triggerEl, contentEl, otherTriggerEl, getExitCount } = setup({ withOtherTrigger: true })
+    await nextTick()
+
+    triggerEl.dispatchEvent(createPointerEvent('pointerleave', { clientX: 50, clientY: 30, currentTarget: triggerEl }))
+    await nextTick()
+
+    // First move: cursor lands on content at a spot with no other trigger underneath.
+    document.elementsFromPoint = vi.fn(() => [contentEl])
+    document.dispatchEvent(createPointerEvent('pointermove', { clientX: 50, clientY: 45, target: contentEl }))
+    await nextTick()
+    expect(getExitCount()).toBe(0)
+
+    // Second move: cursor still on content but now over another grace-area-trigger.
+    document.elementsFromPoint = vi.fn(() => [contentEl, otherTriggerEl!])
+    document.dispatchEvent(createPointerEvent('pointermove', { clientX: 50, clientY: 60, target: contentEl }))
+    await nextTick()
+
+    expect(getExitCount()).toBe(1)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/core/src/shared/useGraceArea.ts
+++ b/packages/core/src/shared/useGraceArea.ts
@@ -57,12 +57,33 @@ export function useGraceArea(triggerElement: Ref<HTMLElement | undefined>, conta
 
         const target = event.target
         const pointerPosition = { x: event.clientX, y: event.clientY }
-        const hasEnteredTarget = triggerElement.value?.contains(target) || containerElement.value?.contains(target)
+        const isOverTrigger = !!triggerElement.value?.contains(target)
+        const isOverContent = !!containerElement.value?.contains(target)
         const isPointerOutsideGraceArea = !isPointInPolygon(pointerPosition, pointerGraceArea.value)
         const isAnotherGraceAreaTrigger = !!target.closest('[data-grace-area-trigger]')
 
-        if (hasEnteredTarget) {
+        // When the cursor is over the content, check if there is another grace
+        // area trigger underneath at the same pointer position (e.g., a tooltip's
+        // content is positioned over another tooltip's trigger). If so, close
+        // the current tooltip so the underlying trigger remains accessible.
+        const isOverOtherTriggerBeneathContent = isOverContent && target.ownerDocument
+          .elementsFromPoint(pointerPosition.x, pointerPosition.y)
+          .some((el) => {
+            const t = el.closest('[data-grace-area-trigger]')
+            return !!t && t !== triggerElement.value
+          })
+
+        if (isOverOtherTriggerBeneathContent) {
           handleRemoveGraceArea()
+          pointerExit.trigger()
+        }
+        else if (isOverTrigger) {
+          handleRemoveGraceArea()
+        }
+        else if (isOverContent) {
+          // Keep the grace area so pointermove keeps firing while the cursor
+          // moves over the content, allowing us to detect when it later
+          // crosses over another trigger underneath.
         }
         else if (isPointerOutsideGraceArea || isAnotherGraceAreaTrigger) {
           handleRemoveGraceArea()


### PR DESCRIPTION
## Summary

Fixes #2598.

When a tooltip's content sits over another tooltip trigger (e.g., stacked triggers in a table or dense list), the existing grace-area logic removed the polygon and stopped tracking the moment the pointer entered the content. The tooltip then stayed open indefinitely and blocked access to the trigger beneath it.

`handleTrackPointerGrace` now uses `document.elementsFromPoint` to detect when the cursor over the content has another `[data-grace-area-trigger]` underneath; in that case it closes the current tooltip so the underlying trigger becomes accessible. When the cursor is over the content but no other trigger sits beneath, the grace area is preserved so subsequent pointer movement over the content continues to be tracked (instead of going dark after the first \"entered content\" event).

This also benefits `HoverCard`, which shares the same composable.

## Test plan

- [x] New unit tests in `packages/core/src/shared/useGraceArea.test.ts` cover:
  - Pointer entering content with another grace-area-trigger underneath ⇒ exit fires.
  - Pointer entering content with nothing underneath ⇒ exit does NOT fire (regression guard).
  - Pointer landing on a \"safe\" area of the content first, then moving over a grace-area-trigger underneath ⇒ exit fires (continuous tracking).
- [x] Existing `Tooltip` and `HoverCard` tests still pass.
- [x] Full suite: 1636 tests pass.
- [ ] Manual verification using the reproduction in #2598 (stacked buttons in a table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pointer exit detection for grace area overlays, ensuring correct behavior when content overlaps multiple triggers.

* **Tests**
  * Added comprehensive test suite for grace area pointer tracking functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->