### PR TITLE
docs: add CONTRIBUTING.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # reka-ui — agent notes
 
-Vue 3 headless component library (port of Radix UI). pnpm monorepo. Node ≥ 22, pnpm 10.
+Vue 3 headless component library. pnpm monorepo. Node ≥ 22, pnpm 10.
 
 ## Commands (from repo root)
 - Install: `pnpm i`
@@ -24,6 +24,5 @@ Vue 3 headless component library (port of Radix UI). pnpm monorepo. Node ≥ 22,
 - Rendering: `Primitive` with `as` / `asChild`; expose refs via `useForwardExpose()`.
 - Tests: colocated `*.test.ts`, vitest + jsdom + `@testing-library/vue` + `vitest-axe` (axe check expected for new components); jsdom quirks handled in `packages/core/vitest.setup.ts`.
 - Commits: Conventional Commits, scope = component family (`fix(Dialog): …`); commitlint enforces; lint-staged runs `eslint --fix` (lints JSON/MD/YAML too — intentional).
-- Match Radix UI (React) behavior when porting — divergence needs a reason.
 
 See CONTRIBUTING.md for the full guide.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# reka-ui — agent notes
+
+Vue 3 headless component library (port of Radix UI). pnpm monorepo. Node ≥ 22, pnpm 10.
+
+## Commands (from repo root)
+- Install: `pnpm i`
+- Test (one-shot): `pnpm --filter reka-ui exec vitest run [path]`  (`pnpm test` = watch mode — avoid in automation)
+- Coverage: `pnpm --filter reka-ui test:coverage`
+- Type-check: `pnpm --filter reka-ui type-check`
+- Lint: `pnpm lint` (fix: `pnpm lint:fix`)
+- Build: `pnpm --filter reka-ui build` (vue-tsc + tsdown)
+- Regenerate API docs after changing public props/emits/slots: `pnpm docs:gen`
+
+## Layout
+- `packages/core/src/<Family>/` — one dir per component family; parts named `<Family><Part>.vue`; each family has `index.ts`; public surface = `packages/core/src/index.ts`.
+- `packages/core/src/shared/` — shared composables (`createContext`, `useForwardExpose`, prop/emit forwarding, …).
+- `packages/core/src/date/` — date/calendar utilities.
+- `packages/plugins` — build-tool integration (resolver, Nuxt module).
+- `docs/` — VitePress site; `docs/content/meta/*.md` is AUTO-GENERATED (never hand-edit).
+- Stories are Histoire (`*.story.vue`), not Storybook.
+
+## Conventions
+- Context: `createContext('<Component>')` → `[inject, provide]`; `*Root.vue` provides, descendants inject.
+- Rendering: `Primitive` with `as` / `asChild`; expose refs via `useForwardExpose()`.
+- Tests: colocated `*.test.ts`, vitest + jsdom + `@testing-library/vue` + `vitest-axe` (axe check expected for new components); jsdom quirks handled in `packages/core/vitest.setup.ts`.
+- Commits: Conventional Commits, scope = component family (`fix(Dialog): …`); commitlint enforces; lint-staged runs `eslint --fix` (lints JSON/MD/YAML too — intentional).
+- Match Radix UI (React) behavior when porting — divergence needs a reason.
+
+See CONTRIBUTING.md for the full guide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,9 @@ All commands run from the repo root.
 
 ## Component architecture
 
-Reka UI is a headless port of Radix UI. A few patterns recur in every family —
-learn them once and the rest of the codebase reads the same way.
-`packages/core/src/Checkbox/` is a small, complete example to read alongside this
-section.
+A few patterns recur in every component family — learn them once and the rest of
+the codebase reads the same way. `packages/core/src/Checkbox/` is a small,
+complete example to read alongside this section.
 
 - **Family folders & naming.** Components are Vue SFCs named
   `<Family><Part>.vue` — `CheckboxRoot.vue`, `CheckboxIndicator.vue`,
@@ -99,8 +98,6 @@ section.
   a wrapper). Expose template refs with `useForwardExpose()`, and forward
   props/emits with `useForwardProps`, `useEmitAsProps`, or
   `useForwardPropsEmits` from `src/shared/`.
