### PR TITLE
fix(DismissableLayer): keep body pointer-events locked when nested layer closes (#2674)

### DIFF
--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -31,6 +31,9 @@ describe('nested layers with disableOutsidePointerEvents (#2674)', () => {
   function mountNested() {
     const outerOpen = ref(true)
     const innerOpen = ref(false)
+    // Mirrors how a modal Menu drives the prop (`menuContext.open.value`):
+    // the layer stays mounted while the prop toggles back to `false`.
+    const innerDisable = ref(true)
 
     const wrapper = mount(defineComponent({
       setup() {
@@ -39,13 +42,13 @@ describe('nested layers with disableOutsidePointerEvents (#2674)', () => {
             ? h(DismissableLayerPrimitive, { 'disableOutsidePointerEvents': true, 'data-testid': 'outer' }, () => 'Outer')
             : null,
           innerOpen.value
-            ? h(DismissableLayerPrimitive, { 'disableOutsidePointerEvents': true, 'data-testid': 'inner' }, () => 'Inner')
+            ? h(DismissableLayerPrimitive, { 'disableOutsidePointerEvents': innerDisable.value, 'data-testid': 'inner' }, () => 'Inner')
             : null,
         ])
       },
     }), { attachTo: document.body })
 
-    return { wrapper, outerOpen, innerOpen }
+    return { wrapper, outerOpen, innerOpen, innerDisable }
   }
 
   it('should keep body pointer-events none after a nested layer closes while outer stays open', async () => {
@@ -62,6 +65,54 @@ describe('nested layers with disableOutsidePointerEvents (#2674)', () => {
 
     // Close inner layer while outer is still open
     innerOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    wrapper.unmount()
+  })
+
+  it('should keep body pointer-events none when a nested layer toggles disableOutsidePointerEvents to false while mounted', async () => {
+    const { wrapper, innerOpen, innerDisable } = mountNested()
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Open inner layer (still disabling outside pointer events)
+    innerOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Toggle the prop off without unmounting (a modal Menu closing)
+    innerDisable.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Now unmount the inner layer entirely; outer still open
+    innerOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    wrapper.unmount()
+  })
+
+  it('should restore and re-lock body pointer-events as the only layer toggles disableOutsidePointerEvents', async () => {
+    const disable = ref(true)
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => h(DismissableLayerPrimitive, { disableOutsidePointerEvents: disable.value }, () => 'Only')
+      },
+    }), { attachTo: document.body })
+
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Toggle off -> body restored, and the layer must leave the tracking set
+    disable.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    // Toggle back on -> body must lock again (would stay '' if a stale entry
+    // remained in the set, making `size === 0` false on re-add)
+    disable.value = true
     await sleep(1)
     expect(document.body.style.pointerEvents).toBe('none')
 

--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -2,7 +2,9 @@ import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
 import { sleep } from '@/test'
+import { DismissableLayer as DismissableLayerPrimitive } from '.'
 import DismissableLayer from './story/_DismissableLayer.vue'
 import { isLayerExist } from './utils'
 
@@ -17,6 +19,65 @@ describe('isLayerExist', () => {
 
     expect(isLayerExist(layer, document as any)).toBe(false)
     expect(isLayerExist(layer, document.createTextNode('x') as any)).toBe(false)
+  })
+})
+
+describe('nested layers with disableOutsidePointerEvents (#2674)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.body.style.pointerEvents = ''
+  })
+
+  function mountNested() {
+    const outerOpen = ref(true)
+    const innerOpen = ref(false)
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => h('div', [
+          outerOpen.value
+            ? h(DismissableLayerPrimitive, { 'disableOutsidePointerEvents': true, 'data-testid': 'outer' }, () => 'Outer')
+            : null,
+          innerOpen.value
+            ? h(DismissableLayerPrimitive, { 'disableOutsidePointerEvents': true, 'data-testid': 'inner' }, () => 'Inner')
+            : null,
+        ])
+      },
+    }), { attachTo: document.body })
+
+    return { wrapper, outerOpen, innerOpen }
+  }
+
+  it('should keep body pointer-events none after a nested layer closes while outer stays open', async () => {
+    const { wrapper, innerOpen } = mountNested()
+    await sleep(1)
+
+    // Outer (dialog) open -> body locked
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Open inner (menu) layer
+    innerOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Close inner layer while outer is still open
+    innerOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    wrapper.unmount()
+  })
+
+  it('should restore body pointer-events after the last layer closes', async () => {
+    const { wrapper, outerOpen } = mountNested()
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    outerOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    wrapper.unmount()
   })
 })
 

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -9,6 +9,7 @@ import {
   computed,
   nextTick,
   reactive,
+  watch,
   watchEffect,
 } from 'vue'
 import { isNullish, useForwardExpose } from '@/shared'
@@ -138,28 +139,38 @@ onKeyStroke('Escape', (event) => {
     emits('dismiss')
 })
 
