### PR TITLE
fix(SelectTrigger): prevent suppression of mousedown event

### DIFF
--- a/packages/core/src/Select/Select.test.ts
+++ b/packages/core/src/Select/Select.test.ts
@@ -38,6 +38,69 @@ describe('given default Select', () => {
     expect(selectTrigger.attributes('data-placeholder')).toBe('')
   })
 
+  describe('trigger mouse interop', () => {
+    async function openSelectWithMouseClick() {
+      const button = wrapper.find('button')
+      // Open on pointerdown, then emit the compatibility mouse events that follow in browsers.
+      await button.trigger('pointerdown', { button: 0, ctrlKey: false })
+      fireEvent.mouseDown(button.element, { button: 0, ctrlKey: false })
+      fireEvent.mouseUp(button.element, { button: 0, ctrlKey: false })
+      fireEvent.click(button.element, { button: 0, ctrlKey: false })
+      await nextTick()
+      await nextTick()
+    }
+
+    it('should not suppress window mousedown listeners when opening (#1773)', async () => {
+      const button = wrapper.find('button').element
+      const onWindowMousedown = vi.fn()
+      window.addEventListener('mousedown', onWindowMousedown, true)
+
+      fireEvent.pointerDown(button, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+      const mousedownEvent = new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        ctrlKey: false,
+      })
+      button.dispatchEvent(mousedownEvent)
+
+      expect(onWindowMousedown).toHaveBeenCalled()
+      expect(mousedownEvent.defaultPrevented).toBe(true)
+
+      window.removeEventListener('mousedown', onWindowMousedown, true)
+    })
+
+    it('should focus the trigger on click without a preceding pointerdown', async () => {
+      const trigger = wrapper.find('[role="combobox"]').element as HTMLElement
+      const focusSpy = vi.spyOn(trigger, 'focus')
+
+      fireEvent.click(trigger, { button: 0, ctrlKey: false })
+
+      expect(focusSpy).toHaveBeenCalled()
+      focusSpy.mockRestore()
+    })
+
+    it('should not re-focus the trigger on click after opening via pointerdown', async () => {
+      const trigger = wrapper.find('[role="combobox"]').element as HTMLElement
+      const focusSpy = vi.spyOn(trigger, 'focus')
+
+      await wrapper.find('button').trigger('pointerdown', { button: 0, ctrlKey: false })
+      fireEvent.click(trigger, { button: 0, ctrlKey: false })
+
+      expect(focusSpy).not.toHaveBeenCalled()
+      focusSpy.mockRestore()
+    })
+
+    it('should not leave focus on the trigger after opening via mouse click', async () => {
+      const trigger = wrapper.find('[role="combobox"]').element
+
+      await openSelectWithMouseClick()
+
+      expect(wrapper.html()).toContain('Apple')
+      expect(document.activeElement).not.toBe(trigger)
+    })
+  })
+
   describe('opening the modal', () => {
     beforeEach(async () => {
       await wrapper.find('button').trigger('pointerdown', {

--- a/packages/core/src/Select/SelectTrigger.vue
+++ b/packages/core/src/Select/SelectTrigger.vue
@@ -48,8 +48,50 @@ function handlePointerOpen(event: PointerEvent) {
   }
 }
 
-function isCtrlLeftClick(event: MouseEvent) {
+function isPlainLeftClick(event: MouseEvent) {
   return event.button === 0 && event.ctrlKey === false
+}
+
+// Tracks direct mouse presses handled in `pointerdown` so the Safari label
+// `click` workaround below does not re-focus the trigger after opening.
+let openedFromPointerDown = false
+
+function onTriggerPointerDown(event: PointerEvent) {
+  // Prevent opening on touch down.
+  // https://github.com/unovue/reka-ui/issues/804
+  if (event.pointerType === 'touch')
+    return event.preventDefault()
+
+  // prevent implicit pointer capture
+  // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
+  const target = event.target as HTMLElement
+  if (target.hasPointerCapture(event.pointerId))
+    target.releasePointerCapture(event.pointerId)
+
+  // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
+  // but not when the control key is pressed (avoiding MacOS right click)
+  if (isPlainLeftClick(event)) {
+    handlePointerOpen(event)
+    openedFromPointerDown = true
+  }
+}
+
+function onTriggerMouseDown(event: MouseEvent) {
+  // Prevent trigger from stealing focus from the active item after opening.
+  // We avoid calling `preventDefault` in `pointerdown` because that suppresses
+  // compatibility mouse events (`mousedown`, `mouseup`, `click`).
+  if (isPlainLeftClick(event))
+    event.preventDefault()
+}
+
+function onTriggerClick(event: MouseEvent) {
+  // Safari: label-associated clicks may not run `pointerdown` on the trigger.
+  // Direct mouse clicks open in `pointerdown` and must not re-focus the trigger
+  // here — `mousedown` `preventDefault` does not suppress `click`.
+  if (!openedFromPointerDown)
+    (event.currentTarget as HTMLElement)?.focus()
+
+  openedFromPointerDown = false
 }
 </script>
 
@@ -73,47 +115,9 @@ function isCtrlLeftClick(event: MouseEvent) {
       :data-placeholder="shouldShowPlaceholder(rootContext.modelValue?.value) ? '' : undefined"
       :as-child="asChild"
       :as="as"
-      @click="
-        (event: MouseEvent) => {
-          // Whilst browsers generally have no issue focusing the trigger when clicking
-          // on a label, Safari seems to struggle with the fact that there's no `onClick`.
-          // We force `focus` in this case. Note: this doesn't create any other side-effect
-          // because we are preventing default in `onMouseDown` so effectively
-          // this only runs for a label 'click'
-          (event?.currentTarget as HTMLElement)?.focus();
-        }
-      "
-      @pointerdown="
-        (event: PointerEvent) => {
-          // Prevent opening on touch down.
-          // https://github.com/unovue/reka-ui/issues/804
-          if (event.pointerType === 'touch')
-            return event.preventDefault();
-
-          // prevent implicit pointer capture
-          // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
-          const target = event.target as HTMLElement;
-          if (target.hasPointerCapture(event.pointerId)) {
-            target.releasePointerCapture(event.pointerId);
-          }
-
-          // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
-          // but not when the control key is pressed (avoiding MacOS right click)
-          if (isCtrlLeftClick(event)) {
-            handlePointerOpen(event)
-          }
-        }
-      "
-      @mousedown="
-        (event: MouseEvent) => {
-          // Prevent trigger from stealing focus from the active item after opening.
-          // We avoid calling `preventDefault` in `pointerdown` because that suppresses
-          // compatibility mouse events (`mousedown`, `mouseup`, `click`).
-          if (isCtrlLeftClick(event)) {
-            event.preventDefault();
-          }
-        }
-      "
+      @click="onTriggerClick"
+      @pointerdown="onTriggerPointerDown"
+      @mousedown="onTriggerMouseDown"
       @pointerup.prevent="
         (event: PointerEvent) => {
           // Only open on pointer up when using touch devices

--- a/packages/core/src/Select/SelectTrigger.vue
+++ b/packages/core/src/Select/SelectTrigger.vue
@@ -74,7 +74,7 @@ function handlePointerOpen(event: PointerEvent) {
           // Whilst browsers generally have no issue focusing the trigger when clicking
           // on a label, Safari seems to struggle with the fact that there's no `onClick`.
           // We force `focus` in this case. Note: this doesn't create any other side-effect
-          // because we are preventing default in `onPointerDown` so effectively
+          // because we are preventing default in `onMouseDown` so effectively
           // this only runs for a label 'click'
           (event?.currentTarget as HTMLElement)?.focus();
         }
@@ -97,9 +97,16 @@ function handlePointerOpen(event: PointerEvent) {
           // but not when the control key is pressed (avoiding MacOS right click)
           if (event.button === 0 && event.ctrlKey === false) {
             handlePointerOpen(event)
-            // prevent trigger from stealing focus from the active item after opening.
-            event.preventDefault();
           }
+        }
+      "
+      @mousedown="
+        (event: MouseEvent) => {
+          // Prevent trigger from stealing focus from the active item after opening.
+          // We avoid calling `preventDefault` in `pointerdown` because that suppresses
+          // compatibility mouse events (`mousedown`, `mouseup`, `click`).
+          if (event.button === 0 && event.ctrlKey === false)
+            event.preventDefault();
         }
       "
       @pointerup.prevent="

--- a/packages/core/src/Select/SelectTrigger.vue
+++ b/packages/core/src/Select/SelectTrigger.vue
@@ -47,6 +47,10 @@ function handlePointerOpen(event: PointerEvent) {
     y: Math.round(event.pageY),
   }
 }
+
+function isCtrlLeftClick(event: MouseEvent) {
+  return event.button === 0 && event.ctrlKey === false
+}
 </script>
 
 <template>
@@ -95,7 +99,7 @@ function handlePointerOpen(event: PointerEvent) {
 
           // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
           // but not when the control key is pressed (avoiding MacOS right click)
-          if (event.button === 0 && event.ctrlKey === false) {
+          if (isCtrlLeftClick(event)) {
             handlePointerOpen(event)
           }
         }
@@ -105,8 +109,9 @@ function handlePointerOpen(event: PointerEvent) {
           // Prevent trigger from stealing focus from the active item after opening.
           // We avoid calling `preventDefault` in `pointerdown` because that suppresses
           // compatibility mouse events (`mousedown`, `mouseup`, `click`).
-          if (event.button === 0 && event.ctrlKey === false)
+          if (isCtrlLeftClick(event)) {
             event.preventDefault();
+          }
         }
       "
       @pointerup.prevent="


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Resolves #1773
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#### Issue
`SelectTrigger` opens the select on `pointerdown` and was calling `event.preventDefault()` there to stop the trigger from taking focus away from the highlighted item in the listbox.

Per the [Pointer Events spec](https://www.w3.org/TR/pointerevents3/), calling `preventDefault()` on `pointerdown` cancels the compatibility mouse events that follow — `mousedown`, `mouseup`, and `click`.

#### Fix
Focus prevention was moved from `pointerdown` to `mousedown`:

- `pointerdown` — still opens the select, but no longer calls `preventDefault()`, so the browser emits `mousedown`.
- `mousedown` — calls `preventDefault()` under the same conditions (left click, no Ctrl) to keep the trigger from stealing focus.

Global mousedown listeners (including capture-phase ones on window) now fire before the trigger’s own mousedown handler runs.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Select trigger interactions to prevent unwanted focus and accidental openings (better handling of left-click vs touch and modifier-key clicks).
* **Tests**
  * Added mouse-interaction tests ensuring correct focus behavior, event propagation, and opening behavior across click/pointer sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->