### PR TITLE
fix(Toolbar): forward disabled to ToolbarButton + reactive focusable count

### DIFF
--- a/packages/core/src/RovingFocus/RovingFocusItem.vue
+++ b/packages/core/src/RovingFocus/RovingFocusItem.vue
@@ -16,7 +16,7 @@ export interface RovingFocusItemProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
 import { useCollection } from '@/Collection'
 import { Primitive } from '@/Primitive'
 import { useId } from '@/shared'
@@ -44,6 +44,17 @@ onMounted(() => {
 onUnmounted(() => {
   if (props.focusable)
     context.onFocusableItemRemove()
+})
+
+watch(() => props.focusable, (newVal, oldVal) => {
+  if (newVal === oldVal)
+    return
+  if (newVal) {
+    context.onFocusableItemAdd()
+  }
+  else {
+    context.onFocusableItemRemove()
+  }
 })
 
 function handleKeydown(event: KeyboardEvent) {

--- a/packages/core/src/Toolbar/Toolbar.test.ts
+++ b/packages/core/src/Toolbar/Toolbar.test.ts
@@ -2,7 +2,11 @@ import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { defineComponent, nextTick, ref } from 'vue'
 import Toolbar from './story/_Toolbar.vue'
+import ToolbarRoot from './ToolbarRoot.vue'
+import ToolbarToggleGroup from './ToolbarToggleGroup.vue'
+import ToolbarToggleItem from './ToolbarToggleItem.vue'
 
 describe('given default Toolbar', () => {
   let wrapper: VueWrapper<InstanceType<typeof Toolbar>>
@@ -23,4 +27,70 @@ describe('given default Toolbar', () => {
   })
 
   // Since Toolbar is just a collection of ToggleGroup, so would exclude the test here
+})
+
+describe('given Toolbar with all ToolbarToggleItem disabled', () => {
+  it('should not be tabbable when all toggle items are disabled', async () => {
+    const TestComponent = defineComponent({
+      components: {
+        ToolbarRoot,
+        ToolbarToggleGroup,
+        ToolbarToggleItem,
+      },
+      setup() {
+        const model = ref([])
+        return { model }
+      },
+      template: `
+        <ToolbarRoot aria-label="Test toolbar">
+          <ToolbarToggleGroup v-model="model" type="multiple" aria-label="Formatting">
+            <ToolbarToggleItem value="bold" disabled>Bold</ToolbarToggleItem>
+            <ToolbarToggleItem value="italic" disabled>Italic</ToolbarToggleItem>
+            <ToolbarToggleItem value="underline" disabled>Underline</ToolbarToggleItem>
+          </ToolbarToggleGroup>
+        </ToolbarRoot>
+      `,
+    })
+
+    const wrapper = mount(TestComponent, { attachTo: document.body })
+    await nextTick()
+
+    // The ToolbarRoot should have tabindex="-1" since all items are disabled
+    const root = wrapper.find('[role="toolbar"]')
+    expect(root.attributes('tabindex')).toBe('-1')
+
+    wrapper.unmount()
+  })
+
+  it('should be tabbable when at least one toggle item is not disabled', async () => {
+    const TestComponent = defineComponent({
+      components: {
+        ToolbarRoot,
+        ToolbarToggleGroup,
+        ToolbarToggleItem,
+      },
+      setup() {
+        const model = ref([])
+        return { model }
+      },
+      template: `
+        <ToolbarRoot aria-label="Test toolbar">
+          <ToolbarToggleGroup v-model="model" type="multiple" aria-label="Formatting">
+            <ToolbarToggleItem value="bold">Bold</ToolbarToggleItem>
+            <ToolbarToggleItem value="italic" disabled>Italic</ToolbarToggleItem>
+            <ToolbarToggleItem value="underline" disabled>Underline</ToolbarToggleItem>
+          </ToolbarToggleGroup>
+        </ToolbarRoot>
+      `,
+    })
+
+    const wrapper = mount(TestComponent, { attachTo: document.body })
+    await nextTick()
+
+    // The ToolbarRoot should have tabindex="0" since there are focusable items
+    const root = wrapper.find('[role="toolbar"]')
+    expect(root.attributes('tabindex')).toBe('0')
+
+    wrapper.unmount()
+  })
 })

--- a/packages/core/src/Toolbar/ToolbarToggleItem.vue
+++ b/packages/core/src/Toolbar/ToolbarToggleItem.vue
@@ -14,7 +14,10 @@ const { forwardRef } = useForwardExpose()
 </script>
 
 <template>
-  <ToolbarButton as-child>
+  <ToolbarButton
+    as-child
+    :disabled="props.disabled"
+  >
     <ToggleGroupItem
       v-bind="props"
       :ref="forwardRef"


### PR DESCRIPTION
🔗 **Resolves** #2728

❓ **Type of change**
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

📚 **Description**

When all `ToolbarToggleItem` children are `disabled`, the `ToolbarRoot` still receives `tabindex="0"` and remains reachable via keyboard Tab navigation.

**Root cause:** `ToolbarToggleItem` was not forwarding its `disabled` prop to `ToolbarButton`, so `RovingFocusItem` always received `focusable=true` regardless of the item's disabled state.

**Additionally:** `RovingFocusItem` only updated `focusableItemsCount` on mount/unmount — dynamic `disabled` changes after mount were not reflected.

**Fixes:**
1. `ToolbarToggleItem` now forwards `disabled` prop to `ToolbarButton` 
2. `RovingFocusItem` now watches `focusable` prop and updates `focusableItemsCount` reactively
3. Added tests for all-disabled and mixed-disabled toolbar scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed roving focus items to dynamically add/remove from the focus group when their focusable state changes.
  * Improved toolbar accessibility with correct tabindex management based on toggle item disabled states.

* **Tests**
  * Added test coverage for toolbar tabindex behavior with disabled toggle items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->