### PR TITLE
fix(Dialog): scope overlay pointerdown prevention to the overlay itself

### DIFF
--- a/packages/core/src/Dialog/Dialog.test.ts
+++ b/packages/core/src/Dialog/Dialog.test.ts
@@ -1,6 +1,6 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import type { Mock, SpyInstance } from 'vitest'
-import { findByText, fireEvent, render } from '@testing-library/vue'
+import { createEvent, findByText, fireEvent, render } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
@@ -47,6 +47,23 @@ const DialogTest = defineComponent({
     <DialogTitle>${TITLE_TEXT}</DialogTitle>
     <DialogClose>${CLOSE_TEXT}</DialogClose>
   </DialogContent>
+</DialogRoot>`,
+})
+
+// Reproduces https://github.com/unovue/reka-ui/issues/2660 — the content is
+// nested *inside* the overlay (a common centering pattern), so pointerdown
+// events from controls in the content bubble up to the overlay.
+const NestedContentDialogTest = defineComponent({
+  components: { DialogRoot, DialogTrigger, DialogOverlay, DialogContent, DialogClose, DialogTitle },
+  template: `<DialogRoot>
+  <DialogTrigger>${OPEN_TEXT}</DialogTrigger>
+  <DialogOverlay>
+    <DialogContent>
+      <DialogTitle>${TITLE_TEXT}</DialogTitle>
+      <input data-testid="text-input" type="text">
+      <DialogClose>${CLOSE_TEXT}</DialogClose>
+    </DialogContent>
+  </DialogOverlay>
 </DialogRoot>`,
 })
 
@@ -159,6 +176,48 @@ describe('given a default Dialog', () => {
       it('should focus trigger', () => {
         expect(document.activeElement).toBe(trigger.element)
       })
+    })
+  })
+})
+
+// Regression test for https://github.com/unovue/reka-ui/issues/2660
+// The overlay calls `preventDefault()` on its own `pointerdown` to keep focus
+// on the trigger after the dialog closes (#2655). When the content is nested
+// inside the overlay, that handler must NOT prevent the default action of
+// pointerdown events bubbling up from controls inside the content — otherwise
+// native `<select>`/`<input>` interactions break.
+describe('given a Dialog with content nested inside the overlay', () => {
+  let wrapper: VueWrapper<InstanceType<typeof NestedContentDialogTest>>
+  let consoleWarnMock: SpyInstance
+
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    wrapper = mount(NestedContentDialogTest, { attachTo: document.body })
+    consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    fireEvent.click(wrapper.find('button').element)
+    await findByText(document.body, CLOSE_TEXT)
+  })
+
+  afterEach(() => {
+    consoleWarnMock.mockRestore()
+  })
+
+  describe('when pressing down on a control inside the content', () => {
+    it('should not prevent the default pointerdown action', async () => {
+      const input = document.querySelector<HTMLInputElement>('[data-testid="text-input"]')!
+      const event = createEvent.pointerDown(input, { button: 0 })
+      input.dispatchEvent(event)
+      await nextTick()
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('should keep the dialog open', async () => {
+      const input = document.querySelector<HTMLInputElement>('[data-testid="text-input"]')!
+      await fireEvent.pointerDown(input, { button: 0 })
+      await nextTick()
+
+      expect(document.body.innerHTML).toContain(CLOSE_TEXT)
     })
   })
 })

--- a/packages/core/src/Dialog/DialogOverlayImpl.vue
+++ b/packages/core/src/Dialog/DialogOverlayImpl.vue
@@ -23,7 +23,7 @@ useForwardExpose()
     :as-child="asChild"
     :data-state="rootContext.open.value ? 'open' : 'closed'"
     style="pointer-events: auto"
-    @pointerdown.left.prevent
+    @pointerdown.left.self.prevent
   >
     <slot />
   </Primitive>


### PR DESCRIPTION
## Summary

Fixes #2660 — a regression introduced in **2.9.8** where native `<select>` dropdowns won't open and `<input>`/`<textarea>` won't focus when clicked inside a `<Dialog>`.

## Root cause

#2655 (`fix(Dialog): restore focus to trigger after overlay click`) added `@pointerdown.left.prevent` to `DialogOverlayImpl` so that clicking the overlay backdrop keeps focus on the trigger after the dialog closes (by skipping the browser's compatibility `mousedown`).

When `DialogContent` is nested inside `DialogOverlay` — a very common centering pattern, and what the reporter's reproduction uses — `pointerdown` events bubble up from controls inside the content to the overlay. The overlay's listener then called `preventDefault()` on them too, which suppresses native behaviors:

- native `<select>` dropdowns don't open
- `<input>` / `<textarea>` don't focus on click

## Fix

Add the `.self` modifier: `@pointerdown.left.self.prevent`. The prevention now only applies when the pointer lands **directly on the overlay backdrop** (`event.target === overlay`), not on descendants. This preserves the #2655 behavior while leaving in-content interactions untouched.

## Tests

Added a regression block in `Dialog.test.ts` using a dialog whose content is nested inside the overlay (reproducing the exact structure):

- asserts a `pointerdown` on a control inside the content is **not** `defaultPrevented`
- asserts the dialog stays open when pressing down on a control inside the content

Verified these tests **fail** on the old `@pointerdown.left.prevent` and **pass** with the `.self` fix. The existing overlay-click tests from #2655 still pass (they dispatch on the overlay directly). Full `reka-ui` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dialog overlay pointer event handling to properly support interactive controls nested inside dialog content, ensuring they function correctly without event interference from the overlay.

* **Tests**
  * Added regression tests to verify dialog behavior with nested interactive elements, confirming proper pointer event handling and that the dialog remains fully functional and accessible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->