### PR TITLE
fix(FocusScope): default present to true so scopes without it still pause ancestor traps

### DIFF
--- a/docs/content/meta/FocusScope.md
+++ b/docs/content/meta/FocusScope.md
@@ -26,7 +26,8 @@
     'name': 'present',
     'description': '<p>Whether the scope is currently visible. Lets a consumer keep the scope\nmounted but hidden (e.g. <code>display: none</code>) and still get correct auto-focus:\nthe mount auto-focus is skipped while not present, and re-runs when it\nbecomes present again. Defaults to <code>true</code> so consumers that mount the scope\nonly while visible are unaffected.</p>\n',
     'type': 'boolean',
-    'required': false
+    'required': false,
+    'default': 'true'
   },
   {
     'name': 'trapped',
@@ -60,7 +61,7 @@
 | `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
 | `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
 | `loop` | When true, tabbing from last item will focus first tabbable and shift+tab from first item will focus last tababble. | `boolean` | No | `false` |
-| `present` | Whether the scope is currently visible. Lets a consumer keep the scope mounted but hidden (e.g. display: none) and still get correct auto-focus: the mount auto-focus is skipped while not present, and re-runs when it becomes present again. Defaults to true so consumers that mount the scope only while visible are unaffected. | `boolean` | No | - |
+| `present` | Whether the scope is currently visible. Lets a consumer keep the scope mounted but hidden (e.g. display: none) and still get correct auto-focus: the mount auto-focus is skipped while not present, and re-runs when it becomes present again. Defaults to true so consumers that mount the scope only while visible are unaffected. | `boolean` | No | `true` |
 | `trapped` | When true, focus cannot escape the focus scope via keyboard, pointer, or a programmatic focus. | `boolean` | No | `false` |
 
 **Events**

--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -1,12 +1,12 @@
 import type { RenderResult } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import { FocusScope } from '.'
 import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot, ComboboxTrigger, ComboboxViewport } from '../Combobox'
 import { DialogContent, DialogRoot, DialogTitle, DialogTrigger } from '../Dialog'
-import { SelectContent, SelectItem, SelectRoot, SelectTrigger, SelectValue } from '../Select'
+import { SelectContent, SelectItem, SelectPortal, SelectRoot, SelectTrigger, SelectValue, SelectViewport } from '../Select'
 
 const INNER_NAME_INPUT_LABEL = 'Name'
 const INNER_EMAIL_INPUT_LABEL = 'Email'
