### PR TITLE
feat(Toast): allow action without dismissing toast

### DIFF
--- a/docs/content/docs/components/toast.md
+++ b/docs/content/docs/components/toast.md
@@ -339,16 +339,14 @@ When providing an icon (or font icon), remember to label it correctly for screen
       keys: ['Space'],
       description: `
         <span>
-          When focus is on a <Code>ToastAction</Code> or
-          <Code>ToastClose</Code>, closes the toast
+          When focus is on a <Code>ToastAction</Code>, closes the toast when <Code>closeOnClick</Code> is <Code>true</Code>. When focus is on <Code>ToastClose</Code>, closes the toast.
         </span>`
     },
     {
       keys: ['Enter'],
       description: `
         <span>
-          When focus is on a <Code>ToastAction</Code> or
-          <Code>ToastClose</Code>, closes the toast
+          When focus is on a <Code>ToastAction</Code>, closes the toast when <Code>closeOnClick</Code> is <Code>true</Code>. When focus is on <Code>ToastClose</Code>, closes the toast.
         </span>`
     },
     {

--- a/docs/content/docs/components/toast.md
+++ b/docs/content/docs/components/toast.md
@@ -139,6 +139,20 @@ An action that is safe to ignore to ensure users are not expected to complete ta
 
 When obtaining a user response is necessary, portal an ["AlertDialog"](/docs/components/alert-dialog) styled as a toast into the viewport instead.
 
+By default, clicking `ToastAction` dismisses the toast. Set `closeOnClick` to `false` when the action should run while keeping the toast visible.
+
+```vue
+<template>
+  <ToastAction
+    alt-text="Retry sending the message"
+    :close-on-click="false"
+    @click="retry"
+  >
+    Retry
+  </ToastAction>
+</template>
+```
+
 <!-- @include: @/meta/ToastAction.md -->
 
 ### Close

--- a/docs/content/meta/ToastAction.md
+++ b/docs/content/meta/ToastAction.md
@@ -13,13 +13,20 @@
     'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
     'type': 'AsTag | Component',
     'required': false,
-    'default': '\'div\''
+    'default': '\'button\''
   },
   {
     'name': 'asChild',
     'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
     'type': 'boolean',
     'required': false
+  },
+  {
+    'name': 'closeOnClick',
+    'description': '<p>Whether the action should close the toast when clicked.</p>\n',
+    'type': 'boolean',
+    'required': false,
+    'default': 'true'
   }
 ]" />
 </llm-exclude>
@@ -31,7 +38,8 @@
 | Name | Description | Type | Required | Default |
 | --- | --- | --- | --- | --- |
 | `altText` | A short description for an alternate way to carry out the action. For screen reader users who will not be able to navigate to the button easily/quickly. | `string` | Yes | - |
-| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"button"` |
 | `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+| `closeOnClick` | Whether the action should close the toast when clicked. | `boolean` | No | `true` |
 
 </llm-only>

