### PR TITLE
fix(Calendar): focus first day when no selected or today cell on initial focus

### DIFF
--- a/packages/core/src/Calendar/Calendar.test.ts
+++ b/packages/core/src/Calendar/Calendar.test.ts
@@ -6,6 +6,7 @@ import { render } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 import { useTestKbd } from '@/shared'
+import { handleCalendarInitialFocus } from '@/shared/date'
 import Calendar from './story/_Calendar.vue'
 import CalendarMultiple from './story/_CalendarMultiple.vue'
 
@@ -898,6 +899,19 @@ describe('calendar - edge cases', () => {
 
     await user.keyboard(kbd.ARROW_LEFT)
     expect(getByTestId('date-0-1-31')).toHaveFocus()
+  })
+
+  it('handles initial focus when no date is selected and today is out of view', async () => {
+    const { calendar, getByTestId } = setup({
+      calendarProps: { defaultPlaceholder: edgeCaseCalendarDate },
+    })
+
+    expect(calendar.querySelector('[data-selected]')).toBeNull()
+    expect(calendar.querySelector('[data-today]')).toBeNull()
+
+    handleCalendarInitialFocus(calendar)
+
+    expect(getByTestId('date-1-1')).toHaveFocus()
   })
 })
 

--- a/packages/core/src/shared/date/utils.ts
+++ b/packages/core/src/shared/date/utils.ts
@@ -62,7 +62,7 @@ export function handleCalendarInitialFocus(calendar: HTMLElement) {
   if (today)
     return today.focus()
 
-  const firstDay = calendar.querySelector<HTMLElement>('[data-reka-calendar-day]')
+  const firstDay = calendar.querySelector<HTMLElement>('[data-value]:not([data-outside-view]):not([data-disabled])')
   if (firstDay)
     return firstDay.focus()
 }


### PR DESCRIPTION
> **TL;DR** — Initial keyboard focus lands nowhere in every calendar/picker component when no date is selected and today is outside the visible month. Root cause: the focus fallback queries `[data-reka-calendar-day]`, an attribute no component renders. Fix points it at the existing cell marker. One-line change + regression test, non-breaking.

### 🔗 Linked issue

No issue was filed — I hit this while integrating `Calendar` in a downstream project. The root cause, reproduction and verification are all below, so this PR is self-contained; happy to open a tracking issue first if you'd prefer.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`handleCalendarInitialFocus` (`packages/core/src/shared/date/utils.ts`) resolves initial focus in three steps: selected day → today → first day. The third fallback queries for `[data-reka-calendar-day]`:

```ts
const firstDay = calendar.querySelector<HTMLElement>('[data-reka-calendar-day]')
```

**No component renders that attribute.** Day cells expose `data-reka-calendar-cell-trigger` (and the Month/Year picker variants expose their own `data-reka-*-cell-trigger`). A repo-wide grep finds `data-reka-calendar-day` referenced only on this one line and assigned nowhere — so the fallback always matches `null`.

**Impact:** when neither a selected day nor today exists in the visible view, initial focus lands nowhere. The simplest reproduction is an unselected calendar whose displayed month does not contain today (e.g. opened on a past month). This affects every consumer of `handleCalendarInitialFocus`: `CalendarRoot`, `RangeCalendarRoot`, `DatePicker`, `DateRangePicker`, `MonthPicker`, `YearPicker`, `MonthRangePicker`, `YearRangePicker`.

#### Fix

```diff
-  const firstDay = calendar.querySelector<HTMLElement>('[data-reka-calendar-day]')
+  const firstDay = calendar.querySelector<HTMLElement>('[data-value]:not([data-outside-view]):not([data-disabled])')
```

- `data-value` is present on **every** calendar/picker cell trigger, so one selector fixes all the components above.
- `:not([data-outside-view])` skips spill-over days from the previous/next month (the attribute only exists on Calendar/RangeCalendar, so it is a harmless no-op for the Month/Year pickers).
- `:not([data-disabled])` skips cells that cannot receive focus — disabled cells render without a `tabindex`, so without this the fallback would target an unfocusable cell and focus would still land nowhere.
- This mirrors the selector reka-ui already uses internally for cell navigation, e.g. `CalendarCellTrigger.vue` and `RangeCalendarCellTrigger.vue` both query `` `[data-value='${...}']:not([data-outside-view])` ``.

#### Verification (TDD)

Added a regression test to `Calendar/Calendar.test.ts` (in the `calendar - edge cases` block) that renders an unselected calendar with a placeholder month containing no today, asserts neither `[data-selected]` nor `[data-today]` exists, then calls `handleCalendarInitialFocus` and expects the first in-view day to receive focus.

- **Before fix:** the test fails — focus stays on `<body>` because the old selector matches nothing.
- **After fix:** the test passes — focus lands on the first in-view, non-disabled day.

All Calendar-family suites pass (`Calendar`, `RangeCalendar`, `DatePicker`, `DateRangePicker`, `MonthPicker`, `YearPicker`, `MonthRangePicker`, `YearRangePicker`), and `eslint` is clean.

### 📝 Checklist

- [ ] I have linked an issue or discussion. (No prior issue exists — see the Linked issue section above.)
- [x] My change is non-breaking and requires no documentation update (internal fix, no public API/props/type change).
- [x] I have added a regression test covering the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for calendar initial focus behavior when no date is selected.

* **Bug Fixes**
  * Improved calendar focus handling to correctly select the first available date when "today" is not visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->