### PR TITLE
fix(ScrollArea): cancel ScrollAreaThumb RAF loop and clean up Presence listeners on unmount

### DIFF
--- a/packages/core/src/Presence/usePresence.ts
+++ b/packages/core/src/Presence/usePresence.ts
@@ -158,6 +158,13 @@ export function usePresence(
   onUnmounted(() => {
     watcher()
     stateWatcher()
+    if (node.value) {
+      node.value.removeEventListener('animationstart', handleAnimationStart)
+      node.value.removeEventListener('animationcancel', handleAnimationEnd)
+      node.value.removeEventListener('animationend', handleAnimationEnd)
+    }
+    if (timeoutId !== undefined)
+      ownerWindow?.clearTimeout(timeoutId)
   })
 
   const isPresent = computed(() =>

--- a/packages/core/src/ScrollArea/ScrollAreaThumb.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaThumb.vue
@@ -63,7 +63,7 @@ watchOnce(sizes, () => {
 })
 
 onUnmounted(() => {
-  viewport.value!.removeEventListener('scroll', handleScroll)
+  viewport.value?.removeEventListener('scroll', handleScroll)
   removeUnlinkedScrollListenerRef.value?.()
 })
 </script>

--- a/packages/core/src/ScrollArea/ScrollAreaThumb.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaThumb.vue
@@ -64,7 +64,7 @@ watchOnce(sizes, () => {
 
 onUnmounted(() => {
   viewport.value!.removeEventListener('scroll', handleScroll)
-  rootContext.viewport.value?.removeEventListener('scroll', handleScroll)
+  removeUnlinkedScrollListenerRef.value?.()
 })
 </script>
 


### PR DESCRIPTION
## Description

Fixes #2420 — Memory leak from detached DOM nodes in Popover/Tooltip/ScrollArea after route navigation.

### Root Causes

1. **ScrollAreaThumb RAF loop never cancelled** — addUnlinkedScrollListener starts a perpetual requestAnimationFrame loop that polls scroll position. The returned cancellation function was stored in a ref but onUnmounted only removed the scroll event listener — it never called the cancellation function. The RAF loop continued running forever, retaining DOM references to the viewport element.

2. **Presence listeners not cleaned up on unmount** — usePresence attaches animationstart/animationcancel/animationend listeners to the DOM node. These were removed only when the node ref changed, but in onUnmounted they were never explicitly cleaned up. With teleported content, these leaked listeners can prevent garbage collection.

### Fixes

- **ScrollAreaThumb**: call removeUnlinkedScrollListenerRef.value?.() in onUnmounted to cancel the RAF loop. Also removed the duplicate viewport event listener removal.
- **Presence**: explicitly remove animation event listeners in onUnmounted before stopping the node watcher.

### Testing

- All 9 Presence tests pass
- All 9 ScrollArea tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unmount cleanup for presence handling by removing animation-related event listeners and canceling any pending timeouts.
  * Refined ScrollArea thumb unmount behavior to properly detach the unlinked scroll listener and avoid redundant native scroll listener removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->