-watchEffect((cleanupFn) => {
-  if (!layerElement.value)
-    return
-  if (props.disableOutsidePointerEvents) {
-    if (context.layersWithOutsidePointerEventsDisabled.size === 0) {
-      context.originalBodyPointerEvents = ownerDocument.value.body.style.pointerEvents
-      ownerDocument.value.body.style.pointerEvents = 'none'
+// Use `watch` with explicit sources (instead of `watchEffect`) so this effect
+// only re-runs when `layerElement` or `disableOutsidePointerEvents` change.
+// Reading `context.layersWithOutsidePointerEventsDisabled.size` inside the
+// callback must NOT make it reactive: otherwise adding/removing any other
+// layer would re-run this effect and its cleanup could prematurely restore the
+// body's `pointer-events` while an ancestor layer is still open (#2674).
+watch(
+  [layerElement, () => props.disableOutsidePointerEvents],
+  ([element, disableOutsidePointerEvents], _, onCleanup) => {
+    if (!element)
+      return
+    if (disableOutsidePointerEvents) {
+      if (context.layersWithOutsidePointerEventsDisabled.size === 0) {
+        context.originalBodyPointerEvents = ownerDocument.value.body.style.pointerEvents
+        ownerDocument.value.body.style.pointerEvents = 'none'
+      }
+      context.layersWithOutsidePointerEventsDisabled.add(element)
     }
-    context.layersWithOutsidePointerEventsDisabled.add(layerElement.value)
-  }
-  layers.value.add(layerElement.value)
+    layers.value.add(element)
 
-  cleanupFn(() => {
-    if (
-      props.disableOutsidePointerEvents
-      && context.layersWithOutsidePointerEventsDisabled.size === 1
-      && !isNullish(context.originalBodyPointerEvents)
-    ) {
-      ownerDocument.value.body.style.pointerEvents = context.originalBodyPointerEvents
-    }
-  })
-})
+    onCleanup(() => {
+      if (
+        disableOutsidePointerEvents
+        && context.layersWithOutsidePointerEventsDisabled.size === 1
+        && !isNullish(context.originalBodyPointerEvents)
+      ) {
+        ownerDocument.value.body.style.pointerEvents = context.originalBodyPointerEvents
+      }
+    })
+  },
+  { immediate: true },
+)
 
 watchEffect((cleanupFn) => {
   cleanupFn(() => {

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -156,18 +156,25 @@ watch(
         ownerDocument.value.body.style.pointerEvents = 'none'
       }
       context.layersWithOutsidePointerEventsDisabled.add(element)
+
+      // Remove this layer from the set on cleanup (re-run via prop toggle, or
+      // unmount) and restore the body's `pointer-events` only once the last
+      // disabling layer is gone. Removing here — rather than relying solely on
+      // the unmount-only effect below — keeps the set accurate when
+      // `disableOutsidePointerEvents` toggles `true -> false` while still
+      // mounted (e.g. a modal Menu closing). Checking `size === 0` *after*
+      // deletion makes the restore independent of cleanup ordering (#2674).
+      onCleanup(() => {
+        context.layersWithOutsidePointerEventsDisabled.delete(element)
+        if (
+          context.layersWithOutsidePointerEventsDisabled.size === 0
+          && !isNullish(context.originalBodyPointerEvents)
+        ) {
+          ownerDocument.value.body.style.pointerEvents = context.originalBodyPointerEvents
+        }
+      })
     }
     layers.value.add(element)
-
-    onCleanup(() => {
-      if (
-        disableOutsidePointerEvents
-        && context.layersWithOutsidePointerEventsDisabled.size === 1
-        && !isNullish(context.originalBodyPointerEvents)
-      ) {
-        ownerDocument.value.body.style.pointerEvents = context.originalBodyPointerEvents
-      }
-    })
   },
   { immediate: true },
 )


### PR DESCRIPTION
Closes #2674

## Problem

Opening a `DropdownMenu` (or any modal layer) inside a `Dialog` and then **closing the menu** strips the `pointer-events: none` style from `<body>`, even though the Dialog is still open. This breaks the modal pointer-event lock while the dialog remains visible.

## Root cause

`DismissableLayer` manages the body lock in a `watchEffect`:

```ts
watchEffect((cleanupFn) => {
  if (props.disableOutsidePointerEvents) {
    if (context.layersWithOutsidePointerEventsDisabled.size === 0) { ... }
    context.layersWithOutsidePointerEventsDisabled.add(layerElement.value)
  }
  ...
})
```

Because `context` is `reactive()`, reading `context.layersWithOutsidePointerEventsDisabled.size` registers a reactive dependency, so the effect **re-runs whenever any layer is added/removed** from the set — across *all* mounted layers.

When the nested menu closes, the still-open Dialog's effect re-runs, and its cleanup sees `size === 1` and restores the body's original `pointer-events`, removing the lock prematurely.

Radix React avoids this by using `useEffect` with a fixed dependency list (`[node, ownerDocument, disableOutsidePointerEvents, context]`) — it does not re-run on set mutations.

## Fix

Convert the `watchEffect` to a `watch` with explicit sources (`layerElement`, `disableOutsidePointerEvents`). Reads of the set size inside the callback no longer create reactive dependencies, so the effect only re-runs when its real inputs change — matching the React behavior.

## Tests

Added two tests under `DismissableLayer.test.ts`:
- nested layer closing keeps `body` `pointer-events: none` while the outer layer stays open
- closing the last layer correctly restores `body` `pointer-events`

All existing Dialog / Menu / Popover / DropdownMenu / AlertDialog tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for nested dismissable layers, validating pointer-event behavior across multiple layers during open/close sequences and prop changes.

* **Refactor**
  * Improved pointer-event management for dismissable layers so body pointer-events are reliably set and restored as layers toggle, ensuring consistent interaction when multiple layers are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->