### PR TITLE
fix(Combobox): keep content open when interacting with associated label

### DIFF
--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -349,6 +349,65 @@ describe('given a Combobox with openOnFocus', () => {
   })
 })
 
+describe('given combobox with an associated label', () => {
+  let wrapper: VueWrapper<InstanceType<typeof Combobox>>
+
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn()
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn()
+  window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(Combobox, { attachTo: document.body })
+  })
+
+  it('should not dismiss when interacting with a label tied to a control inside', async () => {
+    // A `<label for="...">` pointing to the combobox input forwards its click/focus
+    // to that input. Clicking it should keep the content open instead of dismissing
+    // on `pointerdown` and immediately re-opening from the forwarded click.
+    const input = wrapper.find('input')
+    input.element.id = 'combobox-input'
+
+    const label = document.createElement('label')
+    label.setAttribute('for', 'combobox-input')
+    label.textContent = 'Fruit'
+    document.body.appendChild(label)
+
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+    // The document `pointerdown` listener is registered via `setTimeout(0)`.
+    await sleep(1)
+    expect(wrapper.find('[role=group]').exists()).toBe(true)
+
+    label.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    await nextTick()
+
+    expect(wrapper.find('[role=group]').exists()).toBe(true)
+
+    label.remove()
+  })
+
+  it('should dismiss when interacting with an unrelated label', async () => {
+    const externalLabel = document.createElement('label')
+    externalLabel.textContent = 'Unrelated'
+    document.body.appendChild(externalLabel)
+
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+    await sleep(1)
+    expect(wrapper.find('[role=group]').exists()).toBe(true)
+
+    externalLabel.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    // dismiss is emitted after an internal `await nextTick()`.
+    await sleep(1)
+    await nextTick()
+
+    expect(wrapper.find('[role=group]').exists()).toBe(false)
+
+    externalLabel.remove()
+  })
+})
+
 describe('given combobox in a form', async () => {
   let wrapper: VueWrapper<InstanceType<any>>
   let valueBox: DOMWrapper<HTMLInputElement>

--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -380,6 +380,9 @@ describe('given combobox with an associated label', () => {
     expect(wrapper.find('[role=group]').exists()).toBe(true)
 
     label.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    // Wait as long as a real dismiss would take (emitted after an internal
+    // `await nextTick()`) so a regression that fails to prevent it is caught.
+    await sleep(1)
     await nextTick()
 
     expect(wrapper.find('[role=group]').exists()).toBe(true)

--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -97,6 +97,19 @@ onUnmounted(() => {
     rootContext.triggerElement.value?.focus()
   }
 })
+
+function isEventTargetWithinCombobox(target: EventTarget | null) {
+  if (rootContext.parentElement.value?.contains(target as Node))
+    return true
+
+  // A `<label>` associated (via `for`) with an element inside the combobox forwards its
+  // click/focus to that control, so interacting with it should not dismiss the content.
+  // Without this, clicking such a label while open dismisses on `pointerdown` and the
+  // forwarded click/focus immediately re-opens it.
+  const label = target instanceof Element ? target.closest('label') : null
+  const control = label?.control
+  return !!control && !!rootContext.parentElement.value?.contains(control)
+}
 </script>
 
 <template>
@@ -111,15 +124,15 @@ onUnmounted(() => {
         :disable-outside-pointer-events="disableOutsidePointerEvents"
         @dismiss="rootContext.onOpenChange(false)"
         @focus-outside="(ev) => {
-          // if clicking inside the combobox, prevent dismiss
-          if (rootContext.parentElement.value?.contains(ev.target as Node)) ev.preventDefault()
+          // if focusing inside the combobox (or a label tied to it), prevent dismiss
+          if (isEventTargetWithinCombobox(ev.target)) ev.preventDefault()
           emits('focusOutside', ev)
         }"
         @interact-outside="emits('interactOutside', $event)"
         @escape-key-down="emits('escapeKeyDown', $event)"
         @pointer-down-outside="(ev) => {
-          // if clicking inside the combobox, prevent dismiss
-          if (rootContext.parentElement.value?.contains(ev.target as Node)) ev.preventDefault()
+          // if clicking inside the combobox (or a label tied to it), prevent dismiss
+          if (isEventTargetWithinCombobox(ev.target)) ev.preventDefault()
           emits('pointerDownOutside', ev)
         }"
       >


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

A `<label>` associated (via `for`) with a control inside the combobox forwards its click/focus to that control. Without accounting for this, clicking such a label while the combobox is open dismissed the content on `pointerdown`, and the forwarded click/focus then immediately re-opened it, which felt broken.

Added an `isEventTargetWithinCombobox` helper that treats a label whose `control` lives inside the combobox as "inside", so `pointerDownOutside`/`focusOutside` no longer dismiss in that case.

Added two tests: an associated label keeps the content open, an unrelated label still dismisses.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Combobox behavior when interacting with labels: clicking a label linked to the input no longer closes the popup, while clicks on unrelated labels still dismiss it.

* **Tests**
  * Added test coverage for pointer interactions between labels and the Combobox to ensure consistent popup handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->