--- a/packages/core/src/Toast/Toast.test.ts
+++ b/packages/core/src/Toast/Toast.test.ts
@@ -3,10 +3,47 @@ import { findByText, fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
-import { nextTick } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { ToastAction, ToastDescription, ToastProvider, ToastRoot, ToastViewport } from '.'
 import Toast from './story/_Toast.vue'
 
 const CLOSE_TEXT = 'Close'
+
+const ToastWithPersistentAction = defineComponent({
+  setup() {
+    const open = ref(true)
+    const actionClicks = ref(0)
+
+    return {
+      open,
+      actionClicks,
+    }
+  },
+  render() {
+    return h(ToastProvider, null, {
+      default: () => [
+        h(ToastRoot, {
+          'open': this.open,
+          'onUpdate:open': (value: boolean) => {
+            this.open = value
+          },
+        }, {
+          default: () => [
+            h(ToastDescription, null, { default: () => 'Action available' }),
+            h(ToastAction, {
+              altText: 'Keep toast open after action',
+              closeOnClick: false,
+              onClick: () => {
+                this.actionClicks += 1
+              },
+            }, { default: () => 'Undo' }),
+          ],
+        }),
+        h(ToastViewport),
+      ],
+    })
+  },
+})
 
 describe('given a default Toast', () => {
   let wrapper: VueWrapper<InstanceType<typeof Toast>>
@@ -64,6 +101,17 @@ describe('given a default Toast', () => {
     // The toast title and description must both be part of the announced
     // text so screen-reader users actually hear the toast.
     expect(text).toContain('Scheduled: Catch up')
+  })
+
+  it('should keep the toast open when action closeOnClick is false', async () => {
+    const wrapper = mount(ToastWithPersistentAction, { attachTo: document.body })
+
+    const action = await findByText(document.body, 'Undo')
+    await fireEvent.click(action)
+
+    expect(wrapper.vm.actionClicks).toBe(1)
+    expect(wrapper.vm.open).toBe(true)
+    expect(document.body.innerHTML).toContain('Action available')
   })
 
   describe('after clicking the trigger', () => {

--- a/packages/core/src/Toast/Toast.test.ts
+++ b/packages/core/src/Toast/Toast.test.ts
@@ -9,7 +9,13 @@ import Toast from './story/_Toast.vue'
 
 const CLOSE_TEXT = 'Close'
 
-const ToastWithPersistentAction = defineComponent({
+const ToastWithAction = defineComponent({
+  props: {
+    closeOnClick: {
+      type: Boolean,
+      default: undefined,
+    },
+  },
   setup() {
     const open = ref(true)
     const actionClicks = ref(0)
@@ -31,8 +37,8 @@ const ToastWithPersistentAction = defineComponent({
           default: () => [
             h(ToastDescription, null, { default: () => 'Action available' }),
             h(ToastAction, {
-              altText: 'Keep toast open after action',
-              closeOnClick: false,
+              altText: 'Perform action',
+              closeOnClick: this.closeOnClick,
               onClick: () => {
                 this.actionClicks += 1
               },
@@ -103,8 +109,22 @@ describe('given a default Toast', () => {
     expect(text).toContain('Scheduled: Catch up')
   })
 
+  it('should close the toast when action is clicked by default', async () => {
+    const wrapper = mount(ToastWithAction, { attachTo: document.body })
+
+    const action = await findByText(document.body, 'Undo')
+    await fireEvent.click(action)
+
+    expect(wrapper.vm.actionClicks).toBe(1)
+    expect(wrapper.vm.open).toBe(false)
+    expect(action.closest('li')?.getAttribute('data-state')).toBe('closed')
+  })
+
   it('should keep the toast open when action closeOnClick is false', async () => {
-    const wrapper = mount(ToastWithPersistentAction, { attachTo: document.body })
+    const wrapper = mount(ToastWithAction, {
+      attachTo: document.body,
+      props: { closeOnClick: false },
+    })
 
     const action = await findByText(document.body, 'Undo')
     await fireEvent.click(action)

--- a/packages/core/src/Toast/ToastAction.vue
+++ b/packages/core/src/Toast/ToastAction.vue
@@ -22,7 +22,7 @@ export interface ToastActionProps extends ToastCloseProps {
 import { Primitive } from '@/Primitive'
 import { useForwardExpose } from '@/shared'
 import ToastAnnounceExclude from './ToastAnnounceExclude.vue'
-import ToastClose from './ToastClose.vue'
+import { injectToastRootContext } from './ToastRootImpl.vue'
 
 const props = withDefaults(defineProps<ToastActionProps>(), {
   as: 'button',
@@ -32,6 +32,7 @@ const props = withDefaults(defineProps<ToastActionProps>(), {
 if (!props.altText)
   throw new Error('Missing prop `altText` expected on `ToastAction`')
 
+const rootContext = injectToastRootContext()
 const { forwardRef } = useForwardExpose()
 </script>
 
@@ -41,21 +42,12 @@ const { forwardRef } = useForwardExpose()
     :alt-text="altText"
     as-child
   >
-    <ToastClose
-      v-if="closeOnClick"
-      :ref="forwardRef"
-      :as="as"
-      :as-child="asChild"
-    >
-      <slot />
-    </ToastClose>
-
     <Primitive
-      v-else
       :ref="forwardRef"
       :as="as"
       :as-child="asChild"
       :type="as === 'button' ? 'button' : undefined"
+      @click="closeOnClick ? rootContext.onClose() : undefined"
     >
       <slot />
     </Primitive>

--- a/packages/core/src/Toast/ToastAction.vue
+++ b/packages/core/src/Toast/ToastAction.vue
@@ -9,15 +9,25 @@ export interface ToastActionProps extends ToastCloseProps {
    * @example <ToastAction altText="Undo (Alt+U)">Undo</ToastAction>
    */
   altText: string
+  /**
+   * Whether the action should close the toast when clicked.
+   *
+   * @defaultValue true
+   */
+  closeOnClick?: boolean
 }
 </script>
 
 <script setup lang="ts">
+import { Primitive } from '@/Primitive'
 import { useForwardExpose } from '@/shared'
 import ToastAnnounceExclude from './ToastAnnounceExclude.vue'
 import ToastClose from './ToastClose.vue'
 
-const props = defineProps<ToastActionProps>()
+const props = withDefaults(defineProps<ToastActionProps>(), {
+  as: 'button',
+  closeOnClick: true,
+})
 
 if (!props.altText)
   throw new Error('Missing prop `altText` expected on `ToastAction`')
@@ -32,11 +42,22 @@ const { forwardRef } = useForwardExpose()
     as-child
   >
     <ToastClose
+      v-if="closeOnClick"
       :ref="forwardRef"
       :as="as"
       :as-child="asChild"
     >
       <slot />
     </ToastClose>
+
+    <Primitive
+      v-else
+      :ref="forwardRef"
+      :as="as"
+      :as-child="asChild"
+      :type="as === 'button' ? 'button' : undefined"
+    >
+      <slot />
+    </Primitive>
   </ToastAnnounceExclude>
 </template>


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Resolves #2626

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a `closeOnClick` prop to `ToastAction` so action buttons can run without always dismissing their toast. The default remains `true`, preserving the existing dismiss-on-click behavior.

This also documents the new prop and adds a regression test covering `closeOnClick: false` keeping the toast open after clicking the action.

### 📸 Screenshots (if appropriate)

N/A

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a closeOnClick prop for toast actions to control whether clicking an action dismisses the toast (default: true).

* **Changes**
  * Toast actions now render as buttons by default.

* **Documentation**
  * Updated Toast docs with a Vue example and clarified action dismissal and keyboard behavior.

* **Tests**
  * Added tests verifying clicks both dismiss and preserve the toast based on closeOnClick.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->