### PR TITLE
fix(Menu): allow Tab to move focus out of non-modal DropdownMenu

### DIFF
--- a/packages/core/src/DropdownMenu/DropdownMenu.test.ts
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.ts
@@ -1,9 +1,61 @@
 import type { VueWrapper } from '@vue/test-utils'
-import { findByRole } from '@testing-library/vue'
+import { fireEvent, findAllByRole, findByRole, render } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { defineComponent } from 'vue'
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRoot,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '.'
 import DropdownMenu from './story/_DropdownMenu.vue'
+
+const DropdownMenuTabTest = defineComponent({
+  components: {
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuPortal,
+    DropdownMenuRoot,
+    DropdownMenuSub,
+    DropdownMenuSubContent,
+    DropdownMenuSubTrigger,
+    DropdownMenuTrigger,
+  },
+  props: {
+    modal: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  template: `
+    <div>
+      <button>Before</button>
+      <DropdownMenuRoot :open="true" :modal="modal">
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuPortal disabled>
+          <DropdownMenuContent @close-auto-focus.prevent>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+            <DropdownMenuSub :open="true">
+              <DropdownMenuSubTrigger>Sub Trigger</DropdownMenuSubTrigger>
+              <DropdownMenuPortal disabled>
+                <DropdownMenuSubContent>
+                  <DropdownMenuItem>Sub Item</DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenuPortal>
+      </DropdownMenuRoot>
+      <button>After</button>
+    </div>
+  `,
+})
 
 describe('given default DropdownMenu', () => {
   let wrapper: VueWrapper<InstanceType<typeof DropdownMenu>>
@@ -53,5 +105,59 @@ describe('given default DropdownMenu', () => {
         expect(wrapper.emitted('select')?.length).toBe(1)
       })
     })
+  })
+})
+
+describe('given DropdownMenu tab navigation', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('should allow Tab to move focus out of non-modal menu', async () => {
+    const { container } = render(DropdownMenuTabTest, {
+      props: { modal: false },
+    })
+
+    const menu = (await findAllByRole(container, 'menu'))[0]
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Tab',
+    })
+    fireEvent(menu, event)
+
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('should prevent Tab in modal menu', async () => {
+    const { container } = render(DropdownMenuTabTest, {
+      props: { modal: true },
+    })
+
+    const menu = (await findAllByRole(container, 'menu'))[0]
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Tab',
+    })
+    fireEvent(menu, event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('should prevent Tab in modal submenu', async () => {
+    const { container } = render(DropdownMenuTabTest, {
+      props: { modal: true },
+    })
+
+    const submenu = (await findAllByRole(container, 'menu'))[1]
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Tab',
+    })
+    fireEvent(submenu, event)
+
+    expect(event.defaultPrevented).toBe(true)
   })
 })

--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -238,10 +238,7 @@ function handleKeyDown(event: KeyboardEvent) {
   const collectionItems = rovingFocusGroupRef.value?.getItems() ?? []
 
   if (isKeyDownInside) {
-    // menus should not be navigated using tab key so we prevent it
-    // when the menu is modal (trapFocus). For non-modal menus, allow
-    // Tab to move focus to the next focusable element on the page.
-    if (event.key === 'Tab' && trapFocus.value)
+    if (event.key === 'Tab' && rootContext.modal.value)
       event.preventDefault()
     if (!isModifierKey && isCharacterKey && !isKeyDownInTextField)
       handleTypeaheadSearch(event.key, collectionItems)

--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -239,7 +239,9 @@ function handleKeyDown(event: KeyboardEvent) {
 
   if (isKeyDownInside) {
     // menus should not be navigated using tab key so we prevent it
-    if (event.key === 'Tab')
+    // when the menu is modal (trapFocus). For non-modal menus, allow
+    // Tab to move focus to the next focusable element on the page.
+    if (event.key === 'Tab' && trapFocus.value)
       event.preventDefault()
     if (!isModifierKey && isCharacterKey && !isKeyDownInTextField)
       handleTypeaheadSearch(event.key, collectionItems)


### PR DESCRIPTION
## Description

Fixes #2296 — Unable to use Tab to move focus outside of open, non-modal DropdownMenu.

### Root Cause

`MenuContentImpl.vue` unconditionally called `event.preventDefault()` on Tab keydown when inside the menu. This was intended to prevent Tab from navigating between menu items (menus use arrow keys), but it had the side effect of completely disabling Tab — focus could never leave the menu.

### Fix

Gate the Tab `preventDefault` on `trapFocus.value`. When the menu is modal (`trapFocus=true`), Tab is still prevented (FocusScope handles focus trapping). When non-modal (`trapFocus=false`, which is the default for DropdownMenu), Tab is allowed to naturally move focus to the next focusable element on the page, per the WAI-ARIA menubar keyboard interaction pattern.

### Testing

All 21 tests pass: Menu (6), DropdownMenu (6), ContextMenu (3), Menubar (6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard `Tab` behavior in non-modal menus so users can move focus forward instead of being trapped.
  * Preserved `Tab` focus handling for modal menus, including nested submenus, preventing unintended focus changes.
* **Tests**
  * Added tab-navigation coverage validating `Tab` behavior for modal vs non-modal menus and nested submenu keydown prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->