### PR TITLE
fix(ScrollArea): clear scrollbar registration on unmount so corner stays in sync

### DIFF
--- a/packages/core/src/ScrollArea/ScrollArea.test.ts
+++ b/packages/core/src/ScrollArea/ScrollArea.test.ts
@@ -1,8 +1,14 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { defineComponent, h } from 'vue'
 import { sleep } from '@/test'
+import ScrollAreaCorner from './ScrollAreaCorner.vue'
+import ScrollAreaRoot from './ScrollAreaRoot.vue'
+import ScrollAreaScrollbar from './ScrollAreaScrollbar.vue'
+import ScrollAreaThumb from './ScrollAreaThumb.vue'
+import ScrollAreaViewport from './ScrollAreaViewport.vue'
 import ScrollArea from './story/_ScrollArea.vue'
 
 describe('given default ScrollArea', () => {
@@ -90,5 +96,75 @@ describe('given prop:type="scroll" ScrollArea', () => {
       expect(wrapper.html()).toContain('data-orientation="vertical"')
       expect(wrapper.html()).toMatchSnapshot()
     })
+  })
+})
+
+describe('given prop:type="hover" ScrollArea with both scrollbars and a corner', () => {
+  // ScrollAreaCornerImpl sizes itself from a ResizeObserver bound to the
+  // scrollbar elements. jsdom has no ResizeObserver, so provide a minimal mock
+  // that fires its callback immediately on observe (matching a browser's
+  // initial dispatch) so the corner can compute its size and render.
+  let originalResizeObserver: typeof globalThis.ResizeObserver
+
+  const BothScrollArea = defineComponent({
+    props: ['type'],
+    setup(props) {
+      return () =>
+        h(ScrollAreaRoot, { type: props.type, style: 'width: 200px; height: 200px; overflow: hidden;' }, () => [
+          h(ScrollAreaViewport, { style: 'width: 100%; height: 100%;' }, () =>
+            h('div', { style: 'width: 1000px; height: 1000px;' })),
+          h(ScrollAreaScrollbar, { orientation: 'vertical' }, () => h(ScrollAreaThumb)),
+          h(ScrollAreaScrollbar, { orientation: 'horizontal' }, () => h(ScrollAreaThumb)),
+          h(ScrollAreaCorner, null, () => h('span', { 'data-testid': 'corner-content' })),
+        ])
+    },
+  })
+
+  let wrapper: VueWrapper<InstanceType<typeof BothScrollArea>>
+
+  beforeEach(() => {
+    originalResizeObserver = globalThis.ResizeObserver
+    globalThis.ResizeObserver = class {
+      private cb: ResizeObserverCallback
+      constructor(cb: ResizeObserverCallback) {
+        this.cb = cb
+      }
+
+      observe(target: Element) {
+        this.cb([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
+      }
+
+      unobserve() {}
+      disconnect() {}
+    }
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 10 })
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 10 })
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, value: 2000 })
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, value: 2000 })
+
+    wrapper = mount(BothScrollArea, { attachTo: document.body, props: { type: 'hover' } })
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver
+    wrapper?.unmount()
+  })
+
+  it('keeps the corner in sync with the scrollbars across repeated hover cycles', async () => {
+    // 1st cycle: enter -> corner appears
+    await wrapper.trigger('pointerenter')
+    await sleep(100)
+    expect(wrapper.find('[data-testid="corner-content"]').exists()).toBe(true)
+
+    // leave -> scrollbars hide and the corner is removed alongside them
+    await wrapper.trigger('pointerleave')
+    await sleep(700)
+    expect(wrapper.find('[data-testid="corner-content"]').exists()).toBe(false)
+
+    // 2nd cycle: enter again -> corner must re-appear (regression #2669)
+    await wrapper.trigger('pointerenter')
+    await sleep(100)
+    expect(wrapper.find('[data-testid="corner-content"]').exists()).toBe(true)
   })
 })

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbarX.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbarX.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import { useForwardExpose } from '@/shared'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import ScrollAreaScrollbarImpl from './ScrollAreaScrollbarImpl.vue'
@@ -14,6 +14,11 @@ const { forwardRef, currentElement: scrollbarElement } = useForwardExpose()
 onMounted(() => {
   if (scrollbarElement.value)
     rootContext.onScrollbarXChange(scrollbarElement.value)
+})
+// Clear the registration on unmount so consumers (e.g. ScrollAreaCorner) don't
+// hold a stale reference once the scrollbar is removed (e.g. between hover cycles).
+onUnmounted(() => {
+  rootContext.onScrollbarXChange(null)
 })
 const sizes = computed(() => scrollbarVisibleContext.sizes.value)
 </script>

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbarY.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbarY.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import { useForwardExpose } from '@/shared'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import ScrollAreaScrollbarImpl from './ScrollAreaScrollbarImpl.vue'
@@ -14,6 +14,11 @@ const { forwardRef, currentElement: scrollbarElement } = useForwardExpose()
 onMounted(() => {
   if (scrollbarElement.value)
     rootContext.onScrollbarYChange(scrollbarElement.value)
+})
+// Clear the registration on unmount so consumers (e.g. ScrollAreaCorner) don't
+// hold a stale reference once the scrollbar is removed (e.g. between hover cycles).
+onUnmounted(() => {
+  rootContext.onScrollbarYChange(null)
 })
 
 const sizes = computed(() => scrollbarVisibleContext.sizes.value)


### PR DESCRIPTION
Fixes #2669

## Problem

With `type="hover"` and **both** scrollbars enabled, the `ScrollAreaCorner` syncs correctly on the first hover cycle but permanently disappears from the second cycle onward.

## Root cause

`ScrollAreaScrollbarX`/`Y` register their element into the root context on mount but **never clear it on unmount**:

```js
onMounted(() => {
  if (scrollbarElement.value)
    rootContext.onScrollbarXChange(scrollbarElement.value)
})
```

Radix's React original does this via a ref-callback, which fires with the node on mount **and `null` on unmount**. The Vue port dropped the unmount half.

Since hover mounts/unmounts the scrollbars each cycle, `scrollbarX`/`scrollbarY` stayed truthy after the first leave, so the corner's condition `!!scrollbarX.value && !!scrollbarY.value` never went false and `ScrollAreaCornerImpl` never unmounted. Its `ResizeObserver` is bound to the scrollbar element captured once at setup, so on the second hover the corner pointed at a now-detached element and failed to re-render — the "stuck at false on cycle 2" reported in the issue.

## Fix

Add `onUnmounted` cleanup in both scrollbars to reset the registration, mirroring the React ref-callback semantics. The corner now unmounts with the scrollbars on leave and re-mounts fresh (re-binding its observer to the live element) on each enter.

## Tests

Added a regression test in `ScrollArea.test.ts` that drives two hover cycles on a both-scrollbars + corner setup. It fails before the fix (corner stuck mounted after leave) and passes after. Full core suite passes (1642 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where the scrollbar corner would not properly re-appear during repeated hover interactions with multiple scrollbars.
  * Improved cleanup of scrollbar references when components unmount to prevent stale states.

* **Tests**
  * Added regression test for ScrollArea with multiple scrollbars during hover cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/reka-ui/pull/2670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->