@@ -238,6 +238,59 @@ describe('focusScope', () => {
       input.focus()
       await nextTick()
       expect(input).toHaveFocus()
+    })
+  })
+
+  // The Combobox case above is one instance of a general contract: every scope
+  // that omits `present` (Combobox/Select/Popover/Menu/Drawer content all do)
+  // must still register in the focus-scope stack and pause an active ancestor
+  // trap. A Select with its content portaled out of the Dialog exercises the
+  // same path through a different consumer.
+  describe('given a FocusScope with portaled Select content inside Dialog (#2749)', () => {
+    const DialogWithSelect = defineComponent({
+      components: { DialogRoot, DialogTrigger, DialogContent, DialogTitle, SelectRoot, SelectPortal, SelectTrigger, SelectValue, SelectContent, SelectViewport, SelectItem },
+      template: `
+        <DialogRoot>
+          <DialogTrigger>Open</DialogTrigger>
+          <DialogContent>
+            <DialogTitle>Test Dialog</DialogTitle>
+            <SelectRoot>
+              <SelectTrigger>
+                <SelectValue placeholder="Select" />
+              </SelectTrigger>
+              <SelectPortal>
+                <SelectContent data-testid="select-content" position="popper">
+                  <SelectViewport>
+                    <SelectItem value="a">Option A</SelectItem>
+                    <SelectItem value="b">Option B</SelectItem>
+                  </SelectViewport>
+                </SelectContent>
+              </SelectPortal>
+            </SelectRoot>
+          </DialogContent>
+        </DialogRoot>
+      `,
+    })
+
+    beforeAll(() => {
+      // Select's trigger uses pointer capture and items scroll into view — both
+      // unimplemented in jsdom.
+      window.HTMLElement.prototype.hasPointerCapture = vi.fn()
+      window.HTMLElement.prototype.releasePointerCapture = vi.fn()
+      window.HTMLElement.prototype.scrollIntoView = vi.fn()
+    })
+
+    it('should move focus into the Select content, not trap it back to the Dialog', async () => {
+      const rendered = render(DialogWithSelect)
+
+      await userEvent.click(rendered.getByRole('button', { name: 'Open' }))
+      await userEvent.click(rendered.getByRole('combobox'))
+      await nextTick()
+
+      const content = rendered.getByTestId('select-content')
+      // The Select content traps focus; its FocusScope must pause the Dialog's
+      // trap so focus lands inside the Select rather than being yanked back.
+      expect(content.contains(document.activeElement)).toBe(true)
     })
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -4,6 +4,7 @@ import { render } from '@testing-library/vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import { FocusScope } from '.'
+import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot, ComboboxTrigger, ComboboxViewport } from '../Combobox'
 import { DialogContent, DialogRoot, DialogTitle, DialogTrigger } from '../Dialog'
 import { SelectContent, SelectItem, SelectRoot, SelectTrigger, SelectValue } from '../Select'
 
@@ -185,6 +186,58 @@ describe('focusScope', () => {
       await userEvent.click(trigger)
       const inputReopen = rendered.getByTestId('email-input')
       expect(inputReopen).toHaveFocus()
+    })
+  })
+
+  describe('given a FocusScope with Combobox input inside Dialog (#2749)', () => {
+    const DialogWithCombobox = defineComponent({
+      components: { DialogRoot, DialogTrigger, DialogContent, DialogTitle, ComboboxRoot, ComboboxAnchor, ComboboxTrigger, ComboboxPortal, ComboboxContent, ComboboxViewport, ComboboxInput, ComboboxItem },
+      template: `
+        <DialogRoot>
+          <DialogTrigger>Open</DialogTrigger>
+          <DialogContent>
+            <DialogTitle>Test Dialog</DialogTitle>
+            <ComboboxRoot>
+              <ComboboxAnchor as-child>
+                <ComboboxTrigger>Open combobox</ComboboxTrigger>
+              </ComboboxAnchor>
+              <ComboboxPortal>
+                <ComboboxContent position="popper">
+                  <ComboboxViewport>
+                    <ComboboxInput data-testid="combobox-input" />
+                    <ComboboxItem value="a">Option A</ComboboxItem>
+                    <ComboboxItem value="b">Option B</ComboboxItem>
+                  </ComboboxViewport>
+                </ComboboxContent>
+              </ComboboxPortal>
+            </ComboboxRoot>
+          </DialogContent>
+        </DialogRoot>
+      `,
+    })
+
+    // The Combobox content wraps its slot in a FocusScope (added in #2393) whose
+    // job is to pause the Dialog's trapped FocusScope so the Dialog stops yanking
+    // focus back to itself. That scope is registered without a `present` prop, so
+    // it only pauses the Dialog when `present` defaults to `true`. If it doesn't,
+    // the Dialog re-grabs focus and the input can never be focused/typed (#2749).
+    it('should let the Combobox input keep focus inside a Dialog', async () => {
+      const rendered = render(DialogWithCombobox)
+
+      await userEvent.click(rendered.getByRole('button', { name: 'Open' }))
+      await userEvent.click(rendered.getByText('Open combobox'))
+      await nextTick()
+
+      const input = rendered.getByTestId('combobox-input') as HTMLInputElement
+
+      // The content focuses the input on mount; it must not be trapped back to
+      // the Dialog (which would leave focus on the Dialog/ComboboxTrigger).
+      expect(input).toHaveFocus()
+
+      // And focusing it explicitly must stick.
+      input.focus()
+      await nextTick()
+      expect(input).toHaveFocus()
     })
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -61,6 +61,13 @@ import {
 const props = withDefaults(defineProps<FocusScopeProps>(), {
   loop: false,
   trapped: false,
+  // `present` MUST default to `true`. It is typed `boolean`, so Vue's boolean
+  // prop casting would otherwise coerce an absent prop to `false` (not
+  // `undefined`), and the `props.present !== false` gates below would then skip
+  // adding the scope to the stack for every consumer that doesn't pass `present`
+  // (e.g. Combobox/Select content). That scope would never pause an ancestor
+  // trap, so a Combobox input inside a Dialog could not be focused (#2749).
+  present: true,
 })
 const emits = defineEmits<FocusScopeEmits>()
 
@@ -234,7 +241,8 @@ watchEffect(async (cleanupFn) => {
 // scopes' traps) and the mount auto-focus (which only fires on physical mount).
 // Awaiting `nextTick` lets the consumer's visibility change (e.g. `v-show`)
 // apply first, so the focus targets exist. Consumers that don't pass `present`
-// never hit this — it stays `undefined`.
+// default it to `true` (see `withDefaults`); since it never changes for them,
+// this watcher never fires and the main effect above owns their stack membership.
 watch(() => props.present, async (present, prevPresent) => {
   if (!isClient)
     return


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2749 (regression of #2335), resolves #2756.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

The 2.10.0 `FocusScope` refactor (#2662) added a `present` prop and gated **two** behaviors on `props.present !== false`:

1. **Stack membership** — registering in the global focus-scope stack, which **pauses an active ancestor trap** (e.g. a `Dialog`'s trapped `FocusScope`).
2. **Mount auto-focus** — dispatching `mountAutoFocus` and moving focus into the scope's content on mount.

It intended an absent prop to mean "present". But `present` is a **Boolean-typed prop**, so Vue's [boolean casting](https://vuejs.org/guide/components/props.html#boolean-casting) coerces an *absent* prop to `false`, not `undefined`. So `props.present !== false` evaluated to `false`, and **both** behaviors were silently disabled for every `FocusScope` consumer that doesn't pass `present` explicitly — `Combobox`, `Select`, `Popover`, `Menu` (DropdownMenu/Menubar/ContextMenu) and `Drawer` content. Only `Dialog*` (which forwards `present`) was unaffected.

That single gate produced two distinct regressions:

- **#2749 (re-introducing #2335)** — a `Combobox`/`Select` portaled out of an enclosing `Dialog` no longer registered in the stack, so it didn't pause the Dialog's trap and the Dialog kept yanking focus back. The input/items could not be focused or typed.
- **#2756** — a **standalone** `DropdownMenu` (no Dialog involved) no longer dispatched its mount auto-focus, so focus never moved into the menu content on open and arrow-key navigation between items stopped working.

The fix defaults `present` to `true` in `withDefaults`, matching the prop's own documented `@defaultValue true`. Because `withDefaults` supplies a default, Vue's boolean cast-to-`false` for an absent prop no longer applies, so `present` resolves to `true` as intended. Consumers that pass `present` explicitly (`Dialog` with `unmountOnHide`) are unaffected.

Verified in a real browser (`Dialog` → `ComboboxRoot` → `ComboboxPortal` → `ComboboxContent` with the input inside the content):

| Ref | Input focusable / typable |
| --- | --- |
| v2.9.10 | ✅ works |
| v2.10.0 | ❌ focus trapped back to Dialog |
| this PR | ✅ works |

### 🧪 Tests

Two regression tests in `FocusScope.test.ts`, each failing without the fix and passing with it:
- Combobox input inside Dialog (the reported #2749 case).
- Select content (portaled) inside Dialog (a second consumer, to document the fix is not Combobox-specific).

Both cover the stack-membership path (pausing the Dialog's trap); the Combobox test also asserts the mount auto-focus lands on the input, which is the same gate behind #2756.

Full `packages/core` suite (1946 tests) passes.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a focus management regression so focus remains correctly inside Dialogs that contain portal-rendered Combobox or Select elements.

* **Tests**
  * Added regression coverage for Dialog + Combobox focus behavior, including preventing the Dialog focus trap from re-stealing focus immediately.
  * Added regression coverage for portal-rendered Select content within Dialogs to ensure focus lands inside the Select.

* **Documentation**
  * Clarified the `present` prop default for `FocusScope` and its relevance to focus-scope behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
