### PR TITLE
fix(AlertDialog): preserve modal pointer event default

### DIFF
--- a/packages/core/src/AlertDialog/AlertDialog.test.ts
+++ b/packages/core/src/AlertDialog/AlertDialog.test.ts
@@ -3,8 +3,80 @@ import { findAllByText, findByText, fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
-import { nextTick } from 'vue'
+import { defineComponent, nextTick } from 'vue'
+import {
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogRoot,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '.'
 import AlertDialog from './story/_AlertDialog.vue'
+
+const OPEN_TEXT = 'Open'
+const CANCEL_TEXT = 'Cancel'
+
+function makeAlertDialog(contentBinding: string) {
+  return defineComponent({
+    components: {
+      AlertDialogAction,
+      AlertDialogCancel,
+      AlertDialogContent,
+      AlertDialogOverlay,
+      AlertDialogPortal,
+      AlertDialogRoot,
+      AlertDialogTitle,
+      AlertDialogTrigger,
+    },
+    template: `<AlertDialogRoot>
+  <AlertDialogTrigger>${OPEN_TEXT}</AlertDialogTrigger>
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogContent ${contentBinding}>
+      <AlertDialogTitle>Title</AlertDialogTitle>
+      <AlertDialogCancel>${CANCEL_TEXT}</AlertDialogCancel>
+      <AlertDialogAction>Confirm</AlertDialogAction>
+    </AlertDialogContent>
+  </AlertDialogPortal>
+</AlertDialogRoot>`,
+  })
+}
+
+describe('given a modal AlertDialog (#2702)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.body.style.pointerEvents = ''
+  })
+
+  it('should lock body pointer-events and keep content clickable by default', async () => {
+    const wrapper = mount(makeAlertDialog(''), { attachTo: document.body })
+    fireEvent.click(wrapper.find('button').element)
+
+    const cancelButton = await findByText(document.body, CANCEL_TEXT)
+    await nextTick()
+
+    expect(document.body.style.pointerEvents).toBe('none')
+    expect(cancelButton.closest('[data-dismissable-layer]')?.getAttribute('style')).toContain('pointer-events: auto')
+
+    wrapper.unmount()
+  })
+
+  it('should respect disableOutsidePointerEvents=false on the content', async () => {
+    const wrapper = mount(makeAlertDialog(':disable-outside-pointer-events="false"'), { attachTo: document.body })
+    fireEvent.click(wrapper.find('button').element)
+
+    const cancelButton = await findByText(document.body, CANCEL_TEXT)
+    await nextTick()
+
+    expect(document.body.style.pointerEvents).toBe('none')
+    expect(cancelButton.closest('[data-dismissable-layer]')?.getAttribute('style') ?? '').not.toContain('pointer-events: auto')
+
+    wrapper.unmount()
+  })
+})
 
 describe('given a default Dialog', async () => {
   let wrapper: VueWrapper<InstanceType<typeof AlertDialog>>

--- a/packages/core/src/AlertDialog/AlertDialogContent.vue
+++ b/packages/core/src/AlertDialog/AlertDialogContent.vue
@@ -20,7 +20,12 @@ export interface AlertDialogContentProps extends DialogContentProps {}
 import { nextTick, ref } from 'vue'
 import { DialogContent } from '@/Dialog'
 
-const props = defineProps<AlertDialogContentProps>()
+const props = withDefaults(defineProps<AlertDialogContentProps>(), {
+  // Keep `undefined` (instead of Vue's boolean coercion to `false`) so
+  // `DialogContent` can preserve its modal default while still honoring an
+  // explicit `:disable-outside-pointer-events="false"` (#2702).
+  disableOutsidePointerEvents: undefined,
+})
 const emits = defineEmits<AlertDialogContentEmits>()
 
 const emitsAsProps = useEmitAsProps(emits)


### PR DESCRIPTION
### 🔗 Linked issue

#2702

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #2702.

Preserves the modal `DialogContent` default for `AlertDialogContent` by keeping `disableOutsidePointerEvents` as `undefined` when the prop is omitted. This prevents Vue Boolean casting from passing an explicit `false` through to `DialogContentModal`, so modal alert dialogs keep `pointer-events: auto` on their dismissable layer while the body is locked.

Also adds regression coverage for:

- default modal `AlertDialogContent` keeps content clickable while body pointer-events are locked
- explicit `:disable-outside-pointer-events="false"` is still respected

Verification:

- `pnpm --filter reka-ui exec vitest run src/AlertDialog/AlertDialog.test.ts src/Dialog/Dialog.test.ts`
- `pnpm exec eslint packages/core/src/AlertDialog/AlertDialogContent.vue packages/core/src/AlertDialog/AlertDialog.test.ts`
- `git diff --check`

### 📸 Screenshots (if appropriate)

N/A

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AlertDialog pointer-events locking behavior to properly honor the `disableOutsidePointerEvents` configuration.

* **Tests**
  * Added test suite for modal AlertDialog pointer-events locking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->