### PR TITLE
feat(ConfigProvider): add `teleportTo` for global default teleport target

### DIFF
--- a/docs/content/meta/ConfigProvider.md
+++ b/docs/content/meta/ConfigProvider.md
@@ -30,6 +30,12 @@
     'default': 'true'
   },
   {
+    'name': 'teleportTo',
+    'description': '<p>The global default teleport target for all portalled primitives (e.g. <code>Dialog</code>, <code>Popover</code>, <code>Tooltip</code>).\nIndividual <code>*Portal</code> components can still override this via their own <code>to</code> prop.\nUseful when rendering inside a custom element / shadow DOM.</p>\n',
+    'type': 'string | HTMLElement',
+    'required': false
+  },
+  {
     'name': 'useId',
     'description': '<p>The global <code>useId</code> injection as a workaround for preventing hydration issue.</p>\n',
     'type': '(() =&gt; string)',
@@ -56,6 +62,7 @@
 | `locale` | The global locale of your application. This will be inherited by all primitives. | `string` | No | `"en"` |
 | `nonce` | The global nonce value of your application. This will be inherited by the related primitives. | `string` | No | - |
 | `scrollBody` | The global scroll body behavior of your application. This will be inherited by the related primitives. | `boolean \| ScrollBodyOption` | No | `true` |
+| `teleportTo` | The global default teleport target for all portalled primitives (e.g. Dialog, Popover, Tooltip). Individual *Portal components can still override this via their own to prop. Useful when rendering inside a custom element / shadow DOM. | `string \| HTMLElement` | No | - |
 | `useId` | The global useId injection as a workaround for preventing hydration issue. | `(() => string)` | No | - |
 
 **Methods**

--- a/packages/core/src/ConfigProvider/ConfigProvider.vue
+++ b/packages/core/src/ConfigProvider/ConfigProvider.vue
@@ -8,6 +8,7 @@ interface ConfigProviderContextValue {
   locale?: Ref<string>
   scrollBody?: Ref<boolean | ScrollBodyOption>
   nonce?: Ref<string | undefined>
+  teleportTo?: Ref<string | HTMLElement | undefined>
   useId?: () => string
 }
 
@@ -36,6 +37,13 @@ export interface ConfigProviderProps {
    */
   nonce?: string
   /**
+   * The global default teleport target for all portalled primitives (e.g. `Dialog`, `Popover`, `Tooltip`).
+   * Individual `*Portal` components can still override this via their own `to` prop.
+   * Useful when rendering inside a custom element / shadow DOM.
+   * @type string | HTMLElement
+   */
+  teleportTo?: string | HTMLElement
+  /**
    * The global `useId` injection as a workaround for preventing hydration issue.
    */
   useId?: () => string
@@ -54,16 +62,18 @@ const props = withDefaults(defineProps<ConfigProviderProps>(), {
   locale: 'en',
   scrollBody: true,
   nonce: undefined,
+  teleportTo: undefined,
   useId: undefined,
 })
 
-const { dir, locale, scrollBody, nonce } = toRefs(props)
+const { dir, locale, scrollBody, nonce, teleportTo } = toRefs(props)
 
 provideConfigProviderContext({
   dir,
   locale,
   scrollBody,
   nonce,
+  teleportTo,
   useId: props.useId,
 })
 </script>

--- a/packages/core/src/Teleport/Teleport.test.ts
+++ b/packages/core/src/Teleport/Teleport.test.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
+import { ConfigProvider } from '@/ConfigProvider'
 import Teleport from './Teleport.vue'
 
 describe('given default Teleport', () => {
@@ -81,5 +82,60 @@ describe('given default Teleport', () => {
 
     wrapper.unmount()
     container.remove()
+  })
+
+  it('uses the ConfigProvider `teleportTo` target as the default', async () => {
+    const container = document.createElement('div')
+    container.id = 'config-container'
+    document.body.appendChild(container)
+
+    const Host = defineComponent({
+      setup() {
+        return () => h(ConfigProvider, { teleportTo: '#config-container' }, {
+          default: () => h(Teleport, { forceMount: true }, {
+            default: () => h('span', { id: 'config-teleported' }, 'config target'),
+          }),
+        })
+      },
+    })
+
+    const wrapper = mount(Host, { attachTo: document.body })
+    await nextTick()
+
+    const teleported = document.getElementById('config-teleported')
+    expect(teleported).not.toBeNull()
+    expect(container.contains(teleported)).toBe(true)
+
+    wrapper.unmount()
+    container.remove()
+  })
+
+  it('prefers an explicit `to` prop over the ConfigProvider `teleportTo`', async () => {
+    const configContainer = document.createElement('div')
+    configContainer.id = 'config-fallback'
+    const explicitContainer = document.createElement('div')
+    explicitContainer.id = 'explicit-target'
+    document.body.append(configContainer, explicitContainer)
+
+    const Host = defineComponent({
+      setup() {
+        return () => h(ConfigProvider, { teleportTo: '#config-fallback' }, {
+          default: () => h(Teleport, { to: '#explicit-target', forceMount: true }, {
+            default: () => h('span', { id: 'override-teleported' }, 'override target'),
+          }),
+        })
+      },
+    })
+
+    const wrapper = mount(Host, { attachTo: document.body })
+    await nextTick()
+
+    const teleported = document.getElementById('override-teleported')
+    expect(explicitContainer.contains(teleported)).toBe(true)
+    expect(configContainer.contains(teleported)).toBe(false)
+
+    wrapper.unmount()
+    configContainer.remove()
+    explicitContainer.remove()
   })
 })

--- a/packages/core/src/Teleport/Teleport.vue
+++ b/packages/core/src/Teleport/Teleport.vue
@@ -29,10 +29,14 @@ export interface TeleportProps {
 
 <script setup lang="ts">
 import { useMounted } from '@vueuse/core'
+import { computed } from 'vue'
+import { injectConfigProviderContext } from '@/ConfigProvider/ConfigProvider.vue'
 
-withDefaults(defineProps<TeleportProps>(), {
-  to: 'body',
-})
+const props = defineProps<TeleportProps>()
+
+const configContext = injectConfigProviderContext({})
+
+const target = computed(() => props.to ?? configContext.teleportTo?.value ?? 'body')
 
 const isMounted = useMounted()
 </script>
@@ -40,7 +44,7 @@ const isMounted = useMounted()
 <template>
   <Teleport
     v-if="isMounted || forceMount"
-    :to="to"
+    :to="target"
     :disabled="disabled"
     :defer="defer"
   >


### PR DESCRIPTION
Closes #2225.

### Summary
Adds a `teleportTo` prop to `ConfigProvider` so apps can set a single default Teleport target that every portalled primitive (`Dialog`, `Popover`, `Tooltip`, `Menu`, …) inherits — instead of passing `to` to each `*Portal` individually. This is primarily useful when rendering inside a custom element / shadow DOM.

### Changes
- `ConfigProvider`: new optional `teleportTo?: string | HTMLElement` prop, provided through the config context.
- `Teleport`: resolves the target as `to ?? config.teleportTo ?? 'body'`, so:
  - no config + no prop → `'body'` (unchanged default),
  - config set → used as the default for all portals,
  - explicit `to` on a `*Portal` → still wins.
- Tests covering the config-default path and the explicit-override path.
- Regenerated the `ConfigProvider` API meta for the new prop.

### Notes
Fully backwards compatible — the `'body'` default is preserved when `teleportTo` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ConfigProvider now supports a global `teleportTo` configuration option to set a default teleport target for portalled components
  * Teleport components prioritize explicit targets but fall back to the ConfigProvider configuration when no target is specified

* **Documentation**
  * Updated ConfigProvider documentation with the new `teleportTo` prop details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->