### PR TITLE
fix(Combobox): defer handleBlur close to let FocusScope restore focus

### DIFF
--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -306,23 +306,44 @@ describe('given a Combobox with openOnFocus', () => {
   })
 
   it('should close content when focus moves to an element outside', async () => {
-    // Add an external focusable element
     const externalButton = document.createElement('button')
     externalButton.textContent = 'External'
     document.body.appendChild(externalButton)
 
     const input = wrapper.find('input')
 
-    // Focus input to open via openOnFocus
-    await input.trigger('focus')
+    input.element.focus()
     await nextTick()
     expect(wrapper.find('[role=group]').exists()).toBe(true)
 
-    // Simulate blur with relatedTarget pointing to external element
-    await input.trigger('blur', { relatedTarget: externalButton })
+    externalButton.focus()
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
     await nextTick()
 
     expect(wrapper.find('[role=group]').exists()).toBe(false)
+
+    externalButton.remove()
+  })
+
+  it('should not close when focus is restored inside before deferred close fires', async () => {
+    const externalButton = document.createElement('button')
+    externalButton.textContent = 'External'
+    document.body.appendChild(externalButton)
+
+    const input = wrapper.find('input')
+
+    input.element.focus()
+    await nextTick()
+    expect(wrapper.find('[role=group]').exists()).toBe(true)
+
+    // Synthetic blur: fires handleBlur with relatedTarget outside,
+    // but doesn't change document.activeElement — simulates FocusScope
+    // restoring focus back inside before the deferred close callback runs
+    await input.trigger('blur', { relatedTarget: externalButton })
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+    await nextTick()
+
+    expect(wrapper.find('[role=group]').exists()).toBe(true)
 
     externalButton.remove()
   })
@@ -456,5 +477,68 @@ describe('given Combobox with TagsInput and addOnBlur', () => {
 
     // Input should be refocused so subsequent blur can trigger addOnBlur
     expect(document.activeElement).toBe(input.element)
+  })
+})
+
+describe('given combobox handleBlur with deferred close', () => {
+  let wrapper: VueWrapper<InstanceType<typeof Combobox>>
+
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn()
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn()
+  window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(Combobox, { attachTo: document.body, props: { resetSearchTermOnBlur: true } })
+  })
+
+  it('should not close when focus is restored inside before deferred close fires', async () => {
+    const externalButton = document.createElement('button')
+    externalButton.textContent = 'External'
+    document.body.appendChild(externalButton)
+
+    // Open combobox
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+    expect(wrapper.find('[role=group]').exists()).toBe(true)
+
+    const input = wrapper.find('input')
+    input.element.focus()
+
+    // Synthetic blur: fires handleBlur with relatedTarget outside,
+    // but doesn't change document.activeElement — simulates FocusScope
+    // restoring focus back inside before the deferred close callback runs
+    await input.trigger('blur', { relatedTarget: externalButton })
+
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+    await nextTick()
+
+    expect(wrapper.find('[role=group]').exists()).toBe(true)
+
+    externalButton.remove()
+  })
+
+  it('should close when focus stays outside after rAF', async () => {
+    const externalButton = document.createElement('button')
+    externalButton.textContent = 'External'
+    document.body.appendChild(externalButton)
+
+    // Open combobox
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+    expect(wrapper.find('[role=group]').exists()).toBe(true)
+
+    const input = wrapper.find('input')
+    input.element.focus()
+
+    // Focus moves outside and stays there
+    externalButton.focus()
+
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+    await nextTick()
+
+    expect(wrapper.find('[role=group]').exists()).toBe(false)
+
+    externalButton.remove()
   })
 })

--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -74,7 +74,19 @@ function handleBlur(ev: FocusEvent) {
   const isInsideContent = document.getElementById(rootContext.contentId)?.contains(nextFocus)
 
   if (!isInsideRoot && !isInsideContent) {
-    rootContext.onOpenChange(false)
+    // Delay to let FocusScope's focus-restoration (handleFocusOut) run first.
+    // Without this, closing fires before FocusScope can pull focus back inside,
+    // causing a second combobox to immediately close when switching between two.
+    requestAnimationFrame(() => {
+      if (!rootContext.open.value)
+        return
+      const active = document.activeElement
+      const isStillOutside = !rootContext.parentElement.value?.contains(active)
+        && !document.getElementById(rootContext.contentId)?.contains(active)
+      if (isStillOutside) {
+        rootContext.onOpenChange(false)
+      }
+    })
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves nuxt/ui#6437, resolves nuxt/ui#6511

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

When two `ComboboxRoot` instances are on the same page and the first is open, clicking the second's trigger causes it to open briefly then immediately close. This only happens with a quick click (short pointerdown→pointerup). Holding the mouse for ~200ms before releasing works fine.

**Regression introduced in v2.9.3** (commit 9102386 — `FocusScope.handleMutations` null-guard removed an incidental focus-protection that previously masked this race condition).

**Root cause:** `ComboboxInput.handleBlur` fires before `FocusScope`'s `handleFocusOut` (document `focusout` listener) has a chance to restore focus inside the scope. Since `blur` fires before `focusout` in DOM event order, `handleBlur` sees focus outside and synchronousl combobox, unmounting the `FocusScope` before it can act.

**Fix:** wrap `handleBlur`'s close logic in a `requestAnimationFrame` that re-checks `document.activeElement` after giving `FocusScope`'s focus-restoration mechanism a chance to run. If focus ends up back inside the combobox root or content, the close is skipped.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed premature closing of the combobox popup during rapid focus transitions. The popup now correctly waits to confirm focus has definitively left the component before closing, improving behavior when switching quickly between comboboxes or when focus is managed by external tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->