### PR TITLE
fix: honor configured id source before vue useId

### DIFF
--- a/docs/content/docs/utilities/config-provider.md
+++ b/docs/content/docs/utilities/config-provider.md
@@ -64,9 +64,11 @@ import { ConfigProvider } from 'reka-ui'
 </template>
 ```
 
-## Hydration issue (Vue < 3.5)
+## Hydration issue
 
-We expose a temporary workaround to allow current Nuxt (with version >3.10) project fix the current hydration issue by using [`useId`](https://nuxt.com/docs/api/composables/use-id) provided by Nuxt.
+`ConfigProvider` can accept a custom `useId` function for frameworks that need to provide their own SSR-stable ID source. Reka UI uses this function before Vue's native `useId`, so every primitive that generates accessibility IDs follows the same app-provided source.
+
+This is useful in Nuxt projects where prerendered HTML and client hydration can use different Vue app ID prefixes. Pass Nuxt's [`useId`](https://nuxt.com/docs/api/composables/use-id) through `ConfigProvider` so Reka-generated IDs stay stable across server and client rendering.
 
 > Inspired by [Headless UI](https://github.com/tailwindlabs/headlessui/pull/2959)
 

--- a/docs/content/docs/utilities/use-id.md
+++ b/docs/content/docs/utilities/use-id.md
@@ -15,6 +15,17 @@ description: Generate random id
 Generate random id
 </Description>
 
+## Source order
+
+`useId` resolves IDs in this order:
+
+1. Explicit ID passed to `useId(id)`.
+2. The `useId` function provided by `ConfigProvider`.
+3. Vue's native `useId` when available.
+4. Reka UI's fallback counter for older Vue versions.
+
+Use `ConfigProvider` when your framework provides its own SSR-stable ID source, such as Nuxt's `useId`.
+
 ## Usage
 
 ```ts

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -113,6 +113,7 @@
     "@types/node": "^24.0.13",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-istanbul": "^3.2.6",
+    "@vue/server-renderer": "3.5.17",
     "@vue/test-utils": "^2.4.11",
     "@vue/tsconfig": "^0.7.0",
     "jsdom": "^26.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -113,7 +113,7 @@
     "@types/node": "^24.0.13",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-istanbul": "^3.2.6",
-    "@vue/server-renderer": "3.5.17",
+    "@vue/server-renderer": "^3.5.17",
     "@vue/test-utils": "^2.4.11",
     "@vue/tsconfig": "^0.7.0",
     "jsdom": "^26.1.0",

--- a/packages/core/src/Accordion/Accordion.test.ts
+++ b/packages/core/src/Accordion/Accordion.test.ts
@@ -1,9 +1,79 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { findByText, fireEvent } from '@testing-library/vue'
+import { renderToString } from '@vue/server-renderer'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
+import { createSSRApp, defineComponent, h, nextTick } from 'vue'
+import { ConfigProvider } from '@/ConfigProvider'
+import {
+  AccordionContent,
+  AccordionHeader,
+  AccordionItem,
+  AccordionRoot,
+  AccordionTrigger,
+} from '.'
 import Accordion from './story/_Accordion.vue'
