### PR TITLE
fix(Presence): detect CSS transitions alongside animations to prevent premature unmount

### DIFF
--- a/packages/core/src/Presence/usePresence.ts
+++ b/packages/core/src/Presence/usePresence.ts
@@ -14,6 +14,7 @@ export function usePresence(
   const initialState = present.value ? 'mounted' : 'unmounted'
   let timeoutId: number | undefined
   let transitionTimeout: number | undefined
+  let transitionPendingCount: number | undefined
   const ownerWindow = node.value?.ownerDocument.defaultView ?? defaultWindow
 
   const { state, dispatch } = useStateMachine(initialState, {
@@ -68,12 +69,14 @@ export function usePresence(
 
             const duration = getTransitionDuration(node.value)
             if (duration > 0) {
+              transitionPendingCount = getTransitionPropertyCount(node.value)
               transitionTimeout = ownerWindow?.setTimeout(() => {
                 if (state.value === 'unmountSuspended') {
                   dispatchCustomEvent('after-leave')
                   dispatch('ANIMATION_END')
                 }
                 transitionTimeout = undefined
+                transitionPendingCount = undefined
               }, duration + 50)
             }
             else {
@@ -154,16 +157,21 @@ export function usePresence(
   const handleTransitionEnd = (event: TransitionEvent) => {
     if (event.target !== node.value)
       return
-    if (state.value !== 'unmountSuspended' && state.value !== 'mounted')
+    if (state.value !== 'unmountSuspended')
       return
+
+    if (transitionPendingCount !== undefined && transitionPendingCount > 0) {
+      transitionPendingCount--
+      if (transitionPendingCount > 0)
+        return
+    }
 
     if (transitionTimeout !== undefined) {
       ownerWindow?.clearTimeout(transitionTimeout)
       transitionTimeout = undefined
     }
 
-    const directionName = state.value === 'mounted' ? 'enter' : 'leave'
-    dispatchCustomEvent(`after-${directionName}`)
+    dispatchCustomEvent('after-leave')
     dispatch('ANIMATION_END')
   }
 
@@ -190,7 +198,6 @@ export function usePresence(
         newNode.addEventListener('animationstart', handleAnimationStart)
         newNode.addEventListener('animationcancel', handleAnimationEnd)
         newNode.addEventListener('animationend', handleAnimationEnd)
-        newNode.addEventListener('transitionrun', handleTransitionEnd as EventListener)
         newNode.addEventListener('transitioncancel', handleTransitionCancel)
         newNode.addEventListener('transitionend', handleTransitionEnd)
       }
@@ -205,10 +212,10 @@ export function usePresence(
           ownerWindow?.clearTimeout(transitionTimeout)
           transitionTimeout = undefined
         }
+        transitionPendingCount = undefined
         oldNode?.removeEventListener('animationstart', handleAnimationStart)
         oldNode?.removeEventListener('animationcancel', handleAnimationEnd)
         oldNode?.removeEventListener('animationend', handleAnimationEnd)
-        oldNode?.removeEventListener('transitionrun', handleTransitionEnd as EventListener)
         oldNode?.removeEventListener('transitioncancel', handleTransitionCancel)
         oldNode?.removeEventListener('transitionend', handleTransitionEnd)
       }
@@ -248,19 +255,45 @@ function hasTransition(node?: HTMLElement) {
   if (!node)
     return false
   const { transitionProperty, transitionDuration } = getComputedStyle(node)
-  return transitionProperty !== 'none' && transitionDuration !== '0s'
+  return (
+    typeof transitionProperty === 'string'
+    && transitionProperty !== 'none'
+    && typeof transitionDuration === 'string'
+    && transitionDuration !== ''
+    && transitionDuration !== '0s'
+  )
+}
+
+function getTransitionPropertyCount(node?: HTMLElement): number {
+  if (!node)
+    return 0
+  const { transitionProperty } = getComputedStyle(node)
+  if (!transitionProperty || transitionProperty === 'none')
+    return 0
+  if (transitionProperty === 'all')
+    return Infinity
+  return transitionProperty.split(',').length
 }
 
 function getTransitionDuration(node?: HTMLElement): number {
   if (!node)
     return 0
-  const { transitionDuration: durations, transitionDelay: delays } = getComputedStyle(node)
+  const style = getComputedStyle(node)
+  const durations = style.transitionDuration
+  const delays = style.transitionDelay
+  if (typeof durations !== 'string' || typeof delays !== 'string')
+    return 0
+
   const durationArray = durations.split(',').map((d) => {
     const val = parseFloat(d)
+    if (Number.isNaN(val))
+      return 0
     return d.endsWith('ms') ? val : val * 1000
   })
   const delayArray = delays.split(',').map((d) => {
     const val = parseFloat(d)
+    if (Number.isNaN(val))
+      return 0
     return d.endsWith('ms') ? val : val * 1000
   })
 

--- a/packages/core/src/Presence/usePresence.ts
+++ b/packages/core/src/Presence/usePresence.ts
@@ -160,6 +160,8 @@ export function usePresence(
     if (state.value !== 'unmountSuspended')
       return
 
+    // For `transition: all`, pendingCount is Infinity and never reaches 0;
+    // the fallback timeout (duration + 50ms) serves as the completion path.
     if (transitionPendingCount !== undefined && transitionPendingCount > 0) {
       transitionPendingCount--
       if (transitionPendingCount > 0)

--- a/packages/core/src/Presence/usePresence.ts
+++ b/packages/core/src/Presence/usePresence.ts
@@ -13,6 +13,7 @@ export function usePresence(
   const prevPresentRef = ref(present)
   const initialState = present.value ? 'mounted' : 'unmounted'
   let timeoutId: number | undefined
+  let transitionTimeout: number | undefined
   const ownerWindow = node.value?.ownerDocument.defaultView ?? defaultWindow
 
   const { state, dispatch } = useStateMachine(initialState, {
@@ -57,11 +58,36 @@ export function usePresence(
           currentAnimationName === 'none' || currentAnimationName === 'undefined'
           || stylesRef.value?.display === 'none'
         ) {
-          // If there is no exit animation or the element is hidden, animations won't run
-          // so we unmount instantly rv
-          dispatch('UNMOUNT')
-          dispatchCustomEvent('leave')
-          dispatchCustomEvent('after-leave')
+          if (
+            currentAnimationName === 'none'
+            && stylesRef.value?.display !== 'none'
+            && hasTransition(node.value)
+          ) {
+            dispatch('ANIMATION_OUT')
+            dispatchCustomEvent('leave')
+
+            const duration = getTransitionDuration(node.value)
+            if (duration > 0) {
+              transitionTimeout = ownerWindow?.setTimeout(() => {
+                if (state.value === 'unmountSuspended') {
+                  dispatchCustomEvent('after-leave')
+                  dispatch('ANIMATION_END')
+                }
+                transitionTimeout = undefined
+              }, duration + 50)
+            }
+            else {
+              dispatchCustomEvent('after-leave')
+              dispatch('ANIMATION_END')
+            }
+          }
+          else {
+            // If there is no exit animation or the element is hidden, animations won't run
+            // so we unmount instantly
+            dispatch('UNMOUNT')
+            dispatchCustomEvent('leave')
+            dispatchCustomEvent('after-leave')
+          }
         }
         else {
           /**
@@ -125,6 +151,37 @@ export function usePresence(
     }
   }
 
+  const handleTransitionEnd = (event: TransitionEvent) => {
+    if (event.target !== node.value)
+      return
+    if (state.value !== 'unmountSuspended' && state.value !== 'mounted')
+      return
+
+    if (transitionTimeout !== undefined) {
+      ownerWindow?.clearTimeout(transitionTimeout)
+      transitionTimeout = undefined
+    }
+
+    const directionName = state.value === 'mounted' ? 'enter' : 'leave'
+    dispatchCustomEvent(`after-${directionName}`)
+    dispatch('ANIMATION_END')
+  }
+
+  const handleTransitionCancel = (event: TransitionEvent) => {
+    if (event.target !== node.value)
+      return
+    if (state.value !== 'unmountSuspended')
+      return
+
+    if (transitionTimeout !== undefined) {
+      ownerWindow?.clearTimeout(transitionTimeout)
+      transitionTimeout = undefined
+    }
+
+    dispatchCustomEvent('after-leave')
+    dispatch('ANIMATION_END')
+  }
+
   const watcher = watch(
     node,
     (newNode, oldNode) => {
@@ -133,6 +190,9 @@ export function usePresence(
         newNode.addEventListener('animationstart', handleAnimationStart)
         newNode.addEventListener('animationcancel', handleAnimationEnd)
         newNode.addEventListener('animationend', handleAnimationEnd)
+        newNode.addEventListener('transitionrun', handleTransitionEnd as EventListener)
+        newNode.addEventListener('transitioncancel', handleTransitionCancel)
+        newNode.addEventListener('transitionend', handleTransitionEnd)
       }
       else {
         // Transition to the unmounted state if the node is removed prematurely.
@@ -141,9 +201,16 @@ export function usePresence(
 
         if (timeoutId !== undefined)
           ownerWindow?.clearTimeout(timeoutId)
+        if (transitionTimeout !== undefined) {
+          ownerWindow?.clearTimeout(transitionTimeout)
+          transitionTimeout = undefined
+        }
         oldNode?.removeEventListener('animationstart', handleAnimationStart)
         oldNode?.removeEventListener('animationcancel', handleAnimationEnd)
         oldNode?.removeEventListener('animationend', handleAnimationEnd)
+        oldNode?.removeEventListener('transitionrun', handleTransitionEnd as EventListener)
+        oldNode?.removeEventListener('transitioncancel', handleTransitionCancel)
+        oldNode?.removeEventListener('transitionend', handleTransitionEnd)
       }
     },
     { immediate: true },
@@ -158,6 +225,10 @@ export function usePresence(
   onUnmounted(() => {
     watcher()
     stateWatcher()
+    if (transitionTimeout !== undefined) {
+      ownerWindow?.clearTimeout(transitionTimeout)
+      transitionTimeout = undefined
+    }
   })
 
   const isPresent = computed(() =>
@@ -171,4 +242,33 @@ export function usePresence(
 
 function getAnimationName(node?: HTMLElement) {
   return node ? getComputedStyle(node).animationName || 'none' : 'none'
+}
+
+function hasTransition(node?: HTMLElement) {
+  if (!node)
+    return false
+  const { transitionProperty, transitionDuration } = getComputedStyle(node)
+  return transitionProperty !== 'none' && transitionDuration !== '0s'
+}
+
+function getTransitionDuration(node?: HTMLElement): number {
+  if (!node)
+    return 0
+  const { transitionDuration: durations, transitionDelay: delays } = getComputedStyle(node)
+  const durationArray = durations.split(',').map((d) => {
+    const val = parseFloat(d)
+    return d.endsWith('ms') ? val : val * 1000
+  })
+  const delayArray = delays.split(',').map((d) => {
+    const val = parseFloat(d)
+    return d.endsWith('ms') ? val : val * 1000
+  })
+
+  let max = 0
+  for (let i = 0; i < durationArray.length; i++) {
+    const total = (durationArray[i] || 0) + (delayArray[i] || 0)
+    if (total > max)
+      max = total
+  }
+  return max
 }


### PR DESCRIPTION
## Description

Fixes #2403

### Problem
When a component using `Presence` (e.g. `DialogOverlay`) has a CSS `transition` instead of a CSS `animation`, `usePresence` would immediately dispatch `UNMOUNT` because it only checked `animationName`. This caused the body scroll lock to release before the visual transition completed, resulting in a leftward shift when the scrollbar reappeared.

### Root Cause
`usePresence` only detected CSS `animation` (via `animationName` computed style) and completely ignored CSS `transition`. When closing a dialog that uses CSS transitions (e.g., `transition: opacity 0.3s ease`), the component would unmount instantly.

### Fix
- Added `hasTransition()` helper to check if an element has a non-none/non-zero CSS transition
- Added `getTransitionDuration()` to calculate the longest transition duration
- When leaving and no animation is detected but a transition exists, dispatch `ANIMATION_OUT` instead of `UNMOUNT`, keeping `isPresent` true
- Listen for `transitionend` and `transitioncancel` events to dispatch `ANIMATION_END`
- Fallback timeout based on transition duration as a safety net

### Testing
- All existing Presence tests pass (9 tests)
- Typecheck passes cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component unmount behavior to account for CSS exit transitions, ensuring animations complete before removal.
  * Enhanced handling of both transition completion and cancellation events.
  * Coordinated unmount timing using the longest applicable transition (including delay), with immediate fallback when no exit transition applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->