### PR TITLE
fix(RadioGroup): forward parent scope id onto RadioGroupItem control (#2751)

### DIFF
--- a/packages/core/src/RadioGroup/RadioGroupItem.vue
+++ b/packages/core/src/RadioGroup/RadioGroupItem.vue
@@ -2,7 +2,7 @@
 import type { ComputedRef } from 'vue'
 import type { RadioProps } from './Radio.vue'
 import type { SelectEvent } from './utils'
-import { createContext, useForwardExpose } from '@/shared'
+import { createContext, useForwardExpose, useForwardScopeId } from '@/shared'
 
 export interface RadioGroupItemProps extends Omit<RadioProps, 'checked'> {}
 export type RadioGroupItemEmits = {
@@ -80,6 +80,10 @@ function handleFocus() {
       currentElement.value?.click()
   }, 0)
 }
+// `RadioGroupItem` sets `inheritAttrs: false` and wraps the multi-root `Radio`, so the
+// parent's scoped-style id is not auto-forwarded; pass it through manually so consumer
+// `<style scoped>` keeps working. (issue #2751)
+const scopeIdAttrs = useForwardScopeId()
 </script>
 
 <template>
@@ -91,7 +95,7 @@ function handleFocus() {
     :active="checked"
   >
     <Radio
-      v-bind="{ ...$attrs, ...props }"
+      v-bind="{ ...scopeIdAttrs, ...$attrs, ...props }"
       :ref="forwardRef"
       :checked="checked"
       :required="required"

--- a/packages/core/src/RadioGroup/story/_ScopedRadioGroup.vue
+++ b/packages/core/src/RadioGroup/story/_ScopedRadioGroup.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { RadioGroupItem, RadioGroupRoot } from '..'
+</script>
+
+<template>
+  <!-- `marker` receives this SFC's scoped-style id; the RadioGroupItem control must
+       receive the same id (forwarded manually) even though it wraps the multi-root
+       `Radio` and sets `inheritAttrs: false`. -->
+  <span class="marker" />
+  <RadioGroupRoot
+    default-value="default"
+    name="test"
+  >
+    <RadioGroupItem
+      value="default"
+      aria-label="scoped"
+      class="scoped-radio"
+    />
+  </RadioGroupRoot>
+</template>
+
+<style scoped>
+.marker {
+  color: red;
+}
+.scoped-radio {
+  color: rgb(1, 2, 3);
+}
+</style>

--- a/packages/core/src/ToggleGroup/ToggleGroupItem.vue
+++ b/packages/core/src/ToggleGroup/ToggleGroupItem.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { AcceptableValue } from '@/shared/types'
 import type { ToggleProps } from '@/Toggle'
-import { isValueEqualOrExist, useForwardExpose } from '@/shared'
+import { isValueEqualOrExist, useForwardExpose, useForwardScopeId } from '@/shared'
 
 export interface ToggleGroupItemProps extends Omit<ToggleProps, 'name' | 'required' | 'modelValue' | 'defaultValue'> {
   /**
@@ -27,6 +27,9 @@ const disabled = computed(() => rootContext.disabled?.value || props.disabled)
 const pressed = computed(() => isValueEqualOrExist(rootContext.modelValue.value, props.value))
 
 const { forwardRef } = useForwardExpose()
+// `ToggleGroupItem` wraps the multi-root `Toggle`, so the parent's scoped-style id
+// is not auto-forwarded; pass it through manually so consumer `<style scoped>` works.
+const scopeIdAttrs = useForwardScopeId()
 </script>
 
 <template>
@@ -36,7 +39,7 @@ const { forwardRef } = useForwardExpose()
     v-bind="rootContext.rovingFocus.value ? { focusable: !disabled, active: pressed } : {}"
   >
     <Toggle
-      v-bind="props"
+      v-bind="{ ...scopeIdAttrs, ...props }"
       :ref="forwardRef"
       v-slot="slotProps"
       :disabled="disabled"

--- a/packages/core/src/ToggleGroup/story/_ScopedToggleGroup.vue
+++ b/packages/core/src/ToggleGroup/story/_ScopedToggleGroup.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { ToggleGroupItem, ToggleGroupRoot } from '..'
+</script>
+
+<template>
+  <!-- `marker` receives this SFC's scoped-style id; the ToggleGroupItem control must
+       receive the same id (forwarded manually) even though it wraps the multi-root
+       `Toggle`. -->
+  <span class="marker" />
+  <ToggleGroupRoot
+    type="single"
+    default-value="a"
+  >
+    <ToggleGroupItem
+      value="a"
+      aria-label="scoped"
+      class="scoped-toggle"
+    />
+  </ToggleGroupRoot>
+</template>
+
+<style scoped>
+.marker {
+  color: red;
+}
+.scoped-toggle {
+  color: rgb(1, 2, 3);
+}
+</style>

--- a/packages/core/src/shared/useForwardScopeId.test.ts
+++ b/packages/core/src/shared/useForwardScopeId.test.ts
@@ -2,6 +2,8 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import NoScopeCheckbox from '@/Checkbox/story/_NoScopeCheckbox.vue'
 import ScopedCheckbox from '@/Checkbox/story/_ScopedCheckbox.vue'
+import ScopedRadioGroup from '@/RadioGroup/story/_ScopedRadioGroup.vue'
+import ScopedToggleGroup from '@/ToggleGroup/story/_ScopedToggleGroup.vue'
 
 function scopeIdOf(el: Element): string | undefined {
   return el.getAttributeNames().find(name => name.startsWith('data-v-'))
@@ -13,6 +15,36 @@ describe('useForwardScopeId', () => {
   // scope id must land on the interactive control so scoped styles keep working.
   it('forwards the parent scope id onto a multi-root component root', () => {
     const wrapper = mount(ScopedCheckbox, { attachTo: document.body })
+
+    const marker = wrapper.find('.marker').element
+    const button = wrapper.find('button').element
+    const parentScopeId = scopeIdOf(marker)
+
+    expect(parentScopeId).toBeTruthy()
+    expect(button.hasAttribute(parentScopeId!)).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  // `RadioGroupItem` sets `inheritAttrs: false` and wraps the multi-root `Radio`, so the
+  // parent scope id is dropped unless it is forwarded onto the inner control. (issue #2751)
+  it('forwards the parent scope id through RadioGroupItem onto its control', () => {
+    const wrapper = mount(ScopedRadioGroup, { attachTo: document.body })
+
+    const marker = wrapper.find('.marker').element
+    const button = wrapper.find('button').element
+    const parentScopeId = scopeIdOf(marker)
+
+    expect(parentScopeId).toBeTruthy()
+    expect(button.hasAttribute(parentScopeId!)).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  // `ToggleGroupItem` wraps the multi-root `Toggle` the same way, so it has the same
+  // scope-id-drop and must forward it too.
+  it('forwards the parent scope id through ToggleGroupItem onto its control', () => {
+    const wrapper = mount(ScopedToggleGroup, { attachTo: document.body })
 
     const marker = wrapper.find('.marker').element
     const button = wrapper.find('button').element


### PR DESCRIPTION
## Description

Fixes #2751.

`RadioGroupItem` sets `inheritAttrs: false` and renders the multi-root `Radio` (visible control + sibling hidden form input) as its root. Because of this, Vue's automatic parent scope-id fallthrough is dropped, so when a consumer uses `RadioGroupItem` as a styled element under `<style scoped>`, the `data-v-xxxx` attribute never lands on the rendered control and the scoped CSS rules don't apply.

The fix forwards the parent scope id with the existing `useForwardScopeId()` helper (the same approach introduced for the multi-root form controls in #2720) and spreads it onto the inner `Radio`.

### Similar case caught

While auditing for the same pattern, `ToggleGroupItem` was found to wrap the multi-root `Toggle` in exactly the same way and had the identical bug (confirmed failing with a regression test before the fix). It gets the same `useForwardScopeId()` treatment.

Other multi-root form controls (`Checkbox`, `Switch`, `Toggle`, `Radio`) already forward the scope id, and the remaining `*Root` components render their hidden input nested inside a single Primitive root, so they are unaffected.

## Tests

Added regression tests in `useForwardScopeId.test.ts` using scoped-style fixtures (`_ScopedRadioGroup.vue`, `_ScopedToggleGroup.vue`) that assert the parent scope id reaches the control's `<button>` for both `RadioGroupItem` and `ToggleGroupItem`.

- `pnpm --filter reka-ui exec vitest run` (affected suites) ✅
- `pnpm lint` (0 errors) ✅
- `pnpm --filter reka-ui type-check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scoped CSS now applies correctly to items inside radio and toggle groups, even when they wrap other components.
  * Improved style inheritance so custom component styles continue to work as expected in nested setups.

* **Tests**
  * Added coverage for scoped-style behavior in radio and toggle group examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->