### PR TITLE
test(shared): add characterization tests for core composables and Collection

### DIFF
--- a/packages/core/src/Collection/Collection.test.ts
+++ b/packages/core/src/Collection/Collection.test.ts
@@ -1,0 +1,180 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, nextTick, reactive } from 'vue'
+import { useCollection } from './Collection'
+
+// Characterization tests for `useCollection`.
+// These assert on the RETURNED values/order of `getItems()`, `reactiveItems`
+// and `itemMapSize` so they act as a safety net for a future `getItems()`
+// rewrite, rather than locking in implementation details.
+
+interface ItemConfig {
+  value: string
+  disabled?: boolean
+}
+
+// Builds a parent component that acts as the collection provider and renders
+// a `CollectionSlot` wrapping a `CollectionItem` per entry in `items`.
+//
+// Wiring notes:
+// - `useCollection({ isProvider: true })` runs `provide()`, the renderless
+//   `CollectionItem`s `inject()` the same context (same `setup`/`useCollection`
+//   call here returns those components, so they share `context`).
+// - `Slot` (used by both `CollectionSlot` and `CollectionItem`) requires a
+//   single root element child to forward its ref onto, so:
+//     * `CollectionSlot` wraps the items in a single `<div>` root.
+//     * each `CollectionItem` renders a single `<div>` child.
+// - `attachTo: document.body` is required because `getItems()` orders by DOM
+//   order via `querySelectorAll`, which needs a connected document.
+function createWrapper(initialItems: ItemConfig[]) {
+  // Reactive so tests can mutate (e.g. remove an item) and re-render.
+  const items = reactive<ItemConfig[]>([...initialItems])
+
+  let collection!: ReturnType<typeof useCollection>
+
+  const Parent = defineComponent({
+    setup() {
+      collection = useCollection({ key: 'test', isProvider: true })
+      const { CollectionSlot, CollectionItem } = collection
+
+      return () =>
+        h(CollectionSlot, null, {
+          default: () =>
+            h(
+              'div',
+              { 'data-testid': 'collection-root' },
+              items.map(item =>
+                h(
+                  CollectionItem,
+                  { key: item.value, value: item.value },
+                  {
+                    default: () =>
+                      h('div', {
+                        'data-testid': item.value,
+                        // When disabled, expose `data-disabled=""` on the real
+                        // element so `ref.dataset.disabled === ''`.
+                        ...(item.disabled ? { 'data-disabled': '' } : {}),
+                      }, item.value),
+                  },
+                ),
+              ),
+            ),
+        })
+    },
+  })
+
+  const wrapper = mount(Parent, { attachTo: document.body })
+
+  return {
+    wrapper,
+    items,
+    getCollection: () => collection,
+  }
+}
+
+describe('useCollection', () => {
+  it('registers items into reactiveItems and itemMapSize reflects the count', async () => {
+    const { getCollection, wrapper } = createWrapper([
+      { value: 'a' },
+      { value: 'b' },
+      { value: 'c' },
+    ])
+    await nextTick()
+
+    const { reactiveItems, itemMapSize } = getCollection()
+
+    expect(itemMapSize.value).toBe(3)
+    expect(reactiveItems.value).toHaveLength(3)
+    expect(reactiveItems.value.map(i => i.value).sort()).toEqual(['a', 'b', 'c'])
+
+    wrapper.unmount()
+  })
+
+  it('getItems() returns items in DOM order even when registration order differs', async () => {
+    // Registration order (watchEffect firing) is not guaranteed to match DOM
+    // order. `getItems()` sorts by `querySelectorAll` DOM order, so the result
+    // must follow the template/DOM order regardless.
+    const { getCollection, wrapper } = createWrapper([
+      { value: 'first' },
+      { value: 'second' },
+      { value: 'third' },
+    ])
+    await nextTick()
+
+    const { getItems } = getCollection()
+    expect(getItems().map(i => i.value)).toEqual(['first', 'second', 'third'])
+
+    // Sanity-check ordering reflects actual DOM order.
+    const rendered = Array.from(
+      document.querySelectorAll('[data-reka-collection-item]'),
+    ).map(el => (el as HTMLElement).dataset.testid)
+    expect(getItems().map(i => i.value)).toEqual(rendered)
+
+    wrapper.unmount()
+  })
+
+  it('filters out items with data-disabled="" by default, includes them with getItems(true)', async () => {
+    const { getCollection, wrapper } = createWrapper([
+      { value: 'a' },
+      { value: 'b', disabled: true },
+      { value: 'c' },
+    ])
+    await nextTick()
+
+    const { getItems } = getCollection()
+
+    // Disabled item excluded by default.
+    expect(getItems().map(i => i.value)).toEqual(['a', 'c'])
+
+    // Included (in DOM order) when requested.
+    expect(getItems(true).map(i => i.value)).toEqual(['a', 'b', 'c'])
+
+    wrapper.unmount()
+  })
+
+  it('removes an item from the map when it unmounts', async () => {
+    const { getCollection, items, wrapper } = createWrapper([
+      { value: 'a' },
+      { value: 'b' },
+      { value: 'c' },
+    ])
+    await nextTick()
+
+    const { getItems, itemMapSize } = getCollection()
+    expect(itemMapSize.value).toBe(3)
+    expect(getItems().map(i => i.value)).toEqual(['a', 'b', 'c'])
+
+    // Remove the middle item, triggering CollectionItem unmount + cleanup.
+    const idx = items.findIndex(i => i.value === 'b')
+    items.splice(idx, 1)
+    await nextTick()
+
+    expect(itemMapSize.value).toBe(2)
+    expect(getItems().map(i => i.value)).toEqual(['a', 'c'])
+
+    wrapper.unmount()
+  })
+
+  it('getItems() returns [] when no CollectionSlot element is mounted', async () => {
+    // A provider context whose `collectionRef` is never set (no CollectionSlot
+    // currentElement). `getItems()` short-circuits to `[]`.
+    let collection!: ReturnType<typeof useCollection>
+
+    const Parent = defineComponent({
+      setup() {
+        collection = useCollection({ key: 'empty', isProvider: true })
+        // Render nothing collection-related: no CollectionSlot is mounted.
+        return () => h('div', 'no-collection')
+      },
+    })
+
+    const wrapper = mount(Parent, { attachTo: document.body })
+    await nextTick()
+
+    expect(collection.getItems()).toEqual([])
+    expect(collection.getItems(true)).toEqual([])
+    expect(collection.itemMapSize.value).toBe(0)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/core/src/shared/useGraceArea.test.ts
+++ b/packages/core/src/shared/useGraceArea.test.ts
@@ -1,0 +1,180 @@
+import type { Ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { useGraceArea } from './useGraceArea'
+
+// Characterization tests for `useGraceArea`.
+//
+// `useGraceArea(triggerElement, containerElement)` builds a convex-hull "grace
+// polygon" out of the two elements' bounding boxes whenever the pointer leaves
+// one of them (a `pointerleave`). While the pointer stays inside that polygon
+// `isPointerInTransit` stays `true`; once the pointer moves outside the polygon
+// (tracked via a document `pointermove` listener) it fires `onPointerExit` and
+// resets the state. There's also a 300ms auto-reset and an unmount reset.
+//
+// Geometry note (precomputed):
+//   trigger rect:   top:0  left:0   right:100 bottom:100  (100x100)
+//   container rect: top:0  left:200 right:300 bottom:100  (100x100)
+//   A `pointerleave` on the trigger at (100,50) exits the 'right' side; the
+//   padded exit points sit near (99,49)/(99,51) and the resulting hull spans
+//   x in [99,300]. So (150,50) is inside the hull and (150,500) is outside.
+//
+// jsdom note: `getBoundingClientRect` returns all-zero rects, so we stub it per
+// element. jsdom does provide `PointerEvent`; we fall back to `MouseEvent`
+// (which also carries clientX/clientY) if it ever doesn't.
+
+function makeRect(rect: Partial<DOMRect>): DOMRect {
+  return {
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+    ...rect,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+function pointerEvent(type: string, init: { clientX?: number, clientY?: number, bubbles?: boolean }) {
+  const Ctor = typeof PointerEvent !== 'undefined' ? PointerEvent : MouseEvent
+  return new Ctor(type, { bubbles: true, ...init }) as PointerEvent
+}
+
+interface Harness {
+  isPointerInTransit: Ref<boolean>
+  onPointerExit: ReturnType<typeof useGraceArea>['onPointerExit']
+}
+
+function mountGraceArea(trigger: HTMLElement, container: HTMLElement) {
+  const result: { value: Harness | null } = { value: null }
+  const wrapper = mount({
+    template: '<p>grace</p>',
+    setup() {
+      // Refs are initialised to the (already mounted) elements so that the
+      // first `watchEffect` registers the `pointerleave` listeners immediately.
+      const triggerRef = ref(trigger) as Ref<HTMLElement | undefined>
+      const containerRef = ref(container) as Ref<HTMLElement | undefined>
+      const api = useGraceArea(triggerRef, containerRef)
+      result.value = api
+      return api
+    },
+  }, { attachTo: document.body })
+
+  return { wrapper, api: result.value as Harness }
+}
+
+describe('useGraceArea', () => {
+  let trigger: HTMLElement
+  let container: HTMLElement
+  let wrapper: ReturnType<typeof mountGraceArea>['wrapper'] | null
+
+  function setup() {
+    trigger = document.createElement('div')
+    container = document.createElement('div')
+    document.body.appendChild(trigger)
+    document.body.appendChild(container)
+
+    trigger.getBoundingClientRect = () =>
+      makeRect({ top: 0, left: 0, right: 100, bottom: 100, width: 100, height: 100, x: 0, y: 0 })
+    container.getBoundingClientRect = () =>
+      makeRect({ top: 0, left: 200, right: 300, bottom: 100, width: 100, height: 100, x: 200, y: 0 })
+
+    const mounted = mountGraceArea(trigger, container)
+    wrapper = mounted.wrapper
+    return mounted.api
+  }
+
+  afterEach(() => {
+    vi.useRealTimers()
+    wrapper?.unmount()
+    wrapper = null
+    trigger?.remove()
+    container?.remove()
+  })
+
+  it('sets isPointerInTransit to true on a trigger pointerleave', () => {
+    const api = setup()
+    expect(api.isPointerInTransit.value).toBe(false)
+
+    trigger.dispatchEvent(pointerEvent('pointerleave', { clientX: 100, clientY: 50 }))
+
+    expect(api.isPointerInTransit.value).toBe(true)
+  })
+
+  it('keeps isPointerInTransit true and does not fire exit for a pointermove inside the hull', async () => {
+    const api = setup()
+    const exitSpy = vi.fn()
+    api.onPointerExit(exitSpy)
+
+    trigger.dispatchEvent(pointerEvent('pointerleave', { clientX: 100, clientY: 50 }))
+    // Let the second watchEffect register the document `pointermove` listener.
+    await nextTick()
+
+    // (150,50) is inside the hull. Dispatch from `document.body` so the target
+    // is NOT inside trigger/container (avoids the "entered target" branch).
+    document.body.dispatchEvent(pointerEvent('pointermove', { clientX: 150, clientY: 50 }))
+
+    expect(api.isPointerInTransit.value).toBe(true)
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('fires onPointerExit and resets when a pointermove leaves the hull', async () => {
+    const api = setup()
+    const exitSpy = vi.fn()
+    api.onPointerExit(exitSpy)
+
+    trigger.dispatchEvent(pointerEvent('pointerleave', { clientX: 100, clientY: 50 }))
+    await nextTick()
+
+    // (150,500) is well outside the hull.
+    document.body.dispatchEvent(pointerEvent('pointermove', { clientX: 150, clientY: 500 }))
+
+    expect(exitSpy).toHaveBeenCalledTimes(1)
+    expect(api.isPointerInTransit.value).toBe(false)
+  })
+
+  it('removes the grace area without firing exit when the pointer enters the container', async () => {
+    const api = setup()
+    const exitSpy = vi.fn()
+    api.onPointerExit(exitSpy)
+
+    trigger.dispatchEvent(pointerEvent('pointerleave', { clientX: 100, clientY: 50 }))
+    await nextTick()
+    expect(api.isPointerInTransit.value).toBe(true)
+
+    // Dispatch on the container so `event.target` is the container element and
+    // `containerElement.contains(target)` is true -> "entered target" branch.
+    // The coordinates would otherwise be outside the hull, proving the
+    // hasEnteredTarget branch wins.
+    container.dispatchEvent(pointerEvent('pointermove', { clientX: 150, clientY: 500 }))
+
+    expect(exitSpy).not.toHaveBeenCalled()
+    expect(api.isPointerInTransit.value).toBe(false)
+  })
+
+  it('auto-resets isPointerInTransit after 300ms', () => {
+    vi.useFakeTimers()
+    const api = setup()
+
+    trigger.dispatchEvent(pointerEvent('pointerleave', { clientX: 100, clientY: 50 }))
+    expect(api.isPointerInTransit.value).toBe(true)
+
+    vi.advanceTimersByTime(300)
+    expect(api.isPointerInTransit.value).toBe(false)
+  })
+
+  it('resets isPointerInTransit to false on unmount', () => {
+    const api = setup()
+
+    trigger.dispatchEvent(pointerEvent('pointerleave', { clientX: 100, clientY: 50 }))
+    expect(api.isPointerInTransit.value).toBe(true)
+
+    wrapper?.unmount()
+    wrapper = null
+    expect(api.isPointerInTransit.value).toBe(false)
+  })
+})

--- a/packages/core/src/shared/useSelectionBehavior.test.ts
+++ b/packages/core/src/shared/useSelectionBehavior.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest'
+import { reactive, ref } from 'vue'
+import { findValuesBetween } from './arrays'
+import { useSelectionBehavior } from './useSelectionBehavior'
+
+// Helper to build a fake getItems() entry with a real `dataset` (via a DOM element),
+// matching the shape `handleMultipleReplace` expects: `{ ref: HTMLElement, value?: any }`.
+// dataset.disabled is left undefined (i.e. NOT '') so the item survives the source filter.
+function createItem(value: any) {
+  const el = document.createElement('div')
+  return { ref: el, value }
+}
+
+describe('useSelectionBehavior', () => {
+  describe('onSelectItem - multiple + toggle', () => {
+    it('adds the value when condition matches nothing', () => {
+      const modelValue = ref<number[]>([1, 2])
+      const props = reactive({ multiple: true, selectionBehavior: 'toggle' as const })
+      const { onSelectItem } = useSelectionBehavior(modelValue, props)
+
+      onSelectItem(3, v => v === 3)
+      expect(modelValue.value).toEqual([1, 2, 3])
+    })
+
+    it('removes the matched index and preserves other entries', () => {
+      const modelValue = ref<number[]>([1, 2, 3])
+      const props = reactive({ multiple: true, selectionBehavior: 'toggle' as const })
+      const { onSelectItem } = useSelectionBehavior(modelValue, props)
+
+      onSelectItem(2, v => v === 2)
+      expect(modelValue.value).toEqual([1, 3])
+    })
+  })
+
+  describe('onSelectItem - multiple + replace', () => {
+    it('replaces modelValue with [val] and sets firstValue to val', () => {
+      const modelValue = ref<number[]>([1, 2, 3])
+      const props = reactive({ multiple: true, selectionBehavior: 'replace' as const })
+      const { onSelectItem, firstValue } = useSelectionBehavior(modelValue, props)
+
+      onSelectItem(9, () => false)
+      expect(modelValue.value).toEqual([9])
+      expect(firstValue.value).toBe(9)
+    })
+  })
+
+  describe('onSelectItem - single + toggle', () => {
+    it('sets { ...val } when selecting a non-matching value', () => {
+      const modelValue = ref<any>({ id: 1 })
+      const props = reactive({ multiple: false, selectionBehavior: 'toggle' as const })
+      const { onSelectItem } = useSelectionBehavior(modelValue, props)
+
+      const val = { id: 2 }
+      onSelectItem(val, existing => existing?.id === val.id)
+      expect(modelValue.value).toEqual({ id: 2 })
+    })
+
+    it('clears to undefined when the current value matches condition', () => {
+      const current = { id: 1 }
+      const modelValue = ref<any>(current)
+      const props = reactive({ multiple: false, selectionBehavior: 'toggle' as const })
+      const { onSelectItem } = useSelectionBehavior(modelValue, props)
+
+      // condition is evaluated against the *existing* modelValue (the currently selected one).
+      onSelectItem({ id: 1 }, existing => existing?.id === 1)
+      expect(modelValue.value).toBeUndefined()
+    })
+  })
+
+  describe('onSelectItem - single + replace', () => {
+    it('always sets { ...val }', () => {
+      const modelValue = ref<any>({ id: 1 })
+      const props = reactive({ multiple: false, selectionBehavior: 'replace' as const })
+      const { onSelectItem } = useSelectionBehavior(modelValue, props)
+
+      onSelectItem({ id: 5 }, () => true)
+      expect(modelValue.value).toEqual({ id: 5 })
+    })
+  })
+
+  describe('onSelectItem - spread characterization', () => {
+    // NOTE: In the single-select branches the source assigns `{ ...val }`, producing a
+    // shallow COPY rather than the same object reference. This is intentional current
+    // behavior and is characterized here as-is (asserting toEqual but not toBe).
+    it('single + replace assigns a copy of val, not the same reference', () => {
+      const modelValue = ref<any>(undefined)
+      const props = reactive({ multiple: false, selectionBehavior: 'replace' as const })
+      const { onSelectItem } = useSelectionBehavior(modelValue, props)
+
+      const val = { id: 7, nested: { a: 1 } }
+      onSelectItem(val, () => true)
+      expect(modelValue.value).toEqual(val)
+      expect(modelValue.value).not.toBe(val)
+    })
+
+    it('single + toggle (non-matching) assigns a copy of val, not the same reference', () => {
+      const modelValue = ref<any>({ id: 1 })
+      const props = reactive({ multiple: false, selectionBehavior: 'toggle' as const })
+      const { onSelectItem } = useSelectionBehavior(modelValue, props)
+
+      const val = { id: 8 }
+      onSelectItem(val, () => false)
+      expect(modelValue.value).toEqual(val)
+      expect(modelValue.value).not.toBe(val)
+    })
+  })
+
+  describe('handleMultipleReplace - early returns (no change)', () => {
+    it('returns early when firstValue is unset', () => {
+      const modelValue = ref<number[]>([1, 2, 3])
+      const props = reactive({ multiple: true, selectionBehavior: 'replace' as const })
+      const { handleMultipleReplace } = useSelectionBehavior(modelValue, props)
+
+      const items = [createItem(1), createItem(2), createItem(3)]
+      // firstValue never set -> early return, modelValue untouched.
+      handleMultipleReplace('next', items[2].ref, () => items, [1, 2, 3])
+      expect(modelValue.value).toEqual([1, 2, 3])
+    })
+
+    it('returns early when multiple is false', () => {
+      const modelValue = ref<any>([1, 2, 3])
+      const props = reactive({ multiple: false, selectionBehavior: 'replace' as const })
+      const { handleMultipleReplace } = useSelectionBehavior(modelValue, props)
+
+      const items = [createItem(1), createItem(2), createItem(3)]
+      // The `!props.multiple` guard short-circuits before firstValue matters.
+      handleMultipleReplace('next', items[2].ref, () => items, [1, 2, 3])
+      expect(modelValue.value).toEqual([1, 2, 3])
+    })
+
+    it('returns early when modelValue is not an array', () => {
+      const modelValue = ref<any>([1, 2, 3])
+      const props = reactive({ multiple: true, selectionBehavior: 'replace' as const })
+      const { onSelectItem, handleMultipleReplace } = useSelectionBehavior(modelValue, props)
+
+      // Set firstValue via a multiple+replace selection (also makes modelValue = [1]).
+      onSelectItem(1, () => false)
+      // Now make modelValue a non-array; handleMultipleReplace must bail.
+      modelValue.value = { id: 1 }
+
+      const items = [createItem(1), createItem(2), createItem(3)]
+      handleMultipleReplace('next', items[2].ref, () => items, [1, 2, 3])
+      expect(modelValue.value).toEqual({ id: 1 })
+    })
+  })
+
+  describe('handleMultipleReplace - range selection', () => {
+    const options = [10, 20, 30, 40, 50]
+
+    function setup() {
+      const modelValue = ref<any>([])
+      const props = reactive({ multiple: true, selectionBehavior: 'replace' as const })
+      const api = useSelectionBehavior(modelValue, props)
+      // Selecting under replace sets firstValue (and modelValue = [10]).
+      api.onSelectItem(10, () => false)
+      const items = options.map(createItem)
+      const getItems = () => items
+      return { modelValue, items, getItems, handleMultipleReplace: api.handleMultipleReplace }
+    }
+
+    it('\'next\' sets modelValue to the inclusive range firstValue..lastValue', () => {
+      const { modelValue, items, getItems, handleMultipleReplace } = setup()
+      // currentElement = item whose value is 40 (firstValue is 10).
+      const currentElement = items.find(i => i.value === 40)!.ref
+      handleMultipleReplace('next', currentElement, getItems, options)
+      expect(modelValue.value).toEqual(findValuesBetween(options, 10, 40))
+      expect(modelValue.value).toEqual([10, 20, 30, 40])
+    })
+
+    it('\'prev\' sets modelValue to the inclusive range firstValue..lastValue', () => {
+      const { modelValue, items, getItems, handleMultipleReplace } = setup()
+      const currentElement = items.find(i => i.value === 30)!.ref
+      handleMultipleReplace('prev', currentElement, getItems, options)
+      expect(modelValue.value).toEqual(findValuesBetween(options, 10, 30))
+      expect(modelValue.value).toEqual([10, 20, 30])
+    })
+
+    it('\'first\' selects from firstValue back to options[0]', () => {
+      const { modelValue, items, getItems, handleMultipleReplace } = setup()
+      // 'first' uses options[0] as the range end (currentElement value is ignored for the
+      // range), but currentElement must still match an item to pass the lastValue guard.
+      const currentElement = items.find(i => i.value === 50)!.ref
+      handleMultipleReplace('first', currentElement, getItems, options)
+      expect(modelValue.value).toEqual(findValuesBetween(options, 10, options[0]))
+      expect(modelValue.value).toEqual([10])
+    })
+
+    it('\'last\' selects from firstValue to options.at(-1)', () => {
+      const { modelValue, items, getItems, handleMultipleReplace } = setup()
+      const currentElement = items.find(i => i.value === 50)!.ref
+      handleMultipleReplace('last', currentElement, getItems, options)
+      expect(modelValue.value).toEqual(findValuesBetween(options, 10, options.at(-1)))
+      expect(modelValue.value).toEqual([10, 20, 30, 40, 50])
+    })
+  })
+})
+
+// `vi` is imported explicitly per repo test convention. These characterization tests
+// exercise pure composable logic and need no mocks/spies, so it is referenced here.
+void vi

--- a/packages/core/src/shared/useTypeahead.test.ts
+++ b/packages/core/src/shared/useTypeahead.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getNextMatch, useTypeahead, wrapArray } from './useTypeahead'
+
+function createItem(textContent: string, value?: any) {
+  const ref = document.createElement('div')
+  ref.textContent = textContent
+  return { ref, value }
+}
+
+describe('wrapArray', () => {
+  it('wraps the array around itself at the given start index', () => {
+    expect(wrapArray(['a', 'b', 'c', 'd'], 2)).toEqual(['c', 'd', 'a', 'b'])
+  })
+
+  it('returns the same order when start index is 0', () => {
+    expect(wrapArray(['a', 'b', 'c', 'd'], 0)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('handles start index larger than length via modulo', () => {
+    expect(wrapArray(['a', 'b', 'c', 'd'], 5)).toEqual(['b', 'c', 'd', 'a'])
+  })
+})
+
+describe('getNextMatch', () => {
+  it('matches a basic prefix', () => {
+    expect(getNextMatch(['Apple', 'Banana', 'Cherry'], 'b')).toBe('Banana')
+  })
+
+  it('matches case-insensitively', () => {
+    expect(getNextMatch(['Apple', 'Banana', 'Cherry'], 'B')).toBe('Banana')
+    expect(getNextMatch(['apple', 'banana', 'cherry'], 'BA')).toBe('banana')
+  })
+
+  it('cycles to the NEXT value on repeated-character search, excluding current match', () => {
+    // 'aa' normalizes to 'a' (single char => exclude current match)
+    expect(
+      getNextMatch(['Apple', 'Avocado', 'Banana'], 'aa', 'Apple'),
+    ).toBe('Avocado')
+  })
+
+  it('searches forward from the current match and wraps past the end of the array', () => {
+    // current match is 'Cherry' (last). Searching 'a' should wrap around to 'Apple'
+    expect(
+      getNextMatch(['Apple', 'Banana', 'Cherry'], 'a', 'Cherry'),
+    ).toBe('Apple')
+  })
+
+  it('returns undefined when nothing matches', () => {
+    expect(getNextMatch(['Apple', 'Banana', 'Cherry'], 'z')).toBeUndefined()
+  })
+
+  it('returns undefined when the only match IS the current match', () => {
+    // Only 'Apple' starts with 'a'; it is the current match so focus should not move.
+    expect(
+      getNextMatch(['Apple', 'Banana', 'Cherry'], 'a', 'Apple'),
+    ).toBeUndefined()
+  })
+
+  it('does not exclude the current match for multi-character (non-repeated) searches', () => {
+    // 'ap' is length 2 and not repeated => current match is NOT excluded,
+    // so a still-matching current match stays put (returns undefined).
+    expect(
+      getNextMatch(['Apple', 'Apricot', 'Banana'], 'ap', 'Apple'),
+    ).toBeUndefined()
+  })
+})
+
+describe('useTypeahead', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('focuses the matching element when typing', () => {
+    vi.useFakeTimers()
+    const { handleTypeaheadSearch } = useTypeahead()
+
+    const apple = createItem('Apple')
+    const banana = createItem('Banana')
+    const cherry = createItem('Cherry')
+    apple.ref.focus = vi.fn()
+    banana.ref.focus = vi.fn()
+    cherry.ref.focus = vi.fn()
+
+    const result = handleTypeaheadSearch('b', [apple, banana, cherry])
+
+    expect(banana.ref.focus).toHaveBeenCalledTimes(1)
+    expect(apple.ref.focus).not.toHaveBeenCalled()
+    expect(result).toBe(banana.ref)
+  })
+
+  it('focuses via document.activeElement when elements are attached to the body', () => {
+    vi.useFakeTimers()
+    const { handleTypeaheadSearch } = useTypeahead()
+
+    const apple = createItem('Apple')
+    const banana = createItem('Banana')
+    apple.ref.tabIndex = -1
+    banana.ref.tabIndex = -1
+    document.body.appendChild(apple.ref)
+    document.body.appendChild(banana.ref)
+
+    handleTypeaheadSearch('b', [apple, banana])
+    expect(document.activeElement).toBe(banana.ref)
+  })
+
+  it('uses item.value.textValue with precedence over textContent', () => {
+    vi.useFakeTimers()
+    const { handleTypeaheadSearch } = useTypeahead()
+
+    // textContent says 'Zzz' but textValue says 'Banana'
+    const apple = createItem('Apple', { textValue: 'Apple' })
+    const banana = createItem('Zzz', { textValue: 'Banana' })
+    apple.ref.focus = vi.fn()
+    banana.ref.focus = vi.fn()
+
+    const result = handleTypeaheadSearch('b', [apple, banana])
+
+    expect(banana.ref.focus).toHaveBeenCalledTimes(1)
+    expect(result).toBe(banana.ref)
+  })
+
+  it('accumulates the search buffer across calls', () => {
+    vi.useFakeTimers()
+    const { handleTypeaheadSearch, search } = useTypeahead()
+
+    const apple = createItem('Apple')
+    const banana = createItem('Banana')
+    apple.ref.focus = vi.fn()
+    banana.ref.focus = vi.fn()
+    const items = [apple, banana]
+
+    // 'b' matches Banana
+    handleTypeaheadSearch('b', items)
+    expect(search.value).toBe('b')
+    // buffer becomes 'ba' which still matches Banana (not Apple)
+    const result = handleTypeaheadSearch('a', items)
+    expect(search.value).toBe('ba')
+    expect(result).toBe(banana.ref)
+  })
+
+  it('resets the search buffer after 1000ms', () => {
+    vi.useFakeTimers()
+    const { handleTypeaheadSearch, search } = useTypeahead()
+
+    const apple = createItem('Apple')
+    apple.ref.focus = vi.fn()
+
+    handleTypeaheadSearch('a', [apple])
+    expect(search.value).toBe('a')
+
+    vi.advanceTimersByTime(1000)
+    expect(search.value).toBe('')
+  })
+
+  it('resetTypeahead clears the buffer immediately', () => {
+    vi.useFakeTimers()
+    const { handleTypeaheadSearch, resetTypeahead, search } = useTypeahead()
+
+    const apple = createItem('Apple')
+    apple.ref.focus = vi.fn()
+
+    handleTypeaheadSearch('a', [apple])
+    expect(search.value).toBe('a')
+
+    resetTypeahead()
+    expect(search.value).toBe('')
+  })
+
+  it('invokes the callback with the key and does NOT focus when a callback is provided', () => {
+    vi.useFakeTimers()
+    const callback = vi.fn()
+    const { handleTypeaheadSearch, search } = useTypeahead(callback)
+
+    const apple = createItem('Apple')
+    const banana = createItem('Banana')
+    apple.ref.focus = vi.fn()
+    banana.ref.focus = vi.fn()
+
+    const result = handleTypeaheadSearch('b', [apple, banana])
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith('b')
+    expect(apple.ref.focus).not.toHaveBeenCalled()
+    expect(banana.ref.focus).not.toHaveBeenCalled()
+    // search buffer is still updated even though no focusing happens
+    expect(search.value).toBe('b')
+    // NOTE: when a callback is provided, handleTypeaheadSearch returns undefined
+    // (the focusing branch that returns an element ref is skipped entirely).
+    expect(result).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Locks in current behavior of four previously **untested** pieces of core infrastructure ahead of the planned `Collection.getItems()` optimization. Purely additive — **no source files changed**.

- `useTypeahead` — pure `wrapArray`/`getNextMatch` helpers + DOM typeahead focus (17 tests)
- `useSelectionBehavior` — single/multiple × toggle/replace + `handleMultipleReplace` ranges (15 tests)
- `Collection` — DOM-ordered `getItems`, disabled filtering, unmount cleanup, empty-collection (5 tests)
- `useGraceArea` — pointer grace-polygon transit, inside/outside hull, exit, auto-reset, unmount (6 tests)

**43 tests total.** These characterize the *current* behavior, including intentional oddities (e.g. the `{ ...val }` spread in `useSelectionBehavior` single-select), documented with `// NOTE:` comments — they are not fixed here.

## Test Plan

- [x] `pnpm --filter reka-ui exec vitest run` → 84 files, 1766 passed | 3 skipped (no existing suite broken)
- [x] `pnpm --filter reka-ui type-check` → exit 0
- [x] `pnpm lint` → exit 0
- [x] `git status` → only the 4 new test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for internal utility functions to enhance code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->