### PR TITLE
fix(NavigationMenu): behavior should match radix ui navigation menu w…

### DIFF
--- a/packages/core/src/NavigationMenu/NavigationMenu.test.ts
+++ b/packages/core/src/NavigationMenu/NavigationMenu.test.ts
@@ -137,6 +137,11 @@ describe('given default NavigationMenu', () => {
 
     const findLinkContent = () => wrapper.find('[data-dismissable-layer]')
 
+    async function useRealDebounceFn() {
+      const { useDebounceFn: realUseDebounceFn } = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core')
+      vi.mocked(useDebounceFn).mockImplementation(realUseDebounceFn)
+    }
+
     it('should open menu on click by default', async () => {
       const button = findTriggerButton()
 
@@ -209,6 +214,59 @@ describe('given default NavigationMenu', () => {
 
       // Menu should be closed
       expect(findLinkContent().exists()).toBeFalsy()
+    })
+
+    it('switching triggers keeps menu open', async () => {
+      vi.useFakeTimers()
+      await useRealDebounceFn()
+
+      const localWrapper = mount(NavigationMenu, { attachTo: document.body })
+      const triggers = localWrapper.findAll('[data-navigation-menu-trigger]')
+      const findContent = () => localWrapper.find('[data-dismissable-layer]')
+
+      await triggers[0].trigger('pointermove', { pointerType: 'mouse' })
+      await vi.advanceTimersByTimeAsync(200)
+      await nextTick()
+
+      expect(findContent().exists()).toBe(true)
+
+      await triggers[0].trigger('pointerleave', { pointerType: 'mouse' })
+      await triggers[1].trigger('pointermove', { pointerType: 'mouse' })
+      await nextTick()
+
+      expect(triggers[1].attributes('data-state')).toBe('open')
+      expect(findContent().exists()).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(150)
+      await nextTick()
+
+      expect(findContent().exists()).toBe(true)
+
+      localWrapper.unmount()
+      vi.useRealTimers()
+    })
+
+    it('leaving content closes menu', async () => {
+      vi.useFakeTimers()
+      await useRealDebounceFn()
+
+      const localWrapper = mount(NavigationMenu, { attachTo: document.body })
+      const findContent = () => localWrapper.find('[data-dismissable-layer]')
+
+      await localWrapper.find('[data-navigation-menu-trigger]').trigger('pointermove', { pointerType: 'mouse' })
+      await vi.advanceTimersByTimeAsync(200)
+      await nextTick()
+
+      expect(findContent().exists()).toBe(true)
+
+      await findContent().trigger('pointerleave', { pointerType: 'mouse' })
+      await vi.advanceTimersByTimeAsync(150)
+      await nextTick()
+
+      expect(findContent().exists()).toBe(false)
+
+      localWrapper.unmount()
+      vi.useRealTimers()
     })
   })
 })

--- a/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
@@ -212,8 +212,10 @@ provideNavigationMenuContext({
     debouncedFn()
   },
   onContentLeave: () => {
-    if (!props.disablePointerLeaveClose)
+    if (!props.disablePointerLeaveClose) {
+      skipNextClose.value = false
       debouncedFn('')
+    }
   },
   onItemSelect: (val) => {
     // When selecting item we trigger update immediately

--- a/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
@@ -149,14 +149,15 @@ const computedDelay = computed(() => {
 })
 
 const debouncedFn = useDebounceFn((val?: string) => {
-  if (typeof val === "string") {
-    if (val === "" && skipNextClose.value) {
+  if (typeof val === 'string') {
+    if (val === '' && skipNextClose.value) {
       skipNextClose.value = false
       return
     }
     previousValue.value = modelValue.value
     modelValue.value = val
-    if (val === "") isDelaySkipped.value = true
+    if (val === '')
+      isDelaySkipped.value = true
   }
 }, computedDelay)
 
@@ -193,11 +194,12 @@ provideNavigationMenuContext({
     viewport.value = val
   },
   onTriggerEnter: (val) => {
-    if (modelValue.value !== "") {
+    if (modelValue.value !== '') {
       skipNextClose.value = true
       previousValue.value = modelValue.value
       modelValue.value = val
-    } else {
+    }
+    else {
       debouncedFn(val)
     }
   },

--- a/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
@@ -149,6 +149,7 @@ const computedDelay = computed(() => {
 })
 
 const debouncedFn = useDebounceFn((val?: string) => {
+  // passing `undefined` meant to reset the debounce timer
   if (typeof val === 'string') {
     if (val === '' && skipNextClose.value) {
       skipNextClose.value = false

--- a/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
@@ -140,6 +140,7 @@ const { delayDuration, skipDelayDuration, dir: propDir, disableClickTrigger, dis
 const dir = useDirection(propDir)
 
 const isDelaySkipped = refAutoReset(false, skipDelayDuration)
+const skipNextClose = ref(false)
 const computedDelay = computed(() => {
   const isOpen = modelValue.value !== ''
   if (isOpen || isDelaySkipped.value)
@@ -148,10 +149,14 @@ const computedDelay = computed(() => {
 })
 
 const debouncedFn = useDebounceFn((val?: string) => {
-  // passing `undefined` meant to reset the debounce timer
-  if (typeof val === 'string') {
+  if (typeof val === "string") {
+    if (val === "" && skipNextClose.value) {
+      skipNextClose.value = false
+      return
+    }
     previousValue.value = modelValue.value
     modelValue.value = val
+    if (val === "") isDelaySkipped.value = true
   }
 }, computedDelay)
 
@@ -188,10 +193,16 @@ provideNavigationMenuContext({
     viewport.value = val
   },
   onTriggerEnter: (val) => {
-    debouncedFn(val)
+    if (modelValue.value !== "") {
+      skipNextClose.value = true
+      previousValue.value = modelValue.value
+      modelValue.value = val
+    } else {
+      debouncedFn(val)
+    }
   },
   onTriggerLeave: () => {
-    isDelaySkipped.value = true
+    skipNextClose.value = false
     debouncedFn('')
   },
   onContentEnter: () => {


### PR DESCRIPTION
…hen entering another trigger while menu is open

<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In Radix UI, when entering a new trigger while the viewport is visible, there is no delay. In Reka UI, there is quite a visible delay which is especially apparent when going back and forth between triggers rapidly due to a hardcoded 150ms value.

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental/flicker closes when switching between open navigation triggers so menus remain open and responsive while moving between items.
  * Improved timing so opening or switching menu items updates immediately while still honoring intended close delays when leaving content.

* **Tests**
  * Added timer-based tests to ensure debounce and close behavior are reliable in real scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->