-- **Match Radix.** When porting behavior, mirror the Radix UI (React) component.
-  Intentional divergences should have a reason noted in the PR.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing to Reka UI
+
+Thanks for your interest in improving Reka UI! This guide covers everything you
+need to get a local checkout running, find your way around the monorepo, and
+open a pull request that fits the project's conventions.
+
+## Welcome & getting help
+
+We would love your contributions — PRs for core components, docs, tests, and
+stories are all welcome. The best place to ask questions or pair up is our
+Discord: [chat.unovue.com](https://chat.unovue.com). Bugs and feature requests
+belong in the [issue tracker](https://github.com/unovue/reka-ui/issues).
+
+By participating you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Repository layout
+
+This is a pnpm monorepo. The pieces you are most likely to touch:
+
+| Path | What it is |
+|---|---|
+| `packages/core` | The published `reka-ui` package. All components and composables live in `src/`. |
+| `packages/plugins` | Build-tool integration (auto-import resolver, Nuxt module). |
+| `docs/` | The VitePress documentation site (its own workspace — install separately). |
+| `playground/` | Local sandboxes for trying things out. |
+| `.histoire/` | Histoire setup for the component stories. |
+
+Inside `packages/core/src/`:
+
+- One directory per **component family** (e.g. `Accordion/`, `Dialog/`,
+  `Checkbox/` … through the date pickers).
+- `shared/` — shared composables (`createContext`, `useForwardExpose`, the
+  prop/emit forwarding helpers, typeahead, selection, etc.).
+- `date/` — date/calendar utilities used by the date-family components.
+
+## Getting started
+
+**Prerequisites:** Node ≥ 22 and pnpm 10 (the repo pins `pnpm@10.13.1` via the
+`packageManager` field; [Corepack](https://nodejs.org/api/corepack.html) will
+pick this up automatically).
+
+```bash
+git clone https://github.com/unovue/reka-ui.git
+cd reka-ui
+pnpm i
+```
+
+Recommended dev loops, depending on what you're working on:
+
+- **Visual / interactive work** — `pnpm story:dev` opens Histoire with the
+  component stories.
+- **TDD on a component or composable** — `pnpm --filter reka-ui exec vitest <path>`
+  runs that file in watch mode.
+- **Testing against an external app** — `pnpm --filter reka-ui watch` rebuilds
+  the package on change so a linked app sees your edits.
+
+## Project commands
+
+All commands run from the repo root.
+
+| Task | Command |
+|---|---|
+| Install | `pnpm i` |
+| Build core | `pnpm --filter reka-ui build` (vue-tsc type-check + tsdown bundle) |
+| Watch build | `pnpm --filter reka-ui watch` |
+| Type-check only | `pnpm --filter reka-ui type-check` |
+| Tests (watch) | `pnpm test` |
+| Tests (one-shot) | `pnpm --filter reka-ui exec vitest run [path]` |
+| Test coverage | `pnpm --filter reka-ui test:coverage` |
+| Lint / auto-fix | `pnpm lint` / `pnpm lint:fix` |
+| Stories | `pnpm story:dev` |
+| Docs dev | `pnpm docs:install && pnpm docs:dev` |
+| Docs API regen | `pnpm docs:gen` (regenerates `docs/content/meta/*.md`) |
+| Bundle size | `pnpm --filter reka-ui size` |
+
+> `pnpm test` is **watch mode**. For a one-shot run (CI-style) use
+> `pnpm --filter reka-ui exec vitest run`.
+
+## Component architecture
+
+Reka UI is a headless port of Radix UI. A few patterns recur in every family —
+learn them once and the rest of the codebase reads the same way.
+`packages/core/src/Checkbox/` is a small, complete example to read alongside this
+section.
+
+- **Family folders & naming.** Components are Vue SFCs named
+  `<Family><Part>.vue` — `CheckboxRoot.vue`, `CheckboxIndicator.vue`,
+  `DialogRoot.vue`, `DialogContent.vue`, and so on. Each family has an
+  `index.ts` re-exporting its parts and prop types, and every family is
+  re-exported from `packages/core/src/index.ts` (the public surface).
+- **Context.** State flows from a root to its descendants via
+  `createContext('<ComponentName>')` (see
+  `packages/core/src/shared/createContext.ts`). It returns
+  `[injectContext, provideContext]` around a typed `InjectionKey`: the
+  `*Root.vue` calls the provide function, descendants call inject.
+- **Rendering.** Output goes through `Primitive`
+  (`packages/core/src/Primitive`) which implements the `as` / `asChild` props
+  (`asChild` merges props onto the consumer's own element instead of rendering
+  a wrapper). Expose template refs with `useForwardExpose()`, and forward
+  props/emits with `useForwardProps`, `useEmitAsProps`, or
+  `useForwardPropsEmits` from `src/shared/`.
+- **Match Radix.** When porting behavior, mirror the Radix UI (React) component.
+  Intentional divergences should have a reason noted in the PR.
+
+## Testing
+
+- Tests are **colocated** with the code as `<Name>.test.ts` inside each family
+  (e.g. `packages/core/src/Checkbox/Checkbox.test.ts`).
+- Stack: [Vitest](https://vitest.dev) + jsdom, with
+  [`@testing-library/vue`](https://testing-library.com/docs/vue-testing-library/intro/)
+  and `@vue/test-utils` for mounting, and `vitest-axe` for accessibility
+  assertions: `expect(await axe(el)).toHaveNoViolations()`.
+- jsdom quirks (a stubbed `scrollIntoView`, a patched `getComputedStyle` that
+  axe relies on) are handled globally in `packages/core/vitest.setup.ts` — you
+  don't need to repeat that per test.
+- New components and composables should ship with colocated tests, including an
+  axe check for anything that renders.
+
+## Documentation
+
+Each component has a page under `docs/content/`. The **API tables**
+(props / emits / slots) are **auto-generated** — after changing a component's
+public props, emits, or slots, run `pnpm docs:gen` and commit the regenerated
+`docs/content/meta/*.md`. Never hand-edit those generated files.
+
+## Commits & pull requests
+
+- **Conventional Commits**, enforced by commitlint via a pre-commit hook
+  (simple-git-hooks). The scope is the component family:
+  `feat(Dialog): …`, `fix(shared): …`, `docs: …`, `ci: …`.
+- **lint-staged** runs `eslint --fix` on staged files when you commit (the
+  `@antfu/eslint-config` lints JSON / Markdown / YAML too — that's intentional).
+- Open PRs against the default branch. CI runs build, tests, and bundle-size
+  checks; please make sure they're green.
+
+## Releases
+
+Releasing is maintainer-only: versions are bumped with `pnpm bumpp` and
+`reka-ui` is published from `packages/core` with npm provenance. As a
+contributor you don't need to run anything release-related — just land
+conventional commits and a maintainer will cut the release.


### PR DESCRIPTION
## Summary

The repo had no `CONTRIBUTING.md` and no `CLAUDE.md`/`AGENTS.md` — its conventions (the Primitive/`asChild` pattern, `createContext` provide/inject, component-family folder layout, colocated vitest + testing-library + axe tests, the auto-generated docs pipeline) lived only in maintainers' heads and the code. This adds two short documents so every new contributor and coding agent works from the same baseline.

- **`CONTRIBUTING.md`** — full human-facing guide: welcome/help, repo layout, getting started (Node ≥ 22, pnpm 10), the command table, component architecture, testing, docs regeneration, commits/PRs, and a release note.
- **`CLAUDE.md`** — terse agent-facing notes (29 lines; injected per session), consistent with CONTRIBUTING.md.

## Verification

- [x] Every file path referenced in both docs exists (verified with `ls`)
- [x] Every documented one-shot command run and exited 0: `pnpm i`, `build`, `type-check`, `exec vitest run`, `test:coverage`, `lint`, `lint:fix`, `size`
- [x] `pnpm lint` exit 0 (markdown is linted by the antfu config)
- [x] `git status` shows only the two new files

## Notes

- **README link skipped intentionally.** The root `README.md` is a symlink to `packages/core/README.md` (the published npm readme); a relative `CONTRIBUTING.md` link there would be broken on npmjs.com. The plan's README edit was optional, so it was omitted.
- Dev-server commands (`story:dev`, `docs:dev`, `watch`) and `docs:gen` are documented but not executed here — they're long-running servers or require the separate `docs` workspace install; all are existing maintained root scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contributing guidelines describing setup, development workflow, testing and accessibility expectations, commit/PR practices, and release process.
  * Added repository documentation covering project layout, developer commands, build/docs generation, component conventions, and guidance for maintaining and testing components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->