### PR TITLE
fix(HoverCard): ignore the focus that a touch tap triggers

### DIFF
--- a/packages/core/src/HoverCard/HoverCard.test.ts
+++ b/packages/core/src/HoverCard/HoverCard.test.ts
@@ -35,6 +35,29 @@ describe('given a default HoverCard', () => {
       await sleep(100)
       expect(wrapper.find('a').attributes('data-state')).toBe('closed')
     })
+
+    it('should not open from the focus a tap triggers', async () => {
+      const trigger = wrapper.find('a')
+
+      // a real touch tap fires pointerdown then focuses the trigger, which would
+      // otherwise schedule a focus-driven open even when enableTouch is disabled
+      await trigger.trigger('pointerdown', { pointerType: 'touch' })
+      await trigger.trigger('focus')
+      await trigger.trigger('pointerup', { pointerType: 'touch' })
+      await sleep(150)
+      expect(trigger.attributes('data-state')).toBe('closed')
+    })
+  })
+
+  describe('keyboard focus on the trigger', () => {
+    it('should open the hover card', async () => {
+      const trigger = wrapper.find('a')
+
+      // focus not preceded by a touch pointer should still open (a11y)
+      await trigger.trigger('focus')
+      await sleep(150)
+      expect(trigger.attributes('data-state')).toBe('open')
+    })
   })
 
   // HoverCard mainly depends on Popper, test for Popper is not required here

--- a/packages/core/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/core/src/HoverCard/HoverCardTrigger.vue
@@ -4,6 +4,7 @@ export interface HoverCardTriggerProps extends PopperAnchorProps {}
 
 <script setup lang="ts">
 import type { PopperAnchorProps } from '@/Popper'
+import { onScopeDispose } from 'vue'
 import { PopperAnchor } from '@/Popper'
 import { Primitive } from '@/Primitive'
 import { useForwardExpose } from '@/shared'
@@ -35,6 +36,29 @@ function handleTouch(event: PointerEvent) {
   else
     rootContext.onOpenChange(true)
 }
+
+let isPointerDownByTouch = false
+let resetTimer = 0
+
+function handlePointerDown(event: PointerEvent) {
+  // A touch tap focuses the trigger, and that focus would otherwise open the
+  // card even when `enableTouch` is disabled. Flag the touch so the `focus`
+  // that immediately follows can be ignored (touch is driven by `handleTouch`).
+  isPointerDownByTouch = event.pointerType === 'touch'
+  clearTimeout(resetTimer)
+  resetTimer = window.setTimeout(() => {
+    isPointerDownByTouch = false
+  }, 0)
+}
+
+function handleFocus() {
+  if (isPointerDownByTouch)
+    return
+
+  rootContext.onOpen()
+}
+
+onScopeDispose(() => clearTimeout(resetTimer))
 </script>
 
 <template>
@@ -50,8 +74,9 @@ function handleTouch(event: PointerEvent) {
       data-grace-area-trigger
       @pointerenter="excludeTouch(rootContext.onOpen)($event)"
       @pointerleave="excludeTouch(handleLeave)($event)"
+      @pointerdown="handlePointerDown"
       @pointerup="handleTouch"
-      @focus="rootContext.onOpen()"
+      @focus="handleFocus"
       @blur="rootContext.onClose()"
     >
       <slot />


### PR DESCRIPTION
## Regression

Follow-up to #2687, which added the `enableTouch` prop. That PR gated
`pointerenter` / `pointerleave` / `pointerup` behind `pointerType === 'touch'`
checks but left the `focus` handler ungated (`@focus="rootContext.onOpen()"`).

On touch devices, tapping the `HoverCardTrigger` focuses it, and that focus
handler then opened the card — **even when `enableTouch` is `false`** (the
default). This left the touch-ignore semantics incomplete: `enableTouch: false`
is supposed to mean touch interactions are ignored to match pointer-hover
behaviour, yet a tap still opened the card via the focus it incidentally
triggers.

| | Before | After |
|---|---|---|
| Tap trigger, `enableTouch: false` | opens (via focus) ❌ | stays closed ✅ |
| Tap trigger, `enableTouch: true` | toggles, but focus also schedules a stray `openDelay` timer | toggles cleanly via `pointerup` ✅ |
| Keyboard focus (Tab) | opens | opens ✅ (unchanged, a11y preserved) |
| Mouse hover/focus | opens | opens ✅ (unchanged) |

## Fix

Track a touch-originated `pointerdown` and suppress the `focus` that
immediately follows it; touch is driven solely by `handleTouch` on
`pointerup`. The flag is cleared on the next task (so a later genuine focus
still opens) and on scope dispose.

Keyboard and mouse focus paths are untouched — they never fire a touch
`pointerdown`, so they continue to open normally.

## Tests

- `should not open from the focus a tap triggers` — `pointerdown(touch)` →
  `focus` → `pointerup(touch)` stays `closed` (with `openDelay: 100` and a
  150 ms wait, this would open before the fix).
- `keyboard focus on the trigger` → `should open the hover card` — guards the
  accessibility path so the fix can't regress keyboard-driven open.

All 8 HoverCard tests pass; type-check and lint are clean.