### PR TITLE
perf(Checkbox): skip label querySelector when `aria-label` is provided

### DIFF
--- a/packages/core/src/Checkbox/Checkbox.test.ts
+++ b/packages/core/src/Checkbox/Checkbox.test.ts
@@ -1,8 +1,10 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
+import { nextTick } from 'vue'
 import { handleSubmit } from '@/test'
+import { CheckboxRoot } from '.'
 import Checkbox from './story/_Checkbox.vue'
 import CheckboxGroup from './story/_CheckboxGroup.vue'
 
@@ -59,6 +61,34 @@ describe('given a default Checkbox', () => {
         expect(wrapper.find('span').exists()).toBe(false)
       })
     })
+  })
+})
+
+describe('given a Checkbox with an explicit aria-label', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should not query the DOM for a label', () => {
+    const querySpy = vi.spyOn(document, 'querySelector')
+    const wrapper = mount(CheckboxRoot, {
+      attachTo: document.body,
+      attrs: { 'id': 'with-label', 'aria-label': 'Accept terms' },
+    })
+
+    expect(wrapper.find('button').attributes('aria-label')).toBe('Accept terms')
+    expect(querySpy).not.toHaveBeenCalledWith('[for="with-label"]')
+  })
+
+  it('should query for the associated label when no aria-label is given', async () => {
+    const querySpy = vi.spyOn(document, 'querySelector')
+    mount(CheckboxRoot, {
+      attachTo: document.body,
+      attrs: { id: 'without-label' },
+    })
+    await nextTick()
+
+    expect(querySpy).toHaveBeenCalledWith('[for="without-label"]')
   })
 })
 

--- a/packages/core/src/Checkbox/CheckboxRoot.vue
+++ b/packages/core/src/Checkbox/CheckboxRoot.vue
@@ -47,7 +47,7 @@ export const [injectCheckboxRootContext, provideCheckboxRootContext]
 
 <script setup lang="ts" generic="T = boolean">
 import { isEqual } from 'ohash'
-import { computed } from 'vue'
+import { computed, useAttrs } from 'vue'
 import { Primitive } from '@/Primitive'
 import { RovingFocusItem } from '@/RovingFocus'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
@@ -122,9 +122,16 @@ function handleClick() {
 }
 
 const isFormControl = useFormControl(currentElement)
-const ariaLabel = computed(() => props.id && currentElement.value
-  ? (document.querySelector(`[for="${props.id}"]`) as HTMLLabelElement)?.innerText
-  : undefined)
+const attrs = useAttrs()
+const ariaLabel = computed(() => {
+  // An explicit `aria-label` always wins, so skip the (potentially expensive)
+  // label lookup entirely — this matters when rendering many checkboxes at once.
+  if (attrs['aria-label'])
+    return undefined
+  return props.id && currentElement.value
+    ? (document.querySelector(`[for="${props.id}"]`) as HTMLLabelElement)?.innerText
+    : undefined
+})
 
 provideCheckboxRootContext({
   disabled,


### PR DESCRIPTION
Closes #2318.

### Summary
`CheckboxRoot` looks up a fallback aria-label by running `document.querySelector('[for="<id>"]')`. This runs even when an explicit `aria-label` is already provided, which gets expensive when rendering many checkboxes (e.g. hundreds in a data table).

### Changes
- Guard the lookup inside the `ariaLabel` computed via `useAttrs()`: when `aria-label` is present, return early and skip the query entirely. The explicit label always wins anyway, so behavior is unchanged.
- Tests: assert the `[for=...]` query is **not** called when `aria-label` is set, and **is** attempted as the fallback when it isn't.

### Notes
No API or behavior change — purely avoids unnecessary DOM work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for Checkbox component accessibility behavior with aria-label support.

* **Bug Fixes**
  * Improved Checkbox accessibility by properly handling explicit aria-label attributes while maintaining support for labels linked via the `for` attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->