### PR TITLE
fix(select): close open select when another opens

### DIFF
--- a/docs/content/showcase.md
+++ b/docs/content/showcase.md
@@ -19,6 +19,11 @@ packages:
     url: https://floatui.com/
     image: https://ph-files.imgix.net/56069229-222e-4364-88c6-8c5d4aa0c3e5.png?auto=compress&codec=mozjpeg&cs=strip&auto=format&fit=max&dpr=1
 
+  - title: Una UI
+    description: The Atomic UI Framework for Nuxt, Powered by Unocss engine.
+    url: https://unaui.com/
+    image: https://unaui.com/hero.png
+
 projects:
   - title: UnInbox
     description: Modern email for teams and professionals.

--- a/docs/content/showcase.md
+++ b/docs/content/showcase.md
@@ -65,6 +65,12 @@ projects:
     url: https://cider.sh
     image: https://cider.sh/og.png
 
+
+  - title: DevDb
+    description: A lightweight VS Code extension that auto-loads your database and provides affordances from your database to aid development and debugging.
+    url: https://github.com/damms005/devdb-vscode
+    image: https://github.com/damms005/devdb-vscode/raw/main/resources/screenshots/new/main-light-dark.png
+
 starters:
   - title: shadcn-docs
     description: A Nuxt content docs theme built with `shadcn-vue`

--- a/docs/content/showcase.md
+++ b/docs/content/showcase.md
@@ -71,6 +71,11 @@ projects:
     url: https://github.com/damms005/devdb-vscode
     image: https://github.com/damms005/devdb-vscode/raw/main/resources/screenshots/new/main-light-dark.png
 
+  - title: Movie Tracker
+    description: Your guide to movies and TV shows. Find movies and shows, create lists, share your thoughts.
+    url: https://movie-tracker.app/en
+    image: https://raw.githubusercontent.com/dapzer/movie-tracker/refs/heads/master/apps/frontend/src/public/ogImageEn.webp
+
 starters:
   - title: shadcn-docs
     description: A Nuxt content docs theme built with `shadcn-vue`

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs",
   "type": "module",
