### PR TITLE
feat(Combobox): add clearValue prop for custom reset value on clear

### DIFF
--- a/docs/content/docs/components/combobox.md
+++ b/docs/content/docs/components/combobox.md
@@ -590,6 +590,50 @@ import { ref } from 'vue'
 </template>
 ```
 
+### Custom clear value
+
+When `resetModelValueOnClear` is `true`, clicking `ComboboxCancel` will reset the `modelValue` back to `null` (or `[]` for multiple). Use `clearValue` to override this default and reset to a custom value instead.
+
+```vue line=5-6,14
+<script setup lang="ts">
+import {
+  ComboboxCancel,
+  ComboboxContent,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxPortal,
+  ComboboxRoot,
+} from 'reka-ui'
+import { ref } from 'vue'
+
+const selectedPerson = ref('Durward Reynolds')
+</script>
+
+<template>
+  <ComboboxRoot
+    v-model="selectedPerson"
+    reset-model-value-on-clear
+    clear-value="No one selected"
+  >
+    <ComboboxInput placeholder="Search person..." />
+    <ComboboxCancel>Clear</ComboboxCancel>
+    <ComboboxPortal>
+      <ComboboxContent>
+        <ComboboxItem value="Durward Reynolds">
+          Durward Reynolds
+        </ComboboxItem>
+        <ComboboxItem value="Kenton Towne">
+          Kenton Towne
+        </ComboboxItem>
+        <ComboboxItem value="Therese Wunsch">
+          Therese Wunsch
+        </ComboboxItem>
+      </ComboboxContent>
+    </ComboboxPortal>
+  </ComboboxRoot>
+</template>
+```
+
 ### Virtualized combobox with working filtering
 
 Combobox items **must** be filtered manually before passing them over to the virtualizer.

--- a/docs/content/docs/components/combobox.md
+++ b/docs/content/docs/components/combobox.md
@@ -592,7 +592,7 @@ import { ref } from 'vue'
 
 ### Custom clear value
 
-When `resetModelValueOnClear` is `true`, clicking `ComboboxCancel` will reset the `modelValue` back to `null` (or `[]` for multiple). Use `clearValue` to override this default and reset to a custom value instead.
+When `resetModelValueOnClear` is `true`, clicking `ComboboxCancel` will reset the `modelValue`. In single-select mode, it resets to `null` by default, but you can use `clearValue` to specify a custom value. In multiple-select mode, it always resets to `[]`, regardless of `clearValue`.
 
 ```vue line=5-6,14
 <script setup lang="ts">

--- a/docs/content/meta/ComboboxRoot.md
+++ b/docs/content/meta/ComboboxRoot.md
@@ -22,6 +22,12 @@
     'required': false
   },
   {
+    'name': 'clearValue',
+    'description': '<p>The value to set the <code>modelValue</code> to when the combobox is cleared\nand <code>resetModelValueOnClear</code> is <code>true</code>. When not provided, defaults to\n<code>null</code> for single select or <code>[]</code> for multiple select.</p>\n',
+    'type': 'T',
+    'required': false
+  },
+  {
     'name': 'defaultOpen',
     'description': '<p>The open state of the combobox when it is initially rendered. &lt;br&gt; Use when you do not need to control its open state.</p>\n',
     'type': 'boolean',
@@ -166,6 +172,7 @@
 | `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
 | `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
 | `by` | Use this to compare objects by a particular field, or pass your own comparison function for complete control over how objects are compared. | `string \| ((a: T, b: T) => boolean)` | No | - |
+| `clearValue` | The value to set the modelValue to when the combobox is cleared and resetModelValueOnClear is true. When not provided, defaults to null for single select or [] for multiple select. | `T` | No | - |
 | `defaultOpen` | The open state of the combobox when it is initially rendered. <br> Use when you do not need to control its open state. | `boolean` | No | - |
 | `defaultValue` | The value of the listbox when initially rendered. Use when you do not need to control the state of the Listbox | `T \| T[]` | No | - |
 | `dir` | The reading direction of the listbox when applicable. <br> If omitted, inherits globally from ConfigProvider or assumes LTR (left-to-right) reading mode. | `"ltr" \| "rtl"` | No | - |

--- a/packages/core/src/Autocomplete/AutocompleteRoot.vue
+++ b/packages/core/src/Autocomplete/AutocompleteRoot.vue
@@ -237,6 +237,7 @@ provideComboboxRootContext({
   openOnFocus,
   openOnClick,
   resetModelValueOnClear: ref(true),
+  clearValue: ref(undefined),
 })
 
 // Provide autocomplete-specific context

--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import { axe } from 'vitest-axe'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { handleSubmit, sleep } from '@/test'
-import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxRoot, ComboboxTrigger, ComboboxViewport, ComboboxVirtualizer } from '.'
+import { ComboboxAnchor, ComboboxCancel, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxRoot, ComboboxTrigger, ComboboxViewport, ComboboxVirtualizer } from '.'
 import Combobox from './story/_Combobox.vue'
 import ComboboxObject from './story/_ComboboxObject.vue'
 import ComboboxTagsInput from './story/_ComboboxTagsInput.vue'
