### PR TITLE
fix(Menu): prevent sub-menu focus fight when it opens on top of trigger

### DIFF
--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -170,6 +170,12 @@ const activeSubmenuContext = ref<{ onOpenChange: (open: boolean) => void, trigge
 
 watch(highlightedElement, (el) => {
   if (activeSubmenuContext.value && (el === undefined || el !== activeSubmenuContext.value.trigger.value)) {
+    // Don't close the submenu when the highlight disappears (pointer left
+    // all parent items, likely because the submenu opened on top of the
+    // trigger in a constrained viewport). Only close when highlight moves
+    // to a different parent item.
+    if (el === undefined)
+      return
     activeSubmenuContext.value.onOpenChange(false)
     activeSubmenuContext.value = undefined
   }


### PR DESCRIPTION
## Description

Fixes #2446 — focus-fight on DropdownMenu sub-items when sub-menu opens on top of the trigger in a constrained viewport.

### Root Cause

When a sub-menu opens above the parent trigger (small window, long text), the pointer is now over the sub-content items, not over any parent menu item. This causes `highlightedElement` in the parent `MenuContentImpl` to become `undefined`. The watch at `MenuContentImpl.vue:171` would then close the active sub-menu, creating a cycle:

1. Hover sub-trigger → sub-menu opens
2. Sub-menu opens on top → mouse is over sub-content
3. Parent highlightedElement → undefined
4. Watch closes the sub-menu
5. Sub-menu closes → mouse is back over trigger
6. Goto 1 (focus fight)

### Fix

When `highlightedElement` becomes `undefined` with an active sub-menu, keep the sub-menu open. The sub-menu now only closes when the highlight moves to a *different* parent item (expected behavior). The sub-menu can still be closed by:
- Hovering another parent item
- Pressing Escape
- Clicking outside
- Pointer leave + grace area timeout

### Testing

- All 6 Menu tests pass
- All 6 DropdownMenu tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submenu behavior so menus no longer close unexpectedly when the pointer leaves parent menu items. Submenus now persist until explicitly closed or a different menu section is highlighted, creating a more stable navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->