### PR TITLE
docs(Drawer): add documentation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -239,6 +239,7 @@ export default defineConfig({
               { text: 'Collapsible', link: '/docs/components/collapsible' },
               { text: 'Context Menu', link: '/docs/components/context-menu' },
               { text: 'Dialog', link: '/docs/components/dialog' },
+              { text: `Drawer ${BadgeHTML('Alpha', true)}`, link: '/docs/components/drawer' },
               { text: 'Dropdown Menu', link: '/docs/components/dropdown-menu' },
               { text: 'Hover Card', link: '/docs/components/hover-card' },
               { text: 'Menubar', link: '/docs/components/menubar' },

--- a/docs/components/demo/Drawer/css/index.vue
+++ b/docs/components/demo/Drawer/css/index.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import {
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHandle,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerRoot,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'reka-ui'
+import './styles.css'
+</script>
+
+<template>
+  <DrawerRoot>
+    <DrawerTrigger class="Button grass">
+      Open Drawer
+    </DrawerTrigger>
+    <DrawerPortal>
+      <DrawerOverlay class="DrawerOverlay" />
+      <DrawerContent class="DrawerContent">
+        <DrawerHandle class="DrawerHandle" />
+        <div class="DrawerBody">
+          <DrawerTitle class="DrawerTitle">
+            Edit profile
+          </DrawerTitle>
+          <DrawerDescription class="DrawerDescription">
+            Make changes to your profile here. Swipe down or click close when you're done.
+          </DrawerDescription>
+          <fieldset class="Fieldset">
+            <label
+              class="Label"
+              for="name"
+            > Name </label>
+            <input
+              id="name"
+              class="Input"
+              defaultValue="Pedro Duarte"
+            >
+          </fieldset>
+          <div class="DrawerFooter">
+            <DrawerClose as-child>
+              <button class="Button green">
+                Save changes
+              </button>
+            </DrawerClose>
+          </div>
+        </div>
+      </DrawerContent>
+    </DrawerPortal>
+  </DrawerRoot>
+</template>

--- a/docs/components/demo/Drawer/css/index.vue
+++ b/docs/components/demo/Drawer/css/index.vue
@@ -37,7 +37,7 @@ import './styles.css'
             <input
               id="name"
               class="Input"
-              defaultValue="Pedro Duarte"
+              value="Pedro Duarte"
             >
           </fieldset>
           <div class="DrawerFooter">

--- a/docs/components/demo/Drawer/css/styles.css
+++ b/docs/components/demo/Drawer/css/styles.css
@@ -1,0 +1,171 @@
+@import '@radix-ui/colors/black-alpha.css';
+@import '@radix-ui/colors/green.css';
+@import '@radix-ui/colors/mauve.css';
+@import '@radix-ui/colors/grass.css';
+
+/* reset */
+button,
+fieldset,
+input {
+  all: unset;
+}
+
+.DrawerOverlay {
+  background-color: var(--black-a9);
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+}
+.DrawerOverlay[data-state='open'] {
+  animation: drawerOverlayShow 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.DrawerOverlay[data-state='closed'] {
+  animation: drawerOverlayHide 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.DrawerContent {
+  background-color: white;
+  border-radius: 16px 16px 0 0;
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  margin-inline: auto;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  outline: none;
+  z-index: 100;
+  /* `--drawer-swipe-movement-y` is written by DrawerContent while dragging. */
+  transform: translateY(var(--drawer-swipe-movement-y, 0px));
+  transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
+  will-change: transform;
+}
+/* Enter/exit keyframes animate the independent `translate` property so they
+   compose with the inline `transform` carrying the live drag offset. */
+.DrawerContent[data-state='open'] {
+  animation: drawerSlideBottomIn 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.DrawerContent[data-state='closed'] {
+  animation: drawerSlideBottomOut 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+/* Silence the transform transition during an active drag so it tracks the
+   pointer in real time. */
+.DrawerContent[data-swiping] {
+  transition-duration: 0ms;
+  user-select: none;
+}
+
+.DrawerHandle {
+  width: 48px;
+  height: 6px;
+  margin: 12px auto 0;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  background-color: var(--mauve-6);
+}
+
+.DrawerBody {
+  padding: 24px;
+}
+
+.DrawerTitle {
+  margin: 0;
+  color: var(--mauve-12);
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.DrawerDescription {
+  margin: 10px 0 20px;
+  color: var(--mauve-11);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.DrawerFooter {
+  display: flex;
+  margin-top: 25px;
+  justify-content: flex-end;
+}
+
+.Fieldset {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.Label {
+  width: 90px;
+  text-align: right;
+  font-size: 15px;
+  color: var(--grass-11);
+}
+
+.Input {
+  width: 100%;
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  padding: 0 10px;
+  height: 35px;
+  font-size: 15px;
+  line-height: 1;
+  color: var(--grass-11);
+  background-color: #fafafa;
+  box-shadow: 0 0 0 1px var(--green-7);
+}
+.Input:focus {
+  box-shadow: 0 0 0 2px var(--green-8);
+}
+
+.Button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  padding: 0 15px;
+  font-size: 15px;
+  line-height: 1;
+  height: 35px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.Button.grass {
+  background-color: white;
+  color: var(--grass-11);
+  box-shadow: 0 2px 10px var(--black-a7);
+}
+.Button.grass:hover {
+  background-color: var(--mauve-3);
+}
+.Button.green {
+  background-color: var(--green-4);
+  color: var(--green-11);
+}
+.Button.green:hover {
+  background-color: var(--green-5);
+}
+
+@keyframes drawerOverlayShow {
+  from {
+    opacity: 0;
+  }
+}
+@keyframes drawerOverlayHide {
+  to {
+    opacity: 0;
+  }
+}
+@keyframes drawerSlideBottomIn {
+  from {
+    translate: 0 100%;
+  }
+}
+@keyframes drawerSlideBottomOut {
+  to {
+    translate: 0 100%;
+  }
+}

--- a/docs/components/demo/Drawer/tailwind/index.vue
+++ b/docs/components/demo/Drawer/tailwind/index.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import {
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHandle,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerRoot,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'reka-ui'
+</script>
+
+<template>
+  <DrawerRoot>
+    <DrawerTrigger
+      class="text-grass11 font-semibold hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-md bg-white px-[15px] leading-none shadow-sm focus:shadow-[0_0_0_2px] focus:shadow-black dark:focus:shadow-green8 focus:outline-none border"
+    >
+      Open Drawer
+    </DrawerTrigger>
+    <DrawerPortal>
+      <DrawerOverlay class="DrawerOverlay fixed inset-0 z-30 bg-black/40" />
+      <DrawerContent
+        class="DrawerContent fixed inset-x-0 bottom-0 z-[100] mx-auto flex max-w-[500px] flex-col rounded-t-[16px] bg-white outline-none"
+      >
+        <DrawerHandle class="mx-auto mt-3 h-1.5 w-12 shrink-0 rounded-full bg-mauve6" />
+        <div class="p-6">
+          <DrawerTitle class="text-mauve12 m-0 text-[17px] font-semibold">
+            Edit profile
+          </DrawerTitle>
+          <DrawerDescription class="text-mauve11 mt-[10px] mb-5 text-sm leading-normal">
+            Make changes to your profile here. Swipe down or click close when you're done.
+          </DrawerDescription>
+          <fieldset class="mb-[15px] flex items-center gap-5">
+            <label
+              class="text-grass11 w-[90px] text-right text-sm"
+              for="name"
+            > Name </label>
+            <input
+              id="name"
+              class="text-grass11 bg-stone-50 shadow-green7 focus:shadow-green8 inline-flex h-[35px] w-full flex-1 items-center justify-center rounded-lg px-[10px] text-sm leading-none shadow-[0_0_0_1px] outline-none focus:shadow-[0_0_0_2px]"
+              defaultValue="Pedro Duarte"
+            >
+          </fieldset>
+          <div class="mt-[25px] flex justify-end">
+            <DrawerClose as-child>
+              <button
+                class="bg-green4 text-green11 text-sm hover:bg-green5 focus:shadow-green7 inline-flex h-[35px] items-center justify-center rounded-lg px-[15px] font-semibold leading-none focus:shadow-[0_0_0_2px] focus:outline-none"
+              >
+                Save changes
+              </button>
+            </DrawerClose>
+          </div>
+        </div>
+      </DrawerContent>
+    </DrawerPortal>
+  </DrawerRoot>
+</template>
+
+<!--
+  These styles are not scoped: DrawerContent / DrawerOverlay are teleported to
+  `body` by DrawerPortal, so a `scoped` block would not reach them. They drive
+  the enter/exit animation and the live swipe-to-dismiss transform — behaviour
+  Tailwind utility classes alone cannot express.
+-->
+<style>
+.DrawerOverlay[data-state="open"] {
+  animation: drawer-overlay-in 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.DrawerOverlay[data-state="closed"] {
+  animation: drawer-overlay-out 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.DrawerContent {
+  /* `--drawer-swipe-movement-y` is written by DrawerContent while dragging. */
+  transform: translateY(var(--drawer-swipe-movement-y, 0px));
+  transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
+  will-change: transform;
+}
+/* Enter/exit keyframes animate the independent `translate` property so they
+   compose with the inline `transform` carrying the live drag offset. */
+.DrawerContent[data-state="open"] {
+  animation: drawer-slide-bottom-in 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.DrawerContent[data-state="closed"] {
+  animation: drawer-slide-bottom-out 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+/* Silence the transform transition during an active drag so it tracks the
+   pointer in real time. */
+.DrawerContent[data-swiping] {
+  transition-duration: 0ms;
+  user-select: none;
+}
+
+@keyframes drawer-overlay-in { from { opacity: 0; } }
+@keyframes drawer-overlay-out { to { opacity: 0; } }
+@keyframes drawer-slide-bottom-in { from { translate: 0 100%; } }
+@keyframes drawer-slide-bottom-out { to { translate: 0 100%; } }
+</style>

--- a/docs/components/demo/Drawer/tailwind/index.vue
+++ b/docs/components/demo/Drawer/tailwind/index.vue
@@ -40,7 +40,7 @@ import {
             <input
               id="name"
               class="text-grass11 bg-stone-50 shadow-green7 focus:shadow-green8 inline-flex h-[35px] w-full flex-1 items-center justify-center rounded-lg px-[10px] text-sm leading-none shadow-[0_0_0_1px] outline-none focus:shadow-[0_0_0_2px]"
-              defaultValue="Pedro Duarte"
+              value="Pedro Duarte"
             >
           </fieldset>
           <div class="mt-[25px] flex justify-end">

--- a/docs/content/docs/components/drawer.md
+++ b/docs/content/docs/components/drawer.md
@@ -3,7 +3,7 @@
 title: Drawer
 description: A panel that slides in from the edge of the screen, with support for swipe-to-dismiss, snap points, and nested drawers.
 name: drawer
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
 ---
 
 # Drawer

--- a/docs/content/docs/components/drawer.md
+++ b/docs/content/docs/components/drawer.md
@@ -1,0 +1,526 @@
+---
+
+title: Drawer
+description: A panel that slides in from the edge of the screen, with support for swipe-to-dismiss, snap points, and nested drawers.
+name: drawer
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+---
+
+# Drawer
+
+<Badge>Alpha</Badge>
+
+<Description>
+A panel that slides in from the edge of the screen, with support for swipe-to-dismiss, snap points, and nested drawers.
+</Description>
+
+<ComponentPreview name="Drawer" />
+
+## Features
+
+<Highlights
+  :features="[
+    'Slides in from any edge — bottom, top, left or right.',
+    'Swipe-to-dismiss with momentum, plus optional swipe-to-open.',
+    'Supports snap points for partially-open resting positions.',
+    'Modal, focus-trapped non-modal, and fully non-modal modes.',
+    'Can be controlled or uncontrolled.',
+    '<span>Manages screen reader announcements with <Code>Title</Code> and <Code>Description</Code> components.</span>',
+    'Esc closes the component automatically.',
+  ]"
+/>
+
+## Installation
+
+Install the component from your command line.
+
+<InstallationTabs value="reka-ui" />
+
+## Anatomy
+
+Import all parts and piece them together.
+
+```vue
+<script setup>
+import {
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHandle,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerRoot,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'reka-ui'
+</script>
+
+<template>
+  <DrawerRoot>
+    <DrawerTrigger />
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerContent>
+        <DrawerHandle />
+        <DrawerTitle />
+        <DrawerDescription />
+        <DrawerClose />
+      </DrawerContent>
+    </DrawerPortal>
+  </DrawerRoot>
+</template>
+```
+
+## Animating the drawer
+
+The Drawer is unstyled, so the enter/exit transitions and the swipe gesture are
+driven entirely by your CSS. `DrawerContent` exposes the drag offset through CSS
+custom properties so you can wire up the live transform:
+
+- `--drawer-swipe-movement-y` — vertical drag offset (for top/bottom drawers)
+- `--drawer-swipe-movement-x` — horizontal drag offset (for left/right drawers)
+- `--drawer-snap-point-offset` — offset of the active snap point, when snap points are used
+- `--drawer-swipe-progress` — `0` at rest, approaching `1` as the drawer is swiped away
+
+```css
+.DrawerContent {
+  /* Follow the pointer while dragging. */
+  transform: translateY(var(--drawer-swipe-movement-y, 0px));
+  transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+/* Use the independent `translate` property for the enter/exit keyframes so they
+   compose with the `transform` above instead of clobbering the drag offset. */
+.DrawerContent[data-state='open'] {
+  animation: slideIn 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.DrawerContent[data-state='closed'] {
+  animation: slideOut 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+/* Cut the transition while actively dragging so the drawer tracks the pointer. */
+.DrawerContent[data-swiping] {
+  transition-duration: 0ms;
+}
+
+@keyframes slideIn { from { translate: 0 100%; } }
+@keyframes slideOut { to { translate: 0 100%; } }
+```
+
+## API Reference
+
+### Root
+
+Contains all the parts of a drawer. Manages open state, modality, swipe direction
+and snap points, and provides the context consumed by every other part.
+
+<!-- @include: @/meta/DrawerRoot.md -->
+
+### Trigger
+
+The button that opens the drawer.
+
+<!-- @include: @/meta/DrawerTrigger.md -->
+
+<DataAttributesTable
+  :data="[
+    {
+      attribute: '[data-state]',
+      values: ['open', 'closed'],
+    },
+  ]"
+/>
+
+### Portal
+
+When used, portals your overlay and content parts into the `body`.
+
+<!-- @include: @/meta/DrawerPortal.md -->
+
+### Overlay
+
+A layer that covers the inert portion of the view when the drawer is open. Only
+rendered when the drawer is `modal`.
+
+<PresenceCallout />
+
+<!-- @include: @/meta/DrawerOverlay.md -->
+
+<DataAttributesTable
+  :data="[
+    {
+      attribute: '[data-state]',
+      values: ['open', 'closed'],
+    },
+    {
+      attribute: '[data-swipe-direction]',
+      values: ['up', 'down', 'left', 'right'],
+    },
+    {
+      attribute: '[data-swiping]',
+      values: ['Present when the drawer is being dragged'],
+    },
+  ]"
+/>
+
+### Content
+
+Contains the content to be rendered in the open drawer. Owns the swipe gesture
+and exposes the drag offset through CSS custom properties (see [Animating the
+drawer](#animating-the-drawer)). Also aliased as `DrawerPopup` for Base UI parity.
+
+<PresenceCallout />
+
+<!-- @include: @/meta/DrawerContent.md -->
+
+<DataAttributesTable
+  :data="[
+    {
+      attribute: '[data-state]',
+      values: ['open', 'closed'],
+    },
+    {
+      attribute: '[data-swipe-direction]',
+      values: ['up', 'down', 'left', 'right'],
+    },
+    {
+      attribute: '[data-swiping]',
+      values: ['Present while the drawer is being dragged'],
+    },
+    {
+      attribute: '[data-nested-drawer-open]',
+      values: ['Present when a nested drawer is open'],
+    },
+  ]"
+/>
+
+### Close
+
+The button that closes the drawer.
+
+<!-- @include: @/meta/DrawerClose.md -->
+
+### Title
+
+An accessible title to be announced when the drawer is opened.
+
+If you want to hide the title, wrap it inside our Visually Hidden utility like this `<VisuallyHidden asChild>`.
+
+<!-- @include: @/meta/DrawerTitle.md -->
+
+### Description
+
+An optional accessible description to be announced when the drawer is opened.
+
+If you want to hide the description, wrap it inside our Visually Hidden utility like this `<VisuallyHidden asChild>`. If you want to remove the description entirely, remove this part and pass `:aria-describedby="undefined"` to `DrawerContent`.
+
+<!-- @include: @/meta/DrawerDescription.md -->
+
+### Handle
+
+A visual grab handle that hints the drawer can be dragged. It is purely
+decorative (`aria-hidden`) — the whole content is draggable regardless.
+
+<!-- @include: @/meta/DrawerHandle.md -->
+
+<DataAttributesTable
+  :data="[
+    {
+      attribute: '[data-state]',
+      values: ['open', 'closed'],
+    },
+  ]"
+/>
+
+### SwipeArea
+
+An off-screen edge area that lets users swipe the drawer **open**. By default it
+listens on the opposite side of the Root's `swipeDirection`.
+
+<!-- @include: @/meta/DrawerSwipeArea.md -->
+
+<DataAttributesTable
+  :data="[
+    {
+      attribute: '[data-state]',
+      values: ['open', 'closed'],
+    },
+    {
+      attribute: '[data-swipe-direction]',
+      values: ['up', 'down', 'left', 'right'],
+    },
+  ]"
+/>
+
+### Viewport
+
+An optional scrollable wrapper for the drawer content. Mirrors Base UI's
+`Drawer.Viewport` and carries a `data-drawer-viewport` attribute for downstream
+selectors.
+
+<!-- @include: @/meta/DrawerViewport.md -->
+
+### Indent
+
+Wraps page content that should visually shift (scale/indent) as the drawer is
+swiped, mimicking the native iOS "card stack" effect. Reads the visual state
+from a parent `DrawerProvider` and syncs the `--drawer-swipe-progress` and
+`--drawer-height` CSS variables onto its element.
+
+<!-- @include: @/meta/DrawerIndent.md -->
+
+<DataAttributesTable
+  :data="[
+    {
+      attribute: '[data-active]',
+      values: ['Present when a drawer is open'],
+    },
+    {
+      attribute: '[data-inactive]',
+      values: ['Present when no drawer is open'],
+    },
+  ]"
+/>
+
+### IndentBackground
+
+The backdrop layer revealed behind an indented page (typically a solid colour
+that peeks out as the page scales down). Companion to `Indent`.
+
+<!-- @include: @/meta/DrawerIndentBackground.md -->
+
+<DataAttributesTable
+  :data="[
+    {
+      attribute: '[data-active]',
+      values: ['Present when a drawer is open'],
+    },
+    {
+      attribute: '[data-inactive]',
+      values: ['Present when no drawer is open'],
+    },
+  ]"
+/>
+
+## Examples
+
+### Choosing a side
+
+`DrawerRoot` slides up from the bottom by default. Set `swipeDirection` to change
+the edge the drawer attaches to and the direction users swipe to dismiss it.
+
+```vue line=2
+<template>
+  <DrawerRoot swipe-direction="right">
+    <DrawerTrigger>Open</DrawerTrigger>
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerContent>...</DrawerContent>
+    </DrawerPortal>
+  </DrawerRoot>
+</template>
+```
+
+```css
+/* A right-anchored drawer slides along the X axis instead. */
+.DrawerContent {
+  position: fixed;
+  inset-block: 0;
+  right: 0;
+  width: 20rem;
+  transform: translateX(var(--drawer-swipe-movement-x, 0px));
+  transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.DrawerContent[data-state='open'] { animation: slideInRight 450ms cubic-bezier(0.32, 0.72, 0, 1); }
+.DrawerContent[data-state='closed'] { animation: slideOutRight 450ms cubic-bezier(0.32, 0.72, 0, 1); }
+.DrawerContent[data-swiping] { transition-duration: 0ms; }
+
+@keyframes slideInRight { from { translate: 100% 0; } }
+@keyframes slideOutRight { to { translate: 100% 0; } }
+```
+
+### Snap points
+
+Provide `snapPoints` to give the drawer intermediate resting positions. Each point
+is a fraction (`0`–`1`), a pixel value (`> 1`), or a string like `'148px'` /
+`'30rem'`. Use `v-model:snapPoint` to read or control the active one.
+
+```vue line=5-9
+<script setup>
+import { DrawerContent, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTrigger } from 'reka-ui'
+import { ref } from 'vue'
+
+const snapPoints = [0.4, 0.75, 1]
+const activeSnapPoint = ref(0.4)
+</script>
+
+<template>
+  <DrawerRoot
+    v-model:snap-point="activeSnapPoint"
+    :snap-points="snapPoints"
+  >
+    <DrawerTrigger>Open</DrawerTrigger>
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerContent>...</DrawerContent>
+    </DrawerPortal>
+  </DrawerRoot>
+</template>
+```
+
+### Non-modal drawer
+
+By default the drawer is `modal`: it traps focus, locks scroll, and dismisses on
+outside press. Set `modal` to `'trap-focus'` to keep the focus trap while still
+allowing interaction with the rest of the page (no overlay is rendered), or to
+`false` for a fully non-modal panel.
+
+```vue line=2
+<template>
+  <DrawerRoot :modal="false">
+    <DrawerTrigger>Open</DrawerTrigger>
+    <DrawerPortal>
+      <DrawerContent>...</DrawerContent>
+    </DrawerPortal>
+  </DrawerRoot>
+</template>
+```
+
+### Reacting to why the drawer closed
+
+The `update:open` event carries a `details` object whose `reason` tells you what
+triggered the change — useful for distinguishing a deliberate close from a swipe.
+
+```vue line=4-9
+<script setup>
+import { DrawerContent, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTrigger } from 'reka-ui'
+
+function onOpenChange(open, details) {
+  if (!open && details?.reason === 'swipe') {
+    // user flicked the drawer away
+  }
+}
+</script>
+
+<template>
+  <DrawerRoot @update:open="onOpenChange">
+    <DrawerTrigger>Open</DrawerTrigger>
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerContent>...</DrawerContent>
+    </DrawerPortal>
+  </DrawerRoot>
+</template>
+```
+
+Possible reasons are `swipe`, `escape-key`, `outside-press`, `click`, `cancel`,
+`trigger-press` and `close-press`.
+
+### Close using slot props
+
+`DrawerRoot` exposes `open` and `close` via its default slot, so you can close the
+drawer programmatically from anywhere inside it.
+
+```vue line=2
+<template>
+  <DrawerRoot v-slot="{ close }">
+    <DrawerTrigger>Open</DrawerTrigger>
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerContent>
+        <form @submit.prevent="close">
+          <!-- some inputs -->
+          <button type="submit">
+            Save
+          </button>
+        </form>
+      </DrawerContent>
+    </DrawerPortal>
+  </DrawerRoot>
+</template>
+```
+
+## Accessibility
+
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/).
+
+### Keyboard Interactions
+
+<KeyboardTable
+  :data="[
+    {
+      keys: ['Space'],
+      description: 'Opens/closes the drawer.',
+    },
+    {
+      keys: ['Enter'],
+      description: 'Opens/closes the drawer.',
+    },
+    {
+      keys: ['Tab'],
+      description: 'Moves focus to the next focusable element.',
+    },
+    {
+      keys: ['Shift + Tab'],
+      description: 'Moves focus to the previous focusable element.',
+    },
+    {
+      keys: ['Esc'],
+      description: '<span>Closes the drawer and moves focus to <Code>DrawerTrigger</Code>.</span>',
+    },
+  ]"
+/>
+
+## Custom APIs
+
+Create your own API by abstracting the primitive parts into your own component.
+
+### Abstract the overlay and the portal
+
+This example abstracts the `DrawerPortal` and `DrawerOverlay` parts.
+
+#### Usage
+
+```vue
+<script setup>
+import { Drawer, DrawerContent, DrawerTrigger } from './your-drawer'
+</script>
+
+<template>
+  <Drawer>
+    <DrawerTrigger>Drawer trigger</DrawerTrigger>
+    <DrawerContent>Drawer Content</DrawerContent>
+  </Drawer>
+</template>
+```
+
+#### Implementation
+
+```ts
+// your-drawer.ts
+export { default as DrawerContent } from 'DrawerContent.vue'
+export { DrawerRoot as Drawer, DrawerTrigger } from 'reka-ui'
+```
+
+```vue
+<!-- DrawerContent.vue -->
+<script setup lang="ts">
+import type { DrawerContentEmits, DrawerContentProps } from 'reka-ui'
+import { DrawerContent, DrawerHandle, DrawerOverlay, DrawerPortal, useForwardPropsEmits } from 'reka-ui'
+
+const props = defineProps<DrawerContentProps>()
+const emits = defineEmits<DrawerContentEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerContent v-bind="forwarded">
+      <DrawerHandle />
+      <slot />
+    </DrawerContent>
+  </DrawerPortal>
+</template>
+```

--- a/docs/content/meta/DrawerClose.md
+++ b/docs/content/meta/DrawerClose.md
@@ -1,0 +1,30 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'button\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"button"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+
+</llm-only>

--- a/docs/content/meta/DrawerContent.md
+++ b/docs/content/meta/DrawerContent.md
@@ -1,0 +1,102 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'disableOutsidePointerEvents',
+    'description': '<p>When <code>true</code>, hover/focus/click interactions will be disabled on elements outside\nthe <code>DismissableLayer</code>. Users will need to click twice on outside elements to\ninteract with them: once to close the <code>DismissableLayer</code>, and again to trigger the element.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'finalFocus',
+    'description': '<p>Final focus target when the drawer closes.</p>\n<ul>\n<li><code>true</code> / default: focus the trigger</li>\n<li><code>false</code>: do not restore focus</li>\n<li>element ref: focus that specific element</li>\n</ul>\n',
+    'type': 'boolean | HTMLElement | null',
+    'required': false
+  },
+  {
+    'name': 'forceMount',
+    'description': '',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'initialFocus',
+    'description': '<p>Initial focus target when the drawer opens.</p>\n<ul>\n<li><code>true</code> / default: focus the first focusable element inside</li>\n<li><code>false</code>: do not focus anything</li>\n<li>element ref: focus that specific element</li>\n</ul>\n',
+    'type': 'boolean | HTMLElement | null',
+    'required': false
+  }
+]" />
+
+<EmitsTable :data="[
+  {
+    'name': 'closeAutoFocus',
+    'description': '<p>Event handler called when auto-focusing on close.\nCan be prevented.</p>\n',
+    'type': '[event: Event]'
+  },
+  {
+    'name': 'escapeKeyDown',
+    'description': '<p>Event handler called when the escape key is down.\nCan be prevented.</p>\n',
+    'type': '[event: KeyboardEvent]'
+  },
+  {
+    'name': 'focusOutside',
+    'description': '<p>Event handler called when the focus moves outside of the <code>DismissableLayer</code>.\nCan be prevented.</p>\n',
+    'type': '[event: FocusOutsideEvent]'
+  },
+  {
+    'name': 'interactOutside',
+    'description': '<p>Event handler called when an interaction happens outside the <code>DismissableLayer</code>.\nSpecifically, when a <code>pointerdown</code> event happens outside or focus moves outside of it.\nCan be prevented.</p>\n',
+    'type': '[event: PointerDownOutsideEvent | FocusOutsideEvent]'
+  },
+  {
+    'name': 'openAutoFocus',
+    'description': '<p>Event handler called when auto-focusing on open.\nCan be prevented.</p>\n',
+    'type': '[event: Event]'
+  },
+  {
+    'name': 'pointerDownOutside',
+    'description': '<p>Event handler called when a <code>pointerdown</code> event happens outside of the <code>DismissableLayer</code>.\nCan be prevented.</p>\n',
+    'type': '[event: PointerDownOutsideEvent]'
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+| `disableOutsidePointerEvents` | When true, hover/focus/click interactions will be disabled on elements outside the DismissableLayer. Users will need to click twice on outside elements to interact with them: once to close the DismissableLayer, and again to trigger the element. | `boolean` | No | - |
+| `finalFocus` | Final focus target when the drawer closes.  true / default: focus the trigger false: do not restore focus element ref: focus that specific element | `boolean \| HTMLElement \| null` | No | - |
+| `forceMount` |  | `boolean` | No | - |
+| `initialFocus` | Initial focus target when the drawer opens.  true / default: focus the first focusable element inside false: do not focus anything element ref: focus that specific element | `boolean \| HTMLElement \| null` | No | - |
+
+**Events**
+
+| Name | Description | Type |
+| --- | --- | --- |
+| `closeAutoFocus` | Event handler called when auto-focusing on close. Can be prevented. | `[event: Event]` |
+| `escapeKeyDown` | Event handler called when the escape key is down. Can be prevented. | `[event: KeyboardEvent]` |
+| `focusOutside` | Event handler called when the focus moves outside of the DismissableLayer. Can be prevented. | `[event: FocusOutsideEvent]` |
+| `interactOutside` | Event handler called when an interaction happens outside the DismissableLayer. Specifically, when a pointerdown event happens outside or focus moves outside of it. Can be prevented. | `[event: PointerDownOutsideEvent \| FocusOutsideEvent]` |
+| `openAutoFocus` | Event handler called when auto-focusing on open. Can be prevented. | `[event: Event]` |
+| `pointerDownOutside` | Event handler called when a pointerdown event happens outside of the DismissableLayer. Can be prevented. | `[event: PointerDownOutsideEvent]` |
+
+</llm-only>

--- a/docs/content/meta/DrawerDescription.md
+++ b/docs/content/meta/DrawerDescription.md
@@ -1,0 +1,30 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'p\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"p"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+
+</llm-only>

--- a/docs/content/meta/DrawerHandle.md
+++ b/docs/content/meta/DrawerHandle.md
@@ -1,0 +1,30 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+
+</llm-only>

--- a/docs/content/meta/DrawerIndent.md
+++ b/docs/content/meta/DrawerIndent.md
@@ -1,0 +1,30 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+
+</llm-only>

--- a/docs/content/meta/DrawerIndentBackground.md
+++ b/docs/content/meta/DrawerIndentBackground.md
@@ -1,0 +1,30 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+
+</llm-only>

--- a/docs/content/meta/DrawerOverlay.md
+++ b/docs/content/meta/DrawerOverlay.md
@@ -1,0 +1,46 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'forceMount',
+    'description': '<p>Keep mounted for animation control.</p>\n',
+    'type': 'boolean',
+    'required': false,
+    'default': 'false'
+  },
+  {
+    'name': 'forceRender',
+    'description': '<p>Render even when inside a nested drawer.</p>\n',
+    'type': 'boolean',
+    'required': false,
+    'default': 'false'
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+| `forceMount` | Keep mounted for animation control. | `boolean` | No | `false` |
+| `forceRender` | Render even when inside a nested drawer. | `boolean` | No | `false` |
+
+</llm-only>

--- a/docs/content/meta/DrawerPortal.md
+++ b/docs/content/meta/DrawerPortal.md
@@ -1,0 +1,43 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'defer',
+    'description': '<p>Defer the resolving of a Teleport target until other parts of the\napplication have mounted (requires Vue 3.5.0+)</p>\n<p><a href=\'https://vuejs.org/guide/built-ins/teleport.html#deferred-teleport\' target=\'_blank\'>reference</a></p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'disabled',
+    'description': '<p>Disable teleport and render the component inline</p>\n<p><a href=\'https://vuejs.org/guide/built-ins/teleport.html#disabling-teleport\' target=\'_blank\'>reference</a></p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'forceMount',
+    'description': '<p>Used to force mounting when more control is needed. Useful when\ncontrolling animation with Vue animation libraries.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'to',
+    'description': '<p>Vue native teleport component prop <code>:to</code></p>\n<p><a href=\'https://vuejs.org/guide/built-ins/teleport.html#basic-usage\' target=\'_blank\'>reference</a></p>\n',
+    'type': 'string | HTMLElement',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `defer` | Defer the resolving of a Teleport target until other parts of the application have mounted (requires Vue 3.5.0+) reference | `boolean` | No | - |
+| `disabled` | Disable teleport and render the component inline reference | `boolean` | No | - |
+| `forceMount` | Used to force mounting when more control is needed. Useful when controlling animation with Vue animation libraries. | `boolean` | No | - |
+| `to` | Vue native teleport component prop :to reference | `string \| HTMLElement` | No | - |
+
+</llm-only>

--- a/docs/content/meta/DrawerRoot.md
+++ b/docs/content/meta/DrawerRoot.md
@@ -1,0 +1,121 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'defaultOpen',
+    'description': '',
+    'type': 'boolean',
+    'required': false,
+    'default': 'false'
+  },
+  {
+    'name': 'defaultSnapPoint',
+    'description': '',
+    'type': 'null | string | number',
+    'required': false
+  },
+  {
+    'name': 'modal',
+    'description': '<p>Modality of the drawer.</p>\n<ul>\n<li><code>true</code> (default): modal with focus trap, scroll lock, and outside-press dismiss</li>\n<li><code>\'trap-focus\'</code>: traps focus but allows outside pointer events (non-modal side panels)</li>\n<li><code>false</code>: non-modal</li>\n</ul>\n',
+    'type': 'false | true | \'trap-focus\'',
+    'required': false,
+    'default': 'true'
+  },
+  {
+    'name': 'open',
+    'description': '<p>v-model:open</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'snapPoint',
+    'description': '<p>v-model:snapPoint</p>\n',
+    'type': 'null | string | number',
+    'required': false
+  },
+  {
+    'name': 'snapPoints',
+    'description': '<p>Preset snap positions (fractions 0-1, pixels &gt;1, or \'148px\'/\'30rem\' strings)</p>\n',
+    'type': 'DrawerSnapPoint[]',
+    'required': false
+  },
+  {
+    'name': 'snapToSequentialPoints',
+    'description': '<p>When true, snaps to the next sequential snap point (one step at a time).\nWhen false, snaps to the nearest snap point by distance.</p>\n',
+    'type': 'boolean',
+    'required': false,
+    'default': 'false'
+  },
+  {
+    'name': 'swipeDirection',
+    'description': '<p>Direction to swipe to dismiss.</p>\n',
+    'type': '\'right\' | \'left\' | \'down\' | \'up\'',
+    'required': false,
+    'default': '\'down\''
+  }
+]" />
+
+<EmitsTable :data="[
+  {
+    'name': 'update:open',
+    'description': '<p>Event handler called when the open state of the dialog changes.</p>\n',
+    'type': '[value: boolean, details?: DrawerOpenChangeDetails]'
+  },
+  {
+    'name': 'update:openComplete',
+    'description': '',
+    'type': '[value: boolean]'
+  },
+  {
+    'name': 'update:snapPoint',
+    'description': '',
+    'type': '[value: DrawerSnapPoint | null]'
+  }
+]" />
+
+<SlotsTable :data="[
+  {
+    'name': 'open',
+    'description': '',
+    'type': 'boolean'
+  },
+  {
+    'name': 'close',
+    'description': '',
+    'type': '(): void'
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `defaultOpen` |  | `boolean` | No | `false` |
+| `defaultSnapPoint` |  | `null \| string \| number` | No | - |
+| `modal` | Modality of the drawer.  true (default): modal with focus trap, scroll lock, and outside-press dismiss 'trap-focus': traps focus but allows outside pointer events (non-modal side panels) false: non-modal | `false \| true \| "trap-focus"` | No | `true` |
+| `open` | v-model:open | `boolean` | No | - |
+| `snapPoint` | v-model:snapPoint | `null \| string \| number` | No | - |
+| `snapPoints` | Preset snap positions (fractions 0-1, pixels >1, or '148px'/'30rem' strings) | `DrawerSnapPoint[]` | No | - |
+| `snapToSequentialPoints` | When true, snaps to the next sequential snap point (one step at a time). When false, snaps to the nearest snap point by distance. | `boolean` | No | `false` |
+| `swipeDirection` | Direction to swipe to dismiss. | `"right" \| "left" \| "down" \| "up"` | No | `"down"` |
+
+**Events**
+
+| Name | Description | Type |
+| --- | --- | --- |
+| `update:open` | Event handler called when the open state of the dialog changes. | `[value: boolean, details?: DrawerOpenChangeDetails]` |
+| `update:openComplete` |  | `[value: boolean]` |
+| `update:snapPoint` |  | `[value: DrawerSnapPoint \| null]` |
+
+**Slots**
+
+| Name | Description | Type |
+| --- | --- | --- |
+| `open` |  | `boolean` |
+| `close` |  | `(): void` |
+
+</llm-only>

--- a/docs/content/meta/DrawerSwipeArea.md
+++ b/docs/content/meta/DrawerSwipeArea.md
@@ -1,0 +1,45 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'disabled',
+    'description': '<p>Disable swipe-to-open.</p>\n',
+    'type': 'boolean',
+    'required': false,
+    'default': 'false'
+  },
+  {
+    'name': 'swipeDirection',
+    'description': '<p>Override the open swipe direction (defaults to opposite of Root\'s swipeDirection).</p>\n',
+    'type': '\'right\' | \'left\' | \'down\' | \'up\'',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+| `disabled` | Disable swipe-to-open. | `boolean` | No | `false` |
+| `swipeDirection` | Override the open swipe direction (defaults to opposite of Root's swipeDirection). | `"right" \| "left" \| "down" \| "up"` | No | - |
+
+</llm-only>

--- a/docs/content/meta/DrawerTitle.md
+++ b/docs/content/meta/DrawerTitle.md
@@ -1,0 +1,30 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'h2\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"h2"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+
+</llm-only>

--- a/docs/content/meta/DrawerTrigger.md
+++ b/docs/content/meta/DrawerTrigger.md
@@ -1,0 +1,30 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'button\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"button"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+
+</llm-only>

--- a/docs/content/meta/DrawerViewport.md
+++ b/docs/content/meta/DrawerViewport.md
@@ -1,0 +1,30 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'as',
+    'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
+    'type': 'AsTag | Component',
+    'required': false,
+    'default': '\'div\''
+  },
+  {
+    'name': 'asChild',
+    'description': '<p>Change the default rendered element for the one passed as a child, merging their props and behavior.</p>\n<p>Read our <a href=\'https://www.reka-ui.com/docs/guides/composition\'>Composition</a> guide for more details.</p>\n',
+    'type': 'boolean',
+    'required': false
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
+| `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
+
+</llm-only>

--- a/docs/scripts/autogen.ts
+++ b/docs/scripts/autogen.ts
@@ -22,6 +22,19 @@ md.use(transformJSDocLinks)
 const checkerOptions: MetaCheckerOptions = {
   forceUseTs: true,
   printer: { newLine: 1 },
+  // vue-component-meta v3 defaults `schema` to `false`, which stops it from
+  // expanding type aliases/unions into nested enum schemas (props collapse to
+  // alias names like `Direction`, and slot tables are dropped). v2 expanded by
+  // default; restore that so `parseTypeFromSchema` sees the enum members again.
+  schema: true,
+  // KNOWN v3 LIMITATION: generic SFC params (`<script setup generic="T ...">`)
+  // are no longer instantiated to their default/constraint type. v2 resolved
+  // them (e.g. `T` -> `string | string[]`, `T[]` -> `AcceptableValue[]`); v3
+  // emits the bare `T` / `Type` / conditional type. Affects the value props of
+  // generic components (Accordion, Combobox, Listbox, Select, Tree, Checkbox,
+  // PinInput, Tabs, TagsInput, Switch). No clean fix via the public API yet
+  // (getBaseConstraintOfType / manual constraint substitution diverge from v2),
+  // so a full regen will regress those few files until upstream resolves it.
 }
 
 const tsconfigChecker = createChecker(

--- a/packages/core/constant/components.ts
+++ b/packages/core/constant/components.ts
@@ -208,6 +208,22 @@ export const components = {
     'DialogDescription',
   ] as const,
 
+  drawer: [
+    'DrawerRoot',
+    'DrawerTrigger',
+    'DrawerPortal',
+    'DrawerOverlay',
+    'DrawerContent',
+    'DrawerClose',
+    'DrawerTitle',
+    'DrawerDescription',
+    'DrawerHandle',
+    'DrawerSwipeArea',
+    'DrawerViewport',
+    'DrawerIndent',
+    'DrawerIndentBackground',
+  ] as const,
+
   dropdownMenu: [
     'DropdownMenuRoot',
     'DropdownMenuTrigger',


### PR DESCRIPTION
## Summary

Documents the **Drawer** primitive added in #2689, which shipped without docs.

- New doc page `docs/content/docs/components/drawer.md`: anatomy, an *Animating the drawer* section covering the swipe CSS custom properties (`--drawer-swipe-movement-x/y`, `--drawer-snap-point-offset`, `--drawer-swipe-progress`), full API reference for all 13 parts with data-attribute tables, and examples (choosing a side, snap points, modality, close reasons, slot props).
- Tailwind + CSS demos under `docs/components/demo/Drawer/`. Note the demo's animation/swipe styles are intentionally **non-scoped** — `DrawerContent`/`DrawerOverlay` are teleported to `body`, so scoped styles wouldn't reach them.
- Registers the family in `packages/core/constant/components.ts` so `docs:gen` emits its API tables, adds the sidebar entry, and marks it **Alpha** (sidebar badge + on-page `<Badge>`).

## Toolchain fix (separate commit)

While generating the meta tables I found `pnpm docs:gen` was producing degraded output for the whole repo: `vue-component-meta` was bumped v2 → v3 (#2427) but the option default for `schema` flipped to `false`, so type unions collapsed to alias names and all SlotsTables were dropped. The first commit sets `schema: true` to restore v2's expansion (verified: cuts a full-regen diff from 143 → 46 files). A known v3 limitation remains (generic SFC params no longer resolve to their constraint — affects ~17 generic components); it's documented inline and existing meta files are left untouched so they keep their good output until upstream fixes it.

## Test plan

- [ ] `pnpm --filter docs docs:dev` → Drawer page renders, demo is interactive (open, swipe-to-dismiss), Alpha badge shows in sidebar + page.
- [ ] All `@include` meta references resolve; API tables populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Drawer component, including edge slide-in behavior, swipe interactions, snap points, and configurable modal/non-modal operation.

* **Documentation**
  * Added Drawer docs and API reference for the main component and key subcomponents.
  * Included working Drawer examples (standard CSS and Tailwind-styled demos) and updated the site navigation to include the new Drawer entry (Alpha).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->