### PR TITLE
ci(docs): publish docs on release tag instead of every docs push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,8 +2,9 @@ name: Publish Docs
 
 on:
   push:
-    paths:
-      - 'docs/**'
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## What

Changes the Docs publish workflow trigger so docs deploy **on release tags + a manual button**, instead of on every push touching `docs/**`.

```yaml
on:
  push:
    tags:
      - 'v*'
  workflow_dispatch:
```

## Why

Docs deploy was push-driven (`paths: docs/**`, no branch filter) while the npm release is tag-driven. That mismatch meant merging a feature's docs into `v2` published them to production **before** the npm release shipped — showing unreleased features in the docs.

## Behavior after this change

| Action | Result |
|---|---|
| Merge feature + docs into `v2` | Nothing publishes — waits for release |
| Tag `v2.10.0` | Docs deploy in lockstep with the npm release |
| Docs-only fix, no release | **Actions → Run workflow** (workflow_dispatch) |

> Note: the manual button deploys `v2` HEAD, so only use it when HEAD matches the last release; otherwise cut a patch tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation publishing process to trigger on version releases rather than documentation folder changes. Manual publishing is now also supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->