### PR TITLE
fix(DatePicker): align modelValue prop type with sibling pickers

### DIFF
--- a/packages/core/src/Calendar/CalendarRoot.vue
+++ b/packages/core/src/Calendar/CalendarRoot.vue
@@ -98,7 +98,7 @@ export interface CalendarRootProps extends PrimitiveProps {
   /** A function that returns the previous page of the calendar. It receives the current placeholder as an argument inside the component. */
   prevPage?: (placeholder: DateValue) => DateValue
   /** The controlled selected date value of the calendar. Can be bound as `v-model`. */
-  modelValue?: DateValue | DateValue[] | undefined
+  modelValue?: DateValue | DateValue[] | null
   /** Whether multiple dates can be selected */
   multiple?: boolean
   /** Whether or not to disable days outside the current view. */

--- a/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
+++ b/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
@@ -84,7 +84,7 @@ export interface DateRangeFieldRootProps extends PrimitiveProps, FormFieldProps 
 
 export type DateRangeFieldRootEmits = {
   /** Event handler called whenever the model value changes */
-  'update:modelValue': [DateRange]
+  'update:modelValue': [date: DateRange]
   /** Event handler called whenever the placeholder value changes */
   'update:placeholder': [date: DateValue]
 }

--- a/packages/core/src/MonthPicker/MonthPicker.test.ts
+++ b/packages/core/src/MonthPicker/MonthPicker.test.ts
@@ -97,6 +97,20 @@ describe('month picker', async () => {
     expect(getByTestId('heading')).toHaveTextContent('1980')
   })
 
+  it('does not crash when modelValue is null', async () => {
+    const { picker, rerender } = setup({ pickerProps: { modelValue: null } })
+
+    expect(getSelectedMonths(picker)).toHaveLength(0)
+
+    await rerender({
+      pickerProps: {
+        modelValue: calendarDate,
+      },
+    })
+
+    expect(getSelectedMonth(picker)).toHaveTextContent('Jan')
+  })
+
   it('navigates to next year using next button', async () => {
     const { getByTestId, user } = setup({ pickerProps: { modelValue: calendarDate } })
 

--- a/packages/core/src/MonthPicker/MonthPickerRoot.vue
+++ b/packages/core/src/MonthPicker/MonthPickerRoot.vue
@@ -74,7 +74,7 @@ export interface MonthPickerRootProps extends PrimitiveProps {
   /** A function that returns the previous page of the month picker. Receives the current placeholder as an argument. */
   prevPage?: (placeholder: DateValue) => DateValue
   /** The controlled selected month value of the month picker. Can be bound as `v-model`. */
-  modelValue?: DateValue | DateValue[] | undefined
+  modelValue?: DateValue | DateValue[] | null
   /** Whether multiple months can be selected */
   multiple?: boolean
 }

--- a/packages/core/src/YearPicker/YearPicker.test.ts
+++ b/packages/core/src/YearPicker/YearPicker.test.ts
@@ -54,6 +54,20 @@ describe('year picker', async () => {
     expect(getByTestId('heading')).toHaveTextContent('1980 - 1991')
   })
 
+  it('does not crash when modelValue is null', async () => {
+    const { picker, rerender } = setup({ pickerProps: { modelValue: null } })
+
+    expect(getSelectedYears(picker)).toHaveLength(0)
+
+    await rerender({
+      pickerProps: {
+        modelValue: calendarDate,
+      },
+    })
+
+    expect(getSelectedYear(picker)).toHaveTextContent('1980')
+  })
+
   it('navigates to next decade using next button', async () => {
     const { getByTestId, user } = setup({ pickerProps: { modelValue: calendarDate } })
 

--- a/packages/core/src/YearPicker/YearPickerRoot.vue
+++ b/packages/core/src/YearPicker/YearPickerRoot.vue
@@ -75,7 +75,7 @@ export interface YearPickerRootProps extends PrimitiveProps {
   /** A function that returns the previous page of the year picker. Receives the current placeholder as an argument. */
   prevPage?: (placeholder: DateValue) => DateValue
   /** The controlled selected year value of the year picker. Can be bound as `v-model`. */
-  modelValue?: DateValue | DateValue[] | undefined
+  modelValue?: DateValue | DateValue[] | null
   /** Whether multiple years can be selected */
   multiple?: boolean
   /** Number of years to display per page */


### PR DESCRIPTION
## Summary
Closes #2600.

`Calendar`, `MonthPicker`, and `YearPicker` accepted `DateValue | DateValue[] | undefined` for `modelValue`, while `DatePicker`, `RangeCalendar`, and the range pickers also accepted `null`. This inconsistency surfaces in user code when binding form state that uses `null` as the empty value.

Add `| null` to the single/multi-select picker `modelValue` types so all date picker components accept `T | null | undefined` consistently. The runtime already tolerates `null` (existing `isNullish` and falsy checks), so this is a non-breaking type widening.

The range emit types remain `[date: DateRange]` — `DateRange` itself represents the cleared state via `{ start: undefined, end: undefined }`, so the existing type already covers it.

### Changes
- `CalendarRoot`, `MonthPickerRoot`, `YearPickerRoot`: `modelValue` now `DateValue | DateValue[] | null` (effectively `... | null | undefined` via `?`)
- `DateRangeFieldRoot`: rename tuple element to `[date: DateRange]` for consistency with sibling emits
- Add `does not crash when modelValue is null` tests for `MonthPicker` and `YearPicker` mirroring the existing `MonthRangePicker` / `YearRangePicker` / `RangeCalendar` tests

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test --run` — 1635 tests pass
- [x] New `modelValue: null` tests added for MonthPicker & YearPicker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage validating that Calendar, MonthPicker, and YearPicker components properly handle `null` model values without crashes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->