### PR TITLE
chore: replace deprecated computedEager with computed

### DIFF
--- a/packages/core/src/Popper/PopperContent.vue
+++ b/packages/core/src/Popper/PopperContent.vue
@@ -204,7 +204,6 @@ import {
   size,
   useFloating,
 } from '@floating-ui/vue'
-import { computedEager } from '@vueuse/core'
 import { computed, ref, watchEffect, watchPostEffect } from 'vue'
 import {
   Primitive,
@@ -269,7 +268,7 @@ const flipOptions = computed(() => {
   }
 })
 
-const computedMiddleware = computedEager(() => {
+const computedMiddleware = computed(() => {
   return [
     offset({
       mainAxis: props.sideOffset + arrowHeight.value,


### PR DESCRIPTION
## Summary

Cleanup of deprecated third-party APIs found while scanning the codebase.

The only deprecated dependency API in use was `computedEager` from `@vueuse/core` (deprecated in favor of Vue's native `computed`). This swaps it out in `PopperContent.vue` — the single occurrence in the repo.

## Changes

- `packages/core/src/Popper/PopperContent.vue`: replace `computedEager` import + call with `computed`

## Notes

A full sweep for other known-deprecated VueUse exports (`templateRef`, `controlledRef`, `eagerComputed`, `logicAnd`/`logicOr`/`logicNot`, `useThrottledRefHistory`, `reactify`, `asyncComputed`) found **zero** usages, so this was the only cleanup needed.

## Verification

- `pnpm --filter reka-ui type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Popper component's middleware computation to use standard Vue semantics for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->