### PR TITLE
ci: add size-limit budgets for heavy component exports

### DIFF
--- a/packages/core/.size-limit.json
+++ b/packages/core/.size-limit.json
@@ -10,5 +10,53 @@
     "import": "{ DialogRoot, DialogContent, DialogOverlay, DialogTrigger }",
     "limit": "25 KB",
     "name": "Dialog (medium complexity component)"
+  },
+  {
+    "path": "dist/index.js",
+    "import": "{ SelectRoot, SelectTrigger, SelectContent, SelectItem, SelectViewport, SelectPortal }",
+    "limit": "27 KB",
+    "name": "Select"
+  },
+  {
+    "path": "dist/index.js",
+    "import": "{ ComboboxRoot, ComboboxInput, ComboboxContent, ComboboxItem, ComboboxVirtualizer }",
+    "limit": "33 KB",
+    "name": "Combobox"
+  },
+  {
+    "path": "dist/index.js",
+    "import": "{ CalendarRoot, CalendarHeader, CalendarGrid, CalendarCell, CalendarCellTrigger }",
+    "limit": "17 KB",
+    "name": "Calendar"
+  },
+  {
+    "path": "dist/index.js",
+    "import": "{ DateFieldRoot, DateFieldInput }",
+    "limit": "19 KB",
+    "name": "DateField"
+  },
+  {
+    "path": "dist/index.js",
+    "import": "{ TreeRoot, TreeItem, TreeVirtualizer }",
+    "limit": "13 KB",
+    "name": "Tree"
+  },
+  {
+    "path": "dist/index.js",
+    "import": "{ PopoverRoot, PopoverTrigger, PopoverContent, PopoverPortal }",
+    "limit": "21 KB",
+    "name": "Popover"
+  },
+  {
+    "path": "dist/index.js",
+    "import": "{ TooltipProvider, TooltipRoot, TooltipTrigger, TooltipContent }",
+    "limit": "19 KB",
+    "name": "Tooltip"
+  },
+  {
+    "path": "dist/index.js",
+    "import": "*",
+    "limit": "160 KB",
+    "name": "Full library"
   }
 ]


### PR DESCRIPTION
## Summary

CI enforces bundle-size budgets via size-limit (the `size` job in `.github/workflows/build.yaml`), but the config only covered **AspectRatio** and **Dialog**. The heaviest, most dependency-laden exports — Calendar (`@internationalized/date`), Combobox (virtualization + popper), DateField, Tree, Select, Popover, Tooltip — had no budget at all. A change that drags a large dependency into one of them, or breaks tree-shaking, would ship unnoticed.

This adds 8 new entries to `packages/core/.size-limit.json`, each pinned to its current measured cost + ~10% headroom, so regressions fail CI. No CI change needed — the `size` job already runs `pnpm --filter reka-ui size` against the built artifact.

## Baseline (minified + brotli)

| Entry | Measured | Limit |
|---|---|---|
| Select | 24.05 kB | 27 kB |
| Combobox | 29.75 kB | 33 kB |
| Calendar | 14.66 kB | 17 kB |
| DateField | 16.79 kB | 19 kB |
| Tree | 11.57 kB | 13 kB |
| Popover | 18.38 kB | 21 kB |
| Tooltip | 17.02 kB | 19 kB |
| Full library (`*`) | 145.12 kB | 160 kB |

The existing AspectRatio (5 kB) and Dialog (25 kB) entries are untouched.

## Notes

- The `Full library` (`*`) entry is the canary for tree-shaking regressions (barrel-file accidents, side-effectful module scope) — scrutinize any jump there even when per-family entries stay flat.
- Limits absorb noise, not features: bump them consciously, in the same PR as any change that legitimately grows a family.

## Verification

- `pnpm --filter reka-ui size` → exits 0, all entries under budget.
- Gate confirmed to bite: temporarily setting Select to `1 KB` made the run exit non-zero; restored to green.
- Only `packages/core/.size-limit.json` modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build size-limit configurations to track library component sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->