### PR TITLE
fix(Dialog): honor disableOutsidePointerEvents on modal content (#2677)

### DIFF
--- a/packages/core/src/Dialog/Dialog.test.ts
+++ b/packages/core/src/Dialog/Dialog.test.ts
@@ -67,6 +67,68 @@ const NestedContentDialogTest = defineComponent({
 </DialogRoot>`,
 })
 
+// Reproduces https://github.com/unovue/reka-ui/issues/2677 — a modal Dialog
+// hardcoded `disableOutsidePointerEvents` to `true`, so the prop passed to
+// `DialogContent` was ignored. These are tested without a `DialogOverlay`,
+// because the overlay's `useBodyScrollLock` locks `body` pointer-events through
+// a separate mechanism unrelated to this prop.
+function makeModalDialog(contentBinding: string) {
+  return defineComponent({
+    components: { DialogRoot, DialogTrigger, DialogContent, DialogClose, DialogTitle },
+    template: `<DialogRoot>
+  <DialogTrigger>${OPEN_TEXT}</DialogTrigger>
+  <DialogContent ${contentBinding}>
+    <DialogTitle>${TITLE_TEXT}</DialogTitle>
+    <DialogClose>${CLOSE_TEXT}</DialogClose>
+  </DialogContent>
+</DialogRoot>`,
+  })
+}
+
+describe('given a modal Dialog (#2677)', () => {
+  let consoleWarnMock: SpyInstance
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.body.style.pointerEvents = ''
+    consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleWarnMock.mockRestore()
+  })
+
+  it('should lock body pointer-events by default', async () => {
+    const wrapper = mount(makeModalDialog(''), { attachTo: document.body })
+    fireEvent.click(wrapper.find('button').element)
+    await findByText(document.body, CLOSE_TEXT)
+    await nextTick()
+
+    expect(document.body.style.pointerEvents).toBe('none')
+    wrapper.unmount()
+  })
+
+  it('should respect disableOutsidePointerEvents=false on the content', async () => {
+    const wrapper = mount(makeModalDialog(':disable-outside-pointer-events="false"'), { attachTo: document.body })
+    fireEvent.click(wrapper.find('button').element)
+    await findByText(document.body, CLOSE_TEXT)
+    await nextTick()
+
+    expect(document.body.style.pointerEvents).not.toBe('none')
+    wrapper.unmount()
+  })
+
+  it('should still lock body pointer-events when explicitly true', async () => {
+    const wrapper = mount(makeModalDialog(':disable-outside-pointer-events="true"'), { attachTo: document.body })
+    fireEvent.click(wrapper.find('button').element)
+    await findByText(document.body, CLOSE_TEXT)
+    await nextTick()
+
+    expect(document.body.style.pointerEvents).toBe('none')
+    wrapper.unmount()
+  })
+})
+
 describe('given a default Dialog', () => {
   let wrapper: VueWrapper<InstanceType<typeof DialogTest>>
   let trigger: DOMWrapper<HTMLElement>

--- a/packages/core/src/Dialog/DialogContent.vue
+++ b/packages/core/src/Dialog/DialogContent.vue
@@ -22,7 +22,13 @@ import DialogContentModal from './DialogContentModal.vue'
 import DialogContentNonModal from './DialogContentNonModal.vue'
 import { injectDialogRootContext } from './DialogRoot.vue'
 
-const props = defineProps<DialogContentProps>()
+const props = withDefaults(defineProps<DialogContentProps>(), {
+  // Keep `undefined` (instead of Vue's boolean coercion to `false`) so the
+  // modal/non-modal child can apply its own default. This lets a modal
+  // `DialogContent` stay locked by default while still honoring an explicit
+  // `:disable-outside-pointer-events="false"` (#2677).
+  disableOutsidePointerEvents: undefined,
+})
 const emits = defineEmits<DialogContentEmits>()
 
 const rootContext = injectDialogRootContext()

--- a/packages/core/src/Dialog/DialogContentModal.vue
+++ b/packages/core/src/Dialog/DialogContentModal.vue
@@ -4,7 +4,9 @@ import { useEmitAsProps, useForwardExpose, useHideOthers } from '@/shared'
 import DialogContentImpl from './DialogContentImpl.vue'
 import { injectDialogRootContext } from './DialogRoot.vue'
 
-const props = defineProps<DialogContentImplProps>()
+const props = withDefaults(defineProps<DialogContentImplProps>(), {
+  disableOutsidePointerEvents: true,
+})
 const emits = defineEmits<DialogContentImplEmits>()
 
 const rootContext = injectDialogRootContext()
@@ -20,7 +22,7 @@ useHideOthers(currentElement)
     v-bind="{ ...props, ...emitsAsProps }"
     :ref="forwardRef"
     :trap-focus="rootContext.open.value"
-    :disable-outside-pointer-events="true"
+    :disable-outside-pointer-events="props.disableOutsidePointerEvents"
     @close-auto-focus="
       (event) => {
         if (!event.defaultPrevented) {


### PR DESCRIPTION
Closes #2677

## Problem

`DialogContent` documents a `disableOutsidePointerEvents` prop, but passing `:disable-outside-pointer-events="false"` to a modal dialog had no effect — the body still received `pointer-events: none` from the `DismissableLayer`.

## Root cause

`DialogContentModal` hardcoded the value:

```vue
<DialogContentImpl
  :disable-outside-pointer-events="true"
  ...
/>
```

so any value forwarded from `DialogContent` was overridden.

A naive `withDefaults(..., { disableOutsidePointerEvents: true })` on the modal alone is **not enough**: `DialogContent` declares the prop as `Boolean`, so Vue coerces an *absent* prop to `false`, which then explicitly overrides the child's `true` default — breaking the default modal lock. Both "absent" and "explicit false" collapse to `false` before the modal sees them.

## Fix

1. `DialogContentModal`: forward `props.disableOutsidePointerEvents` instead of hardcoding `true`, with `withDefaults(..., { disableOutsidePointerEvents: true })` to preserve the modal default.
2. `DialogContent`: declare an explicit `undefined` default so an absent prop is **not** boolean-coerced to `false` and instead propagates as `undefined`, letting the child apply its own default. An explicit `:disable-outside-pointer-events="false"` is still honored.

Result (modal dialog, no overlay):

| `disableOutsidePointerEvents` | body `pointer-events` |
| --- | --- |
| _(absent)_ | `none` ✅ (default modal lock preserved) |
| `false` | _(unset)_ ✅ (now honored) |
| `true` | `none` ✅ |

## Caveat

When a `DialogOverlay` is rendered, its `useBodyScrollLock(true)` sets the body's `pointer-events: none` through a **separate** scroll-lock mechanism, independent of this prop. This PR only addresses the `DismissableLayer` lock that `DialogContentModal` was overriding — matching the exact issue reported. Freeing the body while an overlay/scroll-lock is active would be a separate change with broader impact (shared by Select/Combobox/Menu/Popover).

## Tests

Added tests under `Dialog.test.ts` (modal dialog, no overlay):
- locks body `pointer-events` by default
- respects `disableOutsidePointerEvents=false`
- still locks when explicitly `true`

All Dialog / Menu / Popover / AlertDialog / DropdownMenu tests pass, and `type-check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dialog component's management of pointer events outside dialog boxes. Modal dialogs now properly apply pointer event blocking settings with better handling of default behavior and explicit configuration options, ensuring more consistent and predictable interaction patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->