@@ -837,5 +837,151 @@ describe('comboboxContent with popper positioning', () => {
 
     expect(wrapper.text()).toContain('Option 59')
     expect(wrapper.text()).not.toContain('Option 1')
+  })
+})
+
+describe('given Combobox with resetModelValueOnClear and clearValue', () => {
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn()
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn()
+  window.HTMLElement.prototype.scrollIntoView = vi.fn()
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('should reset modelValue to clearValue when resetModelValueOnClear is true and clearValue is set', async () => {
+    const modelValue = ref('Banana')
+
+    const ClearValueCombobox = defineComponent({
+      setup() {
+        return () => h(ComboboxRoot, {
+          'modelValue': modelValue.value,
+          'onUpdate:modelValue': (val: string) => modelValue.value = val,
+          'resetModelValueOnClear': true,
+          'clearValue': 'CLEARED',
+        }, {
+          default: () => [
+            h(ComboboxAnchor, null, {
+              default: () => [
+                h(ComboboxInput, { placeholder: 'Select...' }),
+                h(ComboboxCancel, null, { default: () => '×' }),
+              ],
+            }),
+            h(ComboboxContent, null, {
+              default: () => h(ComboboxViewport, null, {
+                default: () => [
+                  h(ComboboxItem, { value: 'Apple' }, { default: () => 'Apple' }),
+                  h(ComboboxItem, { value: 'Banana' }, { default: () => 'Banana' }),
+                  h(ComboboxItem, { value: 'Orange' }, { default: () => 'Orange' }),
+                ],
+              }),
+            }),
+          ],
+        })
+      },
+    })
+
+    const wrapper = mount(ClearValueCombobox, { attachTo: document.body })
+
+    // Input should show initially selected value
+    const input = wrapper.find('input')
+    expect((input.element as HTMLInputElement).value).toBe('Banana')
+
+    // Click the cancel button
+    const cancelButton = wrapper.find('button')
+    await cancelButton.trigger('click')
+    await nextTick()
+
+    // modelValue should be 'CLEARED' instead of null
+    expect(modelValue.value).toBe('CLEARED')
+  })
+
+  it('should reset modelValue to null when resetModelValueOnClear is true and clearValue is not set', async () => {
+    const modelValue = ref('Banana')
+
+    const NoClearValueCombobox = defineComponent({
+      setup() {
+        return () => h(ComboboxRoot, {
+          'modelValue': modelValue.value,
+          'onUpdate:modelValue': (val: string) => modelValue.value = val,
+          'resetModelValueOnClear': true,
+        }, {
+          default: () => [
+            h(ComboboxAnchor, null, {
+              default: () => [
+                h(ComboboxInput),
+                h(ComboboxCancel, null, { default: () => '×' }),
+              ],
+            }),
+            h(ComboboxContent, null, {
+              default: () => h(ComboboxViewport, null, {
+                default: () => [
+                  h(ComboboxItem, { value: 'Apple' }, { default: () => 'Apple' }),
+                  h(ComboboxItem, { value: 'Banana' }, { default: () => 'Banana' }),
+                ],
+              }),
+            }),
+          ],
+        })
+      },
+    })
+
+    const wrapper = mount(NoClearValueCombobox, { attachTo: document.body })
+
+    // Click the cancel button
+    const cancelButton = wrapper.find('button')
+    await cancelButton.trigger('click')
+    await nextTick()
+
+    // modelValue should be null (default behavior preserved)
+    expect(modelValue.value).toBeNull()
+  })
+
+  it('should reset modelValue to [] when resetModelValueOnClear is true with multiple and clearValue is set', async () => {
+    const modelValue = ref(['Banana', 'Apple'])
+
+    const MultipleClearValueCombobox = defineComponent({
+      setup() {
+        return () => h(ComboboxRoot, {
+          'modelValue': modelValue.value,
+          'onUpdate:modelValue': (val: string[]) => modelValue.value = val,
+          'multiple': true,
+          'resetModelValueOnClear': true,
+          'clearValue': 'SHOULD_IGNORE',
+        }, {
+          default: () => [
+            h(ComboboxAnchor, null, {
+              default: () => [
+                h(ComboboxInput),
+                h(ComboboxCancel, null, { default: () => '×' }),
+              ],
+            }),
+            h(ComboboxContent, null, {
+              default: () => h(ComboboxViewport, null, {
+                default: () => [
+                  h(ComboboxItem, { value: 'Apple' }, { default: () => 'Apple' }),
+                  h(ComboboxItem, { value: 'Banana' }, { default: () => 'Banana' }),
+                ],
+              }),
+            }),
+          ],
+        })
+      },
+    })
+
+    const wrapper = mount(MultipleClearValueCombobox, { attachTo: document.body })
+
+    // Click the cancel button
+    const cancelButton = wrapper.find('button')
+    await cancelButton.trigger('click')
+    await nextTick()
+
+    // modelValue should be [] in multiple mode regardless of clearValue
+    expect(modelValue.value).toEqual([])
   })
 })