-  "version": "1.9.16",
+  "version": "1.9.17",
   "scripts": {
     "docs:dev": "vitepress dev",
     "docs:build": "vitepress build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radix-vue",
-  "version": "1.9.16",
+  "version": "1.9.17",
   "private": true,
   "packageManager": "pnpm@9.4.0",
   "license": "MIT",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugins",
   "type": "module",
-  "version": "1.9.16",
+  "version": "1.9.17",
   "description": "Nuxt module for Radix Vue",
   "license": "MIT",
   "keywords": [

--- a/packages/radix-vue/package.json
+++ b/packages/radix-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "radix-vue",
   "type": "module",
-  "version": "1.9.16",
+  "version": "1.9.17",
   "description": "Vue port for Radix UI Primitives.",
   "author": "Radix Vue Contributors (https://github.com/unovue/radix-vue)",
   "license": "MIT",

--- a/packages/radix-vue/src/Menu/story/MenuRadioItems.story.vue
+++ b/packages/radix-vue/src/Menu/story/MenuRadioItems.story.vue
@@ -30,7 +30,7 @@ function handleSelect(text: string) {
       <MenuWithAnchor>
         <MenuItem
           class="flex items-center justify-between leading-[1] cursor-default select-none whitespace-nowrap h-[25px] px-[10px] text-black rounded-[3px] outline-none data-[highlighted]:bg-black data-[highlighted]:text-white data-[disabled]:text-gray-100"
-          @select="handleSelect('minize')"
+          @select="handleSelect('minimize')"
         >
           Minimize window
         </MenuItem>

--- a/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbar.vue
+++ b/packages/radix-vue/src/ScrollArea/ScrollAreaScrollbar.vue
@@ -13,7 +13,7 @@ export interface ScrollAreaScrollbarProps extends PrimitiveProps {
   forceMount?: boolean
 }
 
-export interface ScrollAreaScollbarContext {
+export interface ScrollAreaScrollbarContext {
   as: Ref<PrimitiveProps['as']>
   orientation: Ref<'vertical' | 'horizontal'>
   forceMount?: Ref<boolean>
@@ -22,7 +22,7 @@ export interface ScrollAreaScollbarContext {
 }
 
 export const [injectScrollAreaScrollbarContext, provideScrollAreaScrollbarContext]
-  = createContext<ScrollAreaScollbarContext>('ScrollAreaScrollbar')
+  = createContext<ScrollAreaScrollbarContext>('ScrollAreaScrollbar')
 </script>
 
 <script setup lang="ts">

--- a/packages/radix-vue/src/Select/Select.test.ts
+++ b/packages/radix-vue/src/Select/Select.test.ts
@@ -3,9 +3,59 @@ import { axe } from 'vitest-axe'
 import Select from './story/_SelectTest.vue'
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { nextTick } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
 import { fireEvent } from '@testing-library/vue'
+import { SelectContent, SelectItem, SelectPortal, SelectRoot, SelectTrigger, SelectValue, SelectViewport } from './'
 import { handleSubmit } from '@/test'
+
+const TwoSelects = defineComponent({
+  setup() {
+    const first = ref('')
+    const second = ref('')
+
+    return { first, second }
+  },
+  template: `
+    <SelectRoot v-model="first">
+      <SelectTrigger style="pointer-events: auto">
+        <SelectValue placeholder="First" />
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectContent>
+          <SelectViewport>
+            <SelectItem value="first-option">
+              First option
+            </SelectItem>
+          </SelectViewport>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+
+    <SelectRoot v-model="second">
+      <SelectTrigger style="pointer-events: auto">
+        <SelectValue placeholder="Second" />
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectContent>
+          <SelectViewport>
+            <SelectItem value="second-option">
+              Second option
+            </SelectItem>
+          </SelectViewport>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+  `,
+  components: {
+    SelectContent,
+    SelectItem,
+    SelectPortal,
+    SelectRoot,
+    SelectTrigger,
+    SelectValue,
+    SelectViewport,
+  },
+})
 
 describe('given default Select', () => {
   let wrapper: VueWrapper<InstanceType<typeof Select>>
@@ -148,6 +198,35 @@ describe('given select in a form', async () => {
     it('should trigger submit once', () => {
       expect(handleSubmit).toHaveBeenCalledTimes(2)
       expect(handleSubmit.mock.results[1].value).toStrictEqual({ test: 'Pineapple' })
+    })
+  })
+
+  describe('after opening another select', () => {
+    it('should close the previously opened select', async () => {
+      const wrapper = mount(TwoSelects, {
+        attachTo: document.body,
+      })
+      const triggers = wrapper.findAll('button')
+
+      await triggers[0].trigger('pointerdown', {
+        button: 0,
+        ctrlKey: false,
+      })
+      await nextTick()
+
+      expect(document.querySelectorAll('[role=listbox]')).toHaveLength(1)
+
+      await triggers[1].trigger('pointerdown', {
+        button: 0,
+        ctrlKey: false,
+      })
+      await nextTick()
+
+      expect(document.querySelectorAll('[role=listbox]')).toHaveLength(1)
+      expect(triggers[0].attributes('aria-expanded')).toBe('false')
+      expect(triggers[1].attributes('aria-expanded')).toBe('true')
+
+      wrapper.unmount()
     })
   })
 })

--- a/packages/radix-vue/src/Select/SelectRoot.vue
+++ b/packages/radix-vue/src/Select/SelectRoot.vue
@@ -51,6 +51,8 @@ export interface SelectRootContext {
 export const [injectSelectRootContext, provideSelectRootContext]
   = createContext<SelectRootContext>('SelectRoot')
 
+const openSelects = new Set<(open: boolean) => void>()
+
 export interface SelectNativeOptionsContext {
   onNativeOptionAdd: (option: VNode) => void
   onNativeOptionRemove: (option: VNode) => void
@@ -61,7 +63,7 @@ export const [injectSelectNativeOptionsContext, provideSelectNativeOptionsContex
 </script>
 
 <script setup lang="ts">
-import { computed, ref, toRefs } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toRefs } from 'vue'
 import BubbleSelect from './BubbleSelect.vue'
 import { PopperRoot } from '@/Popper'
 import { useVModel } from '@vueuse/core'
@@ -101,6 +103,25 @@ const triggerPointerDownPosRef = ref({
 })
 const valueElementHasChildren = ref(false)
 
+function handleOpenChange(value: boolean) {
+  open.value = value
+
+  if (value) {
+    openSelects.forEach((onOpenChange) => {
+      if (onOpenChange !== handleOpenChange)
+        onOpenChange(false)
+    })
+  }
+}
+
+onMounted(() => {
+  openSelects.add(handleOpenChange)
+})
+
+onUnmounted(() => {
+  openSelects.delete(handleOpenChange)
+})
+
 const { required, disabled, dir: propDir } = toRefs(props)
 const dir = useDirection(propDir)
 provideSelectRootContext({
@@ -123,9 +144,7 @@ provideSelectRootContext({
   },
   open,
   required,
-  onOpenChange: (value) => {
-    open.value = value
-  },
+  onOpenChange: handleOpenChange,
   dir,
   triggerPointerDownPosRef,
   disabled,


### PR DESCRIPTION
## Description

Resolves #2583.

- Close any currently open Select root before opening another Select
- Add regression coverage for two Selects whose triggers use `pointer-events: auto`

## Tests

- `corepack pnpm --filter radix-vue test Select.test.ts`
- `corepack pnpm --filter radix-vue type-check`
- `corepack pnpm exec eslint packages/radix-vue/src/Select/SelectRoot.vue packages/radix-vue/src/Select/Select.test.ts`

Note: `corepack pnpm lint` currently fails on pre-existing docs lint errors in `docs/content/showcase.md` and `docs/content/utilities/use-date-formatter.md`.
