### PR TITLE
fix(Listbox): keep activedescendant highlight on focusout when filter-driven

### DIFF
--- a/packages/core/src/Listbox/Listbox.test.ts
+++ b/packages/core/src/Listbox/Listbox.test.ts
@@ -5,7 +5,7 @@ import { axe } from 'vitest-axe'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { useKbd } from '@/shared'
 import { handleSubmit } from '@/test'
-import { ListboxContent, ListboxItem, ListboxRoot, ListboxVirtualizer } from '.'
+import { ListboxContent, ListboxFilter, ListboxItem, ListboxRoot, ListboxVirtualizer } from '.'
 import Listbox from './story/_Listbox.vue'
 
 describe('given default Listbox', () => {
@@ -536,5 +536,56 @@ describe('given Listbox in a form', async () => {
       expect(handleSubmit).toHaveBeenCalledTimes(2)
       expect(handleSubmit.mock.results[1].value).toStrictEqual({ test: items[4].text() })
     })
+  })
+})
+
+// Regression for the 2.10.0 on-open highlight loss in filter-driven listboxes
+// (Combobox/Select, e.g. Nuxt UI's USelectMenu). When a `ListboxFilter` is
+// present the root is `focusable === false`: DOM focus stays on the input and
+// items are highlighted via `aria-activedescendant`, never DOM-focused. The
+// input is also frequently portaled outside the root, so the root `focusout`
+// target is never contained by the root — which previously made the handler
+// treat every focus move as "left the listbox" and wipe the highlight.
+describe('given a filter-driven Listbox (focusable === false)', () => {
+  const FilterListbox = defineComponent({
+    components: { ListboxRoot, ListboxFilter, ListboxContent, ListboxItem },
+    template: `
+      <div>
+        <ListboxRoot data-testid="root">
+          <ListboxFilter data-testid="filter" />
+          <ListboxContent>
+            <ListboxItem value="apple" data-testid="apple">Apple</ListboxItem>
+            <ListboxItem value="banana" data-testid="banana">Banana</ListboxItem>
+          </ListboxContent>
+        </ListboxRoot>
+        <button data-testid="outside">outside</button>
+      </div>
+    `,
+  })
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('should keep the highlight when focus leaves the root via focusout', async () => {
+    const wrapper = mount(FilterListbox, { attachTo: document.body })
+    // `ListboxFilter` flips `focusable` to false on mount.
+    await nextTick()
+
+    // Highlight the first item the filter-driven way (no DOM focus moves).
+    await wrapper.find('[data-testid=filter]').trigger('keydown', { key: 'ArrowDown' })
+    const apple = wrapper.find('[data-testid=apple]')
+    expect(apple.attributes('data-highlighted')).toBe('')
+
+    // Focus moves to an element outside the root (as the portaled input does).
+    const outside = wrapper.find('[data-testid=outside]').element
+    await wrapper.find('[data-testid=root]').trigger('focusout', { relatedTarget: outside })
+    // The handler awaits `nextTick` before deciding; let it settle.
+    await nextTick()
+    await nextTick()
+
+    // The highlight must survive — it is owned by `aria-activedescendant`, not
+    // by DOM focus, so a root `focusout` must not clear it in this mode.
+    expect(apple.attributes('data-highlighted')).toBe('')
   })
 })

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -421,7 +421,16 @@ provideListboxRootContext({
     @focusout="async (event: FocusEvent) => {
       const target = (event.relatedTarget || event.target) as HTMLElement | null
       await nextTick()
-      if (highlightedElement && currentElement && !currentElement.contains(target)) {
+      // Only treat a focusout as 'focus left the listbox' when the items are
+      // themselves focusable (standalone Listbox). When the listbox is driven by
+      // a filter input (`focusable === false`, e.g. Combobox/Select), DOM focus
+      // deliberately lives on that input while items are highlighted via
+      // `aria-activedescendant`, and that input is often portaled outside
+      // `currentElement` (Combobox content). In that mode `currentElement` can
+      // never contain the focus target, so this check would always fire and wipe
+      // the highlight (e.g. the just-set on-open highlight). Highlight lifecycle
+      // there is owned by the filter input's blur handling and the dismiss layer.
+      if (focusable && highlightedElement && currentElement && !currentElement.contains(target)) {
         onLeave(event)
       }
     }"


### PR DESCRIPTION
### 🔗 Linked issue

2.10.0 regression: filter-driven listboxes (Combobox / Select, e.g. Nuxt UI's `USelectMenu`) no longer highlight the first item on open. Related: #2752.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

When a `Listbox` is driven by a filter input (`ListboxFilter`, used by `ComboboxInput`), it sets `rootContext.focusable = false`: DOM focus deliberately stays on the input and items are highlighted via `aria-activedescendant`, never DOM-focused. In a `Combobox`/`Select` the content (input + items) is also portaled **out** of the `ListboxRoot` element, so `currentElement.contains(target)` in the root's `@focusout` handler is *always* `false`.

`packages/core/src/Listbox` is byte-identical between 2.9.10 and 2.10.0, but a 2.10.0 timing change moved the relevant `focusout` to land *after* the on-open highlight is set. The handler then sees focus "leave the listbox" (it can't contain the portaled input) and calls `onLeave`, which nulls `highlightedElement` and wipes the just-set highlight.

The fix gates the highlight-clearing branch on `focusable`: when `focusable === false`, a `focusout` from `currentElement` tells us nothing about whether the user left the widget (focus lives on the portaled input by design), so the highlight must not be cleared. Standalone (DOM-focusable) listboxes are unchanged.

```diff
- if (highlightedElement && currentElement && !currentElement.contains(target))
+ if (focusable && highlightedElement && currentElement && !currentElement.contains(target))
    onLeave(event)
```

### 🧪 Tests

Added a deterministic regression test in `Listbox.test.ts` ("filter-driven Listbox"): with a `ListboxFilter` present (`focusable === false`), a root `focusout` whose target sits outside the root must not clear the `aria-activedescendant` highlight. It exercises the exact code path without relying on focus-trap timing (which doesn't reproduce reliably in jsdom) — it fails without the gate and passes with it.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
