### PR TITLE
fix(Select): close open select when another opens

### DIFF
--- a/packages/core/src/Select/Select.test.ts
+++ b/packages/core/src/Select/Select.test.ts
@@ -38,14 +38,14 @@ const TwoSelects = defineComponent({
     SelectViewport,
   },
   setup() {
-    const first = ref('')
-    const second = ref('')
+    const first = ref()
+    const second = ref()
 
     return { first, second }
   },
   template: `
     <SelectRoot v-model="first">
-      <SelectTrigger style="pointer-events: auto">
+      <SelectTrigger aria-label="First" style="pointer-events: auto">
         <SelectValue placeholder="First" />
       </SelectTrigger>
       <SelectPortal>
@@ -60,7 +60,7 @@ const TwoSelects = defineComponent({
     </SelectRoot>
 
     <SelectRoot v-model="second">
-      <SelectTrigger style="pointer-events: auto">
+      <SelectTrigger aria-label="Second" style="pointer-events: auto">
         <SelectValue placeholder="Second" />
       </SelectTrigger>
       <SelectPortal>
@@ -495,6 +495,7 @@ describe('given two Selects', () => {
     expect(document.querySelectorAll('[role=listbox]')).toHaveLength(1)
     expect(triggers[0].attributes('aria-expanded')).toBe('false')
     expect(triggers[1].attributes('aria-expanded')).toBe('true')
+    expect(await axe(wrapper.element)).toHaveNoViolations()
 
     wrapper.unmount()
   })

--- a/packages/core/src/Select/Select.test.ts
+++ b/packages/core/src/Select/Select.test.ts
@@ -3,10 +3,19 @@ import { fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
-import { nextTick } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
 import { handleSubmit } from '@/test'
 import SelectUnmountCleanup from './__test__/SelectUnmountCleanup.vue'
 import Select from './story/_SelectTest.vue'
+import {
+  SelectContent,
+  SelectItem,
+  SelectPortal,
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from '.'
 
 beforeAll(() => {
   window.HTMLElement.prototype.releasePointerCapture = vi.fn()
@@ -16,6 +25,55 @@ beforeAll(() => {
     unobserve() {}
     disconnect() {}
   }
+})
+
+const TwoSelects = defineComponent({
+  components: {
+    SelectContent,
+    SelectItem,
+    SelectPortal,
+    SelectRoot,
+    SelectTrigger,
+    SelectValue,
+    SelectViewport,
+  },
+  setup() {
+    const first = ref('')
+    const second = ref('')
+
+    return { first, second }
+  },
+  template: `
+    <SelectRoot v-model="first">
+      <SelectTrigger style="pointer-events: auto">
+        <SelectValue placeholder="First" />
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectContent>
+          <SelectViewport>
+            <SelectItem value="first-option">
+              First option
+            </SelectItem>
+          </SelectViewport>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+
+    <SelectRoot v-model="second">
+      <SelectTrigger style="pointer-events: auto">
+        <SelectValue placeholder="Second" />
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectContent>
+          <SelectViewport>
+            <SelectItem value="second-option">
+              Second option
+            </SelectItem>
+          </SelectViewport>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+  `,
 })
 
 describe('given default Select', () => {
@@ -410,5 +468,34 @@ describe('given Select in a form', async () => {
       expect(handleSubmit).toHaveBeenCalledTimes(2)
       expect(handleSubmit.mock.results[1].value).toStrictEqual({ test: 'Pineapple' })
     })
+  })
+})
+
+describe('given two Selects', () => {
+  it('should close the previously opened select when another opens', async () => {
+    const wrapper = mount(TwoSelects, {
+      attachTo: document.body,
+    })
+    const triggers = wrapper.findAll('button')
+
+    await triggers[0].trigger('pointerdown', {
+      button: 0,
+      ctrlKey: false,
+    })
+    await nextTick()
+
+    expect(document.querySelectorAll('[role=listbox]')).toHaveLength(1)
+
+    await triggers[1].trigger('pointerdown', {
+      button: 0,
+      ctrlKey: false,
+    })
+    await nextTick()
+
+    expect(document.querySelectorAll('[role=listbox]')).toHaveLength(1)
+    expect(triggers[0].attributes('aria-expanded')).toBe('false')
+    expect(triggers[1].attributes('aria-expanded')).toBe('true')
+
+    wrapper.unmount()
   })
 })

--- a/packages/core/src/Select/SelectRoot.vue
+++ b/packages/core/src/Select/SelectRoot.vue
@@ -62,11 +62,13 @@ export const [injectSelectRootContext, provideSelectRootContext]
   = createContext<SelectRootContext<AcceptableValue>>('SelectRoot')
 
 interface SelectOption { value: any, disabled?: boolean, textContent: string }
+
+const openSelects = new Set<(open: boolean) => void>()
 </script>
 
 <script setup lang="ts" generic="T extends AcceptableValue = AcceptableValue">
 import { useVModel } from '@vueuse/core'
-import { computed, ref, toRefs } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toRefs } from 'vue'
 import { PopperRoot } from '@/Popper'
 import BubbleSelect from './BubbleSelect.vue'
 
@@ -152,6 +154,25 @@ function getOption(value: SelectOption['value']) {
     .find(option => valueComparator(value, option.value, props.by))
 }
 
+function handleOpenChange(value: boolean) {
+  open.value = value
+
+  if (value) {
+    openSelects.forEach((onOpenChange) => {
+      if (onOpenChange !== handleOpenChange)
+        onOpenChange(false)
+    })
+  }
+}
+
+onMounted(() => {
+  openSelects.add(handleOpenChange)
+})
+
+onUnmounted(() => {
+  openSelects.delete(handleOpenChange)
+})
+
 provideSelectRootContext({
   triggerElement,
   onTriggerChange: (node) => {
@@ -170,9 +191,7 @@ provideSelectRootContext({
   open,
   multiple,
   required,
-  onOpenChange: (value) => {
-    open.value = value
-  },
+      onOpenChange: handleOpenChange,
   dir,
   triggerPointerDownPosRef,
   disabled,


### PR DESCRIPTION
## Description

Resolves #2583.

When multiple Select components are on the same page, opening one Select should close any other open Select. This matches native `<select>` behavior where only one dropdown can be open at a time.

### Changes
- Added a module-level `openSelects` Set to track all open SelectRoot instances
- When a Select opens, it calls `onOpenChange(false)` on all other registered Selects
- Added regression test for two Selects with `pointer-events: auto` on triggers

### Testing
All 30 Select tests pass, including the new "should close the previously opened select when another opens" test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Select behavior so only one Select instance can be open at a time. Opening a Select now automatically closes any other open instances and keeps ARIA state in sync.

* **Tests**
  * Added coverage for multiple Select instances in the same view, including checks that only one listbox is present at a time, ARIA `aria-expanded` updates correctly, and an accessibility (axe) verification passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->