### PR TITLE
ci: reuse build artifact in size job and report test coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,14 +25,12 @@ jobs:
       - name: Build
         run: pnpm --filter reka-ui build
 
-      - name: Check for errors
-        run: |
-          if [ $? -eq 0 ]; then
-            echo "Build succeeded"
-          else
-            echo "Build failed"
-            exit 1
-          fi
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: reka-ui-dist
+          path: packages/core/dist
+          retention-days: 1
 
   test:
     needs: build
@@ -45,8 +43,16 @@ jobs:
       - name: Setup (Install node & pnpm)
         uses: ./.github/actions/setup
 
-      - name: Test
-        run: pnpm test
+      - name: Test (with coverage)
+        run: pnpm --filter reka-ui test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: packages/core/coverage
+          retention-days: 7
 
   size:
     needs: build
@@ -59,8 +65,11 @@ jobs:
       - name: Setup (Install node & pnpm)
         uses: ./.github/actions/setup
 
-      - name: Build
-        run: pnpm --filter reka-ui build
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: reka-ui-dist
+          path: packages/core/dist
 
       - name: Check bundle size
         run: pnpm --filter reka-ui size

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,9 @@ on:
     paths:
       - 'packages/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,6 +79,7 @@
     "watch": "tsdown --watch",
     "type-check": "vue-tsc -p tsconfig.check.json --noEmit",
     "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test-update": "vitest -u",
     "pub:release": "npm publish --access public --provenance",
     "size": "size-limit"


### PR DESCRIPTION
## Summary

Two independent inefficiencies in `.github/workflows/build.yaml`:

1. **Redundant build** — the `size` job declared `needs: build` but ran a second full `pnpm --filter reka-ui build` from scratch (~2–3 min wasted per PR). The `build` job now uploads `packages/core/dist` as the `reka-ui-dist` artifact and the `size` job downloads it instead of rebuilding. Also dropped the no-op `Check for errors` step (`$?` is always 0 after a fresh step).
2. **Coverage never reported** — `@vitest/coverage-istanbul` was configured in `vite.config.ts` but nothing ran it. Added a `test:coverage` script; the `test` job now runs `vitest run --coverage` and uploads the report as the `coverage-report` artifact. **Report-only** — no thresholds, no gating (maintainer can set floors later).

## Test Plan

- [x] `pnpm --filter reka-ui test:coverage` → exit 0, prints istanbul summary (Statements 90.7%), ~29s vs ~26s plain (well under 3×)
- [x] `packages/core/coverage` is git-ignored
- [x] Exactly 1 `pnpm --filter reka-ui build` invocation left in the workflow
- [x] Only `.github/workflows/build.yaml` + `packages/core/package.json` changed

> ⚠️ Full validation is the **first CI run** of this workflow — please confirm the `size` and `test` jobs both go green and the coverage artifact is produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI to cache and reuse built distribution artifacts across jobs, reducing redundant rebuilds.
  * Enhanced test coverage workflow with automated coverage uploads and reliable reporting regardless of test outcome.
  * Added a test coverage script to package configuration and configured artifact retention for build and coverage outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->