--- a/packages/core/src/Combobox/ComboboxCancel.vue
+++ b/packages/core/src/Combobox/ComboboxCancel.vue
@@ -26,7 +26,12 @@ function handleClick() {
   }
 
   if (rootContext.resetModelValueOnClear?.value) {
-    rootContext.modelValue.value = rootContext.multiple.value ? [] : null
+    if (rootContext.multiple.value) {
+      rootContext.modelValue.value = []
+    }
+    else {
+      rootContext.modelValue.value = rootContext.clearValue?.value !== undefined ? rootContext.clearValue.value : null
+    }
   }
 }
 </script>

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -30,6 +30,7 @@ type ComboboxRootContext<T> = {
   openOnFocus: Ref<boolean>
   openOnClick: Ref<boolean>
   resetModelValueOnClear: Ref<boolean>
+  clearValue: Ref<T | undefined>
 }
 
 export const [injectComboboxRootContext, provideComboboxRootContext]
@@ -77,6 +78,12 @@ export interface ComboboxRootProps<T = AcceptableValue> extends Omit<ListboxRoot
    * When `true` the `modelValue` will be reset to `null` (or `[]` if `multiple`)
    */
   resetModelValueOnClear?: boolean
+  /**
+   * The value to set the `modelValue` to when the combobox is cleared
+   * and `resetModelValueOnClear` is `true`. When not provided, defaults to
+   * `null` for single select or `[]` for multiple select.
+   */
+  clearValue?: T
 }
 </script>
 
@@ -108,7 +115,7 @@ defineSlots<{
 }>()
 
 const { primitiveElement, currentElement: parentElement } = usePrimitiveElement<GenericComponentInstance<typeof ListboxRoot>>()
-const { multiple, disabled, ignoreFilter, resetSearchTermOnSelect, openOnFocus, openOnClick, dir: propDir, resetModelValueOnClear, highlightOnHover } = toRefs(props)
+const { multiple, disabled, ignoreFilter, resetSearchTermOnSelect, openOnFocus, openOnClick, dir: propDir, resetModelValueOnClear, clearValue, highlightOnHover } = toRefs(props)
 
 const dir = useDirection(propDir)
 
@@ -243,6 +250,7 @@ provideComboboxRootContext({
   openOnFocus,
   openOnClick,
   resetModelValueOnClear,
+  clearValue,
 })
 </script>
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2565

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a `clearValue` prop to `ComboboxRoot` that allows specifying a custom value to use when resetting the model value on clear (via `ComboboxCancel` with `resetModelValueOnClear: true`).

**Before:** clearing always reset to `null` (single) or `[]` (multiple).
**After:** when `clearValue` is set, single-select clears to that value instead of `null`. Multiple mode always resets to `[]` regardless of `clearValue` (by design — an empty array is the natural "nothing selected" state for multi-select).

**Changes:**
- `ComboboxRoot.vue` — add `clearValue` prop to `ComboboxRootProps` interface and `ComboboxRootContext` type
- `ComboboxCancel.vue` — use `clearValue` from context when resetting modelValue (falls back to `null` when not set)
- `AutocompleteRoot.vue` — add `clearValue: ref(undefined)` to provided Combobox context
- `Combobox.test.ts` — add 3 tests: custom clearValue, default null fallback, multiple mode ignores clearValue

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Tests: 45/45 pass (`npx vitest run src/Combobox/Combobox.test.ts`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `clearValue` prop to Combobox components to customize what `modelValue` is set to when cleared.

* **Bug Fixes**
  * Refined clear/cancel behavior so clearing resets `modelValue` to `clearValue` in single-select mode (or `null` when unset), and to `[]` in multiple-select mode.

* **Tests**
  * Added coverage for clear/cancel scenarios, including behavior with and without `clearValue`, and in multiple-select mode.

* **Documentation**
  * Updated `ComboboxRoot` prop docs and added an example demonstrating custom clear values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->