### PR TITLE
fix(AlertDialog): preserve default pointer events lock

### DIFF
--- a/packages/core/src/AlertDialog/AlertDialog.test.ts
+++ b/packages/core/src/AlertDialog/AlertDialog.test.ts
@@ -1,7 +1,7 @@
 import type { VueWrapper } from '@vue/test-utils'
-import { findAllByText, findByText, fireEvent } from '@testing-library/vue'
+import { findAllByText, findByRole, findByText, fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
 import AlertDialog from './story/_AlertDialog.vue'
@@ -13,6 +13,12 @@ describe('given a default Dialog', async () => {
   beforeEach(async () => {
     wrapper = mount(AlertDialog, { attachTo: document.body })
     trigger = await findByText(wrapper.element as HTMLElement, 'Open')
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+    document.body.innerHTML = ''
+    document.body.style.cssText = ''
   })
 
   it('should pass axe accessibility tests', async () => {
@@ -36,6 +42,13 @@ describe('given a default Dialog', async () => {
     it('should focus the cancel button', async () => {
       const cancelButton = await findAllByText(document.body, 'Cancel')
       expect(cancelButton.at(-1)).toBe(document.activeElement)
+    })
+
+    it('should keep content interactive while body pointer events are locked', async () => {
+      const content = await findByRole(document.body, 'alertdialog')
+
+      expect(document.body.style.pointerEvents).toBe('none')
+      expect(content.style.pointerEvents).toBe('auto')
     })
   })
 })

--- a/packages/core/src/AlertDialog/AlertDialogContent.vue
+++ b/packages/core/src/AlertDialog/AlertDialogContent.vue
@@ -20,7 +20,12 @@ export interface AlertDialogContentProps extends DialogContentProps {}
 import { nextTick, ref } from 'vue'
 import { DialogContent } from '@/Dialog'
 
-const props = defineProps<AlertDialogContentProps>()
+const props = withDefaults(defineProps<AlertDialogContentProps>(), {
+  // Keep `undefined` (instead of Vue's boolean coercion to `false`) so
+  // DialogContent can preserve the modal default while still honoring an
+  // explicit `:disable-outside-pointer-events="false"`.
+  disableOutsidePointerEvents: undefined,
+})
 const emits = defineEmits<AlertDialogContentEmits>()
 
 const emitsAsProps = useEmitAsProps(emits)


### PR DESCRIPTION
## Summary

This plugs the same boolean-default hole in `AlertDialogContent` that `DialogContent` already fixed in #2679 🧩✨ Without it, the wrapper accidentally forwards an absent `disableOutsidePointerEvents` prop as `false`, so alert dialogs with an overlay can open with the body locked while the content itself stays non-interactive 😬

- 🐛 Preserve `undefined` for absent `disableOutsidePointerEvents` on `AlertDialogContent`, letting `DialogContentModal` keep its default lock behavior
- ✅ Add regression coverage that confirms alert dialog content receives `pointer-events: auto` while the body remains locked
- 🧹 Clean up the alert dialog test mount between cases so teleported layers do not stack up and muddy pointer-event assertions

## Why

`DialogContent` now avoids Vue's boolean prop coercion by defaulting `disableOutsidePointerEvents` to `undefined`. `AlertDialogContent` extends the same props, but still used plain `defineProps`, so Vue coerced the missing prop to `false` before forwarding it downstream.

That means `DialogContentModal` never gets to apply its default `true`, and `DismissableLayer` does not mark the active alert dialog content as pointer-interactive. The body can still be locked by the overlay path, leaving the visible buttons looking fine but unable to receive real browser clicks 🧊

This is a small follow-up to #2677 / #2679.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added cleanup hooks and pointer-event behavior validation to AlertDialog test suite.

* **Bug Fixes**
  * Improved AlertDialog pointer-event handling to properly respect component prop configurations while maintaining expected modal interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->