### PR TITLE
fix(Splitter): set data-state="collapsed" for px sizeUnit panels

### DIFF
--- a/packages/core/src/Splitter/Splitter.test.ts
+++ b/packages/core/src/Splitter/Splitter.test.ts
@@ -118,4 +118,60 @@ describe('nested px SplitterGroup layout re-initialization (issue #2509)', () =>
     // Content panel (%): should occupy the bulk of the remaining space
     expect(lastLayout[1]).toBeGreaterThan(50)
   })
+
+  // Regression test: with sizeUnit="px" the panel is visually collapsed but
+  // data-state stays "expanded". px constraints are converted px→% and the
+  // layout renormalized to sum to 100, so panelSize drifts from collapsedSize
+  // by a float epsilon and the old strict `===` comparison failed.
+  it('should set data-state="collapsed" for a collapsed px panel', async () => {
+    const showPanels = ref(false)
+
+    const TestComponent = defineComponent({
+      components: { SplitterGroup, SplitterPanel, SplitterResizeHandle },
+      setup() {
+        return { showPanels }
+      },
+      // Group width 923px is intentionally indivisible by the px constraints so
+      // the px→% conversion produces non-terminating decimals.
+      template: `
+        <SplitterGroup direction="horizontal">
+          <template v-if="showPanels">
+            <SplitterPanel
+              id="sidebar"
+              ref="sidebar"
+              size-unit="px"
+              collapsible
+              :collapsed-size="80"
+              :default-size="300"
+              :min-size="150"
+            />
+            <SplitterResizeHandle />
+            <SplitterPanel id="content" />
+          </template>
+        </SplitterGroup>
+      `,
+    })
+
+    const wrapper = mount(TestComponent)
+    await nextTick()
+
+    // Establish a real group size before the panels register, so px constraints
+    // can be converted and the layout initialized with a defined panel size.
+    fireResize(923)
+    await nextTick()
+
+    showPanels.value = true
+    await nextTick() // registerPanel
+    await nextTick() // panelDataArrayChanged → layout init
+
+    const sidebar = wrapper.find('#sidebar')
+    expect(sidebar.attributes('data-state')).toBe('expanded')
+
+    // Collapse via the public API; the panel reaches collapsedSize through
+    // adjustLayoutByDelta, leaving panelSize a float-epsilon off collapsedSize.
+    ;(wrapper.vm.$refs.sidebar as { collapse: () => void }).collapse()
+    await nextTick()
+
+    expect(sidebar.attributes('data-state')).toBe('collapsed')
+  })
 })

--- a/packages/core/src/Splitter/SplitterGroup.vue
+++ b/packages/core/src/Splitter/SplitterGroup.vue
@@ -847,7 +847,9 @@ function isPanelCollapsed(panelData: PanelData) {
     return constraints.defaultSize === constraints.collapsedSize
   }
   else {
-    return panelSize === collapsedSize
+    // Fuzzy compare: px sizeUnit converts constraints px→% and renormalizes the
+    // layout, so panelSize drifts from collapsedSize by a float epsilon.
+    return fuzzyCompareNumbers(panelSize, collapsedSize) <= 0
   }
 }
 
@@ -872,7 +874,7 @@ function isPanelExpanded(panelData: PanelData) {
     `Panel size not found for panel "${panelData.id}"`,
   )
 
-  return !collapsible || panelSize > collapsedSize
+  return !collapsible || fuzzyCompareNumbers(panelSize, collapsedSize) > 0
 }
 
 providePanelGroupContext({


### PR DESCRIPTION
### 🔗 Linked issue

#2742

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`isPanelCollapsed`/`isPanelExpanded` compares `panelSize` to `collapsedSize` with strict equality. With `size-unit="px"`, constraints are converted from `px` to `%` and the layout re-normalized to 100%, so `panelSize` drifts from `collapsedSize` by a float epsilon and the comparison failed; the panel collapsed visually but data-state stayed `"expanded"`. Use `fuzzyCompareNumbers` (already used by `collapsePanel`) instead.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. (Nothing to update, as docs don't cover this particular case)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where collapsible panels could incorrectly display their visual state due to floating-point precision errors during size unit conversions. Panels now properly reflect their collapsed or expanded state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->