+
+const AccordionHydrationFixture = defineComponent({
+  setup() {
+    const items = ['One', 'Two']
+    let count = 0
+    const useId = () => `nuxt-${++count}`
+
+    return () =>
+      h(ConfigProvider, { useId }, () =>
+        h(
+          AccordionRoot,
+          { type: 'single', collapsible: true },
+          () => items.map(item =>
+            h(AccordionItem, { value: item }, () => [
+              h(AccordionHeader, () =>
+                h(AccordionTrigger, () => `Trigger ${item}`)),
+              h(AccordionContent, () => `Content ${item}`),
+            ]),
+          ),
+        ))
+  },
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ssr hydration', () => {
+  it('uses ConfigProvider ids when Vue app id prefixes differ', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Nuxt prerender can produce a different Vue useId app prefix than the
+    // hydrating client. ConfigProvider's useId must remain the stable source.
+    const serverApp = createSSRApp(AccordionHydrationFixture)
+    serverApp.config.idPrefix = 'v-1'
+
+    const container = document.createElement('div')
+    container.innerHTML = await renderToString(serverApp)
+    document.body.innerHTML = ''
+    document.body.append(container)
+
+    expect(container.innerHTML).toContain('id="reka-accordion-trigger-nuxt-1"')
+    expect(container.innerHTML).toContain('id="reka-collapsible-content-nuxt-2"')
+    const triggerId = container.querySelector('button')?.id
+    const contentId = container.querySelector('[role="region"]')?.id
+
+    const clientApp = createSSRApp(AccordionHydrationFixture)
+    clientApp.config.idPrefix = 'v-0'
+    clientApp.mount(container)
+    await nextTick()
+
+    expect(container.querySelector('button')?.id).toBe(triggerId)
+    expect(container.querySelector('[role="region"]')?.id).toBe(contentId)
+
+    const warnings = warn.mock.calls.flat().join('\n')
+    expect(warnings).not.toContain('Hydration attribute mismatch')
+    expect(error.mock.calls.flat().join('\n')).not.toContain('Hydration completed but contains mismatches')
+  })
+})
 
 describe('given a single Accordion', () => {
   let wrapper: VueWrapper<InstanceType<typeof Accordion>>

--- a/packages/core/src/ConfigProvider/ConfigProvider.test.ts
+++ b/packages/core/src/ConfigProvider/ConfigProvider.test.ts
@@ -2,8 +2,10 @@ import type { VueWrapper } from '@vue/test-utils'
 import type vueuse from '@vueuse/core'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { defineComponent, h, nextTick } from 'vue'
+import { useId } from '@/shared'
 import ConfigProviderTest from './_ConfigProvider.vue'
+import ConfigProvider from './ConfigProvider.vue'
 
 vi.mock('@vueuse/core', async (importOriginal) => {
   const mod: typeof vueuse = await importOriginal()
@@ -82,5 +84,27 @@ describe('given a scrollBody ConfigProvider', async () => {
     await nextTick()
     expect(document.body.style.paddingRight).toBe('0px')
     expect(document.body.style.marginRight).toBe('20px')
+  })
+})
+
+describe('given a useId ConfigProvider', () => {
+  it('uses the provided id generator before Vue useId', () => {
+    const IdConsumer = defineComponent({
+      setup() {
+        const id = useId(undefined, 'reka-test')
+        return () => h('div', { id })
+      },
+    })
+
+    const wrapper = mount(ConfigProvider, {
+      props: {
+        useId: () => 'provided-id',
+      },
+      slots: {
+        default: () => h(IdConsumer),
+      },
+    })
+
+    expect(wrapper.find('#reka-test-provided-id').exists()).toBe(true)
   })
 })

--- a/packages/core/src/Tabs/Tabs.test.ts
+++ b/packages/core/src/Tabs/Tabs.test.ts
@@ -1,9 +1,68 @@
 import type { VueWrapper } from '@vue/test-utils'
+import { renderToString } from '@vue/server-renderer'
 import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
+import { createSSRApp, defineComponent, h, nextTick } from 'vue'
+import { ConfigProvider } from '@/ConfigProvider'
 import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '.'
 import Tabs from './story/_Tabs.vue'
+
+const TabsHydrationFixture = defineComponent({
+  setup() {
+    let count = 0
+    const useId = () => `nuxt-${++count}`
+
+    return () =>
+      h(ConfigProvider, { useId }, () =>
+        h(TabsRoot, { defaultValue: 'account' }, () => [
+          h(TabsList, () => [
+            h(TabsTrigger, { value: 'account' }, () => 'Account'),
+            h(TabsTrigger, { value: 'password' }, () => 'Password'),
+          ]),
+          h(TabsContent, { value: 'account' }, () => 'Account content'),
+          h(TabsContent, { value: 'password' }, () => 'Password content'),
+        ]))
+  },
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ssr hydration', () => {
+  it('uses ConfigProvider ids when Vue app id prefixes differ', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Tabs derives trigger/content IDs from one base ID, so this catches the
+    // shared source-order bug for components that build related IDs.
+    const serverApp = createSSRApp(TabsHydrationFixture)
+    serverApp.config.idPrefix = 'v-1'
+
+    const container = document.createElement('div')
+    container.innerHTML = await renderToString(serverApp)
+    document.body.innerHTML = ''
+    document.body.append(container)
+
+    expect(container.innerHTML).toContain('id="reka-tabs-nuxt-1-trigger-account"')
+    expect(container.innerHTML).toContain('id="reka-tabs-nuxt-1-content-account"')
+    const triggerId = container.querySelector('[role="tab"]')?.id
+    const contentId = container.querySelector('[role="tabpanel"]')?.id
+
+    const clientApp = createSSRApp(TabsHydrationFixture)
+    clientApp.config.idPrefix = 'v-0'
+    clientApp.mount(container)
+    await nextTick()
+
+    expect(container.querySelector('[role="tab"]')?.id).toBe(triggerId)
+    expect(container.querySelector('[role="tabpanel"]')?.id).toBe(contentId)
+
+    const warnings = warn.mock.calls.flat().join('\n')
+    expect(warnings).not.toContain('Hydration attribute mismatch')
+    expect(error.mock.calls.flat().join('\n')).not.toContain('Hydration completed but contains mismatches')
+  })
+})
 
 describe('given default Tabs', () => {
   let wrapper: VueWrapper<InstanceType<typeof Tabs>>

--- a/packages/core/src/shared/useId.ts
+++ b/packages/core/src/shared/useId.ts
@@ -5,24 +5,32 @@ import { injectConfigProviderContext } from '@/ConfigProvider/ConfigProvider.vue
 
 let count = 0
 /**
- * The `useId` function generates a unique identifier using a provided deterministic ID or a default
- * one prefixed with "reka-", or the provided one via `useId` props from `<ConfigProvider>`.
+ * The `useId` function generates a unique identifier using a provided deterministic ID,
+ * a configured `<ConfigProvider>` ID source, Vue's native `useId`, or a fallback counter.
  * @param {string | null | undefined} [deterministicId] - The `useId` function you provided takes an
  * optional parameter `deterministicId`, which can be a string, null, or undefined. If
  * `deterministicId` is provided, the function will return it. Otherwise, it will generate an id using
- * the `useId` function obtained
+ * the configured ID source.
  */
 export function useId(deterministicId?: string | null | undefined, prefix = 'reka') {
   if (deterministicId)
     return deterministicId
 
   let id: string
-  if ('useId' in vue) {
+  const configProviderContext = injectConfigProviderContext({ useId: undefined })
+
+  // Keep the app-provided ID source authoritative. Frameworks such as Nuxt can
+  // prerender with a different Vue app ID prefix than the hydrating client, so
+  // falling through to Vue's native useId would bypass the stable source that
+  // ConfigProvider was explicitly given.
+  if (configProviderContext.useId) {
+    id = configProviderContext.useId()
+  }
+  else if ('useId' in vue) {
     id = vue.useId?.()
   }
   else {
-    const configProviderContext = injectConfigProviderContext({ useId: undefined })
-    id = configProviderContext.useId?.() ?? `${++count}`
+    id = `${++count}`
   }
 
   return prefix ? `${prefix}-${id}` : id

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,9 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^3.2.6
         version: 3.2.6(vitest@4.1.8)
+      '@vue/server-renderer':
+        specifier: 3.5.17
+        version: 3.5.17(vue@3.5.17(typescript@5.8.3))
       '@vue/test-utils':
         specifier: ^2.4.11
         version: 2.4.11(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.17(vue@3.5.17(typescript@5.8.3)))(vue@3.5.17(typescript@5.8.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,7 +263,7 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(vitest@4.1.8)
       '@vue/server-renderer':
-        specifier: 3.5.17
+        specifier: ^3.5.17
         version: 3.5.17(vue@3.5.17(typescript@5.8.3))
       '@vue/test-utils':
         specifier: ^2.4.11
@@ -7450,7 +7450,7 @@ snapshots:
 
   '@babel/generator@7.28.0':
     dependencies:
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.29.7
       '@babel/types': 7.28.0
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
@@ -7514,7 +7514,7 @@ snapshots:
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.29.7
       '@babel/types': 7.28.0
 
   '@babel/traverse@7.26.7':
@@ -9204,7 +9204,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.17':
     dependencies:
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.29.7
       '@vue/shared': 3.5.17
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -9286,8 +9286,8 @@ snapshots:
   '@vue/language-core@3.2.6':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.17
-      '@vue/shared': 3.5.21
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
       alien-signals: 3.1.2
       muggle-string: 0.4.1
       path-browserify: 1.0.1
@@ -9540,7 +9540,7 @@ snapshots:
 
   ast-kit@2.1.1:
     dependencies:
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.29.7
       pathe: 2.0.3
 
   asynckit@0.4.0: {}
@@ -13434,8 +13434,8 @@ snapshots:
   rolldown-plugin-dts@0.13.13(rolldown@1.0.0-beta.26)(typescript@5.8.3)(vue-tsc@3.2.6(typescript@5.8.3)):
     dependencies:
       '@babel/generator': 7.28.0
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       ast-kit: 2.1.1
       birpc: 2.4.0
       debug: 4.4.3
@@ -14311,7 +14311,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.7
       '@babel/standalone': 7.26.7
-      '@babel/types': 7.28.0
+      '@babel/types': 7.29.7
       citty: 0.1.6
       defu: 6.1.6
       jiti: 2.4.2


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/unovue/reka-ui/issues/2682

#### Nuxt UI issues
https://github.com/nuxt/ui/issues/5801
https://github.com/nuxt/ui/issues/5529

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates Reka's shared `useId` helper so `ConfigProvider.useId` is treated as the canonical app-provided ID source before falling back to Vue's native `useId`.

The new precedence is:

```txt
explicit deterministic ID
-> ConfigProvider.useId
-> Vue useId
-> local fallback counter
```

This preserves the existing public API and fixes the provider invariant for all primitives that use the shared `useId` helper.

Previously, on Vue 3.5+, Reka preferred Vue `useId` whenever it was available. That meant an app or framework could provide a custom SSR-stable ID generator through `ConfigProvider`, but Reka would still bypass it and use Vue's app-scoped ID source.

This matters for framework integrations such as Nuxt UI. In Nuxt prerender/static output, Vue `useId` can produce different IDs between generated SSR HTML and client hydration. The related Nuxt UI issue shows mismatches like:

```txt
server: reka-accordion-trigger-v-1-0
client: reka-accordion-trigger-v-0-0
```

and:

```txt
server: reka-tabs-v-2-0-trigger-account
client: reka-tabs-v-1-0-trigger-account
```

By honoring `ConfigProvider.useId` first, Reka lets integrations provide the correct stable ID source at the provider boundary instead of requiring component-specific fixes.

This PR also updates the docs/tests around the expected source order.

### Release note

- Behavior change: on Vue 3.5+, `ConfigProvider`'s `useId` option now takes precedence over Vue's native `useId`, matching the documented Reka UI configuration behavior and avoiding SSR hydration mismatches when an app provides a stable ID source.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance on custom ID generation for SSR stability and Nuxt usage.
  * Added ID resolution precedence and when to use a provider-supplied ID source.

* **Bug Fixes**
  * Prioritized app-provided ID generators to improve SSR hydration stability.
  * Ensured consistent ID generation across server and client renders with differing prefixes.

* **Tests**
  * Added SSR hydration tests covering accordion, tabs, and provider ID behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->