### PR TITLE
fix(NumberField): snap off-grid value to the nearest grid line when stepping

### DIFF
--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -300,6 +300,30 @@ describe('numberField', () => {
       await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 21 (max not snapped to step)
       expect(input.value).toBe('21')
     })
+
+    it('should snap an off-grid value to the next grid line when incrementing', async () => {
+      // Seed the off-grid value via defaultValue: typing it would snap on commit.
+      const { input, increment } = setup({ step: 1, stepSnapping: true, defaultValue: 18.98 })
+
+      await userEvent.click(increment) // snap up to the nearest grid line, not 18.98 + 1 -> 20
+      expect(input.value).toBe('19')
+    })
+
+    it('should snap an off-grid value to the previous grid line when decrementing', async () => {
+      const { input, decrement } = setup({ step: 1, stepSnapping: true, defaultValue: 18.11 })
+
+      await userEvent.click(decrement) // snap down to the nearest grid line, not 18.11 - 1 -> 17
+      expect(input.value).toBe('18')
+    })
+
+    it('should add a full step when the value is already on the grid', async () => {
+      const { input, increment, decrement } = setup({ step: 1, stepSnapping: true, defaultValue: 5 })
+
+      await userEvent.click(increment)
+      expect(input.value).toBe('6')
+      await userEvent.click(decrement)
+      expect(input.value).toBe('5')
+    })
   })
 
   describe('given setting the input value manually', async () => {

--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -354,6 +354,14 @@ describe('numberField', () => {
 
       expect(decrement).toHaveAttribute('disabled')
     })
+
+    it('should clamp the empty/NaN fallback to the range', async () => {
+      const { input, increment } = setup({ max: -5 })
+
+      // Empty input: the bare fallback would be 0, which is above max; it must be clamped.
+      await userEvent.click(increment)
+      expect(input.value).toBe('-5')
+    })
   })
 
   describe('given setting the input value manually', async () => {

--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -326,6 +326,36 @@ describe('numberField', () => {
     })
   })
 
+  describe('given step alignment near min/max boundaries', () => {
+    it('should keep increment enabled when an off-grid value can still align below max', async () => {
+      const { input, increment } = setup({ max: 10, step: 3, stepSnapping: true, defaultValue: 8 })
+
+      expect(increment).not.toHaveAttribute('disabled')
+      await userEvent.click(increment) // aligns to 9, not 8 + 3
+      expect(input.value).toBe('9')
+    })
+
+    it('should keep decrement enabled when an off-grid value can still align above min', async () => {
+      const { input, decrement } = setup({ min: 2, step: 3, stepSnapping: true, defaultValue: 4 })
+
+      expect(decrement).not.toHaveAttribute('disabled')
+      await userEvent.click(decrement) // aligns to 2, not 4 - 3
+      expect(input.value).toBe('2')
+    })
+
+    it('should disable increment once the next aligned value cannot exceed max', async () => {
+      const { increment } = setup({ max: 10, step: 3, stepSnapping: true, defaultValue: 9 })
+
+      expect(increment).toHaveAttribute('disabled')
+    })
+
+    it('should disable decrement once the next aligned value cannot go below min', async () => {
+      const { decrement } = setup({ min: 2, step: 3, stepSnapping: true, defaultValue: 2 })
+
+      expect(decrement).toHaveAttribute('disabled')
+    })
+  })
+
   describe('given setting the input value manually', async () => {
     it('should it increase/decrease the value appropriately', async () => {
       const { input, increment, decrement } = setup({ defaultValue: 6 })

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -94,22 +94,50 @@ const locale = useLocale(propLocale)
 const isFormControl = useFormControl(currentElement)
 const inputEl = ref<HTMLInputElement>()
 
-const isDecreaseDisabled = computed(() => (
-  !isNullish(modelValue.value) && (
-    clampInputValue(modelValue.value) === min.value
-    || (min.value && !isNaN(modelValue.value)
-    )
-      ? (handleDecimalOperation('-', modelValue.value, step.value) < min.value)
-      : false)),
-)
-const isIncreaseDisabled = computed(() => (
-  !isNullish(modelValue.value) && (
-    clampInputValue(modelValue.value) === max.value
-    || (max.value && !isNaN(modelValue.value)
-    )
-      ? (handleDecimalOperation('+', modelValue.value, step.value) > max.value)
-      : false)),
-)
+const isDecreaseDisabled = computed(() => {
+  if (isNullish(modelValue.value) || isNaN(modelValue.value))
+    return false
+  // Disabled when a decrement can't produce a smaller in-range value.
+  return getNextValue('decrease', modelValue.value) >= modelValue.value
+})
+const isIncreaseDisabled = computed(() => {
+  if (isNullish(modelValue.value) || isNaN(modelValue.value))
+    return false
+  // Disabled when an increment can't produce a larger in-range value.
+  return getNextValue('increase', modelValue.value) <= modelValue.value
+})
+
+// Compute the clamped value a single increment/decrement (or multi-step key) would land on.
+// When snapping is enabled and `from` is off the step grid, a tick snaps to the nearest grid
+// line in the requested direction (HTML stepUp/stepDown semantics), instead of adding a whole
+// step and rounding to nearest — which overshoots (e.g. 18.98 + step 1 -> 19.98 -> 20 not 19).
+function getNextValue(type: 'increase' | 'decrease', from: number, multiplier = 1): number {
+  const stepValue = step.value ?? 1
+  const operator = type === 'increase' ? '+' : '-'
+  let nextValue: number
+
+  if (stepSnapping.value && !isNaN(stepValue)) {
+    const snapped = snapValueToStep(from, min.value, max.value, stepValue)
+    if (snapped === from) {
+      nextValue = handleDecimalOperation(operator, from, stepValue * multiplier)
+    }
+    else {
+      // Align to the grid line in the requested direction first…
+      const aligned = type === 'increase'
+        ? (snapped > from ? snapped : handleDecimalOperation('+', snapped, stepValue))
+        : (snapped < from ? snapped : handleDecimalOperation('-', snapped, stepValue))
+      // …then apply any remaining steps for multi-step keys (PageUp/PageDown).
+      nextValue = multiplier > 1
+        ? handleDecimalOperation(operator, aligned, stepValue * (multiplier - 1))
+        : aligned
+    }
+  }
+  else {
+    nextValue = handleDecimalOperation(operator, from, stepValue * multiplier)
+  }
+
+  return clampInputValue(nextValue)
+}
 
 function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
   if (props.focusOnChange) {
@@ -123,35 +151,7 @@ function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
     return
   }
 
-  const stepValue = step.value ?? 1
-  const operator = type === 'increase' ? '+' : '-'
-  let nextValue: number
-
-  // When snapping is enabled and the current value is off the step grid, a single tick should
-  // snap to the nearest grid line in the requested direction (HTML stepUp/stepDown semantics),
-  // not add a whole step and then round to nearest — which overshoots
-  // (e.g. 18.98 + step 1 -> 19.98 -> 20 instead of 19).
-  if (stepSnapping.value && !isNaN(stepValue)) {
-    const snapped = snapValueToStep(currentInputValue, min.value, max.value, stepValue)
-    if (snapped === currentInputValue) {
-      nextValue = handleDecimalOperation(operator, currentInputValue, stepValue * multiplier)
-    }
-    else {
-      // Align to the grid line in the requested direction first…
-      const aligned = type === 'increase'
-        ? (snapped > currentInputValue ? snapped : handleDecimalOperation('+', snapped, stepValue))
-        : (snapped < currentInputValue ? snapped : handleDecimalOperation('-', snapped, stepValue))
-      // …then apply any remaining steps for multi-step keys (PageUp/PageDown).
-      nextValue = multiplier > 1
-        ? handleDecimalOperation(operator, aligned, stepValue * (multiplier - 1))
-        : aligned
-    }
-  }
-  else {
-    nextValue = handleDecimalOperation(operator, currentInputValue, stepValue * multiplier)
-  }
-
-  modelValue.value = clampInputValue(nextValue)
+  modelValue.value = getNextValue(type, currentInputValue, multiplier)
 }
 
 function handleIncrease(multiplier = 1) {

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -147,7 +147,9 @@ function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
     return
   const currentInputValue = numberParser.parse(inputEl.value?.value ?? '')
   if (isNaN(currentInputValue)) {
-    modelValue.value = min.value ?? 0
+    // Route the fallback through clampInputValue so the min/max contract still holds
+    // (e.g. a negative max would otherwise be violated by the bare 0 fallback).
+    modelValue.value = clampInputValue(min.value ?? 0)
     return
   }
 

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -120,13 +120,38 @@ function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
   const currentInputValue = numberParser.parse(inputEl.value?.value ?? '')
   if (isNaN(currentInputValue)) {
     modelValue.value = min.value ?? 0
+    return
+  }
+
+  const stepValue = step.value ?? 1
+  const operator = type === 'increase' ? '+' : '-'
+  let nextValue: number
+
+  // When snapping is enabled and the current value is off the step grid, a single tick should
+  // snap to the nearest grid line in the requested direction (HTML stepUp/stepDown semantics),
+  // not add a whole step and then round to nearest — which overshoots
+  // (e.g. 18.98 + step 1 -> 19.98 -> 20 instead of 19).
+  if (stepSnapping.value && !isNaN(stepValue)) {
+    const snapped = snapValueToStep(currentInputValue, min.value, max.value, stepValue)
+    if (snapped === currentInputValue) {
+      nextValue = handleDecimalOperation(operator, currentInputValue, stepValue * multiplier)
+    }
+    else {
+      // Align to the grid line in the requested direction first…
+      const aligned = type === 'increase'
+        ? (snapped > currentInputValue ? snapped : handleDecimalOperation('+', snapped, stepValue))
+        : (snapped < currentInputValue ? snapped : handleDecimalOperation('-', snapped, stepValue))
+      // …then apply any remaining steps for multi-step keys (PageUp/PageDown).
+      nextValue = multiplier > 1
+        ? handleDecimalOperation(operator, aligned, stepValue * (multiplier - 1))
+        : aligned
+    }
   }
   else {
-    if (type === 'increase')
-      modelValue.value = clampInputValue(currentInputValue + ((step.value ?? 1) * multiplier))
-    else
-      modelValue.value = clampInputValue(currentInputValue - ((step.value ?? 1) * multiplier))
+    nextValue = handleDecimalOperation(operator, currentInputValue, stepValue * multiplier)
   }
+
+  modelValue.value = clampInputValue(nextValue)
 }
 
 function handleIncrease(multiplier = 1) {


### PR DESCRIPTION
### 🔗 Linked issue
#2758

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes increment/decrement overshooting when the value is off the step grid.

Previously a tick added a full step and then rounded to nearest, so an off-grid value skipped a line (`18.98` + step `1` → `20` instead of `19`; `18.11` − step `1` → `17` instead of `18`). Stepping now snaps to the nearest grid line in the requested direction (HTML `stepUp`/`stepDown` semantics); values already on the grid still move by a full step.

The +/- disabled state had the same root cause: `isIncreaseDisabled`/`isDecreaseDisabled` used the raw `value ± step` instead of the aligned next value, so a valid off-grid move (e.g. `8 → 9` with `max=10`, `step=3`) was wrongly disabled. Both now reuse the same `getNextValue` calculation as the handler.

> Note: an earlier version of this PR also stopped snapping manually-typed values on
> commit. That was dropped per review — snapping the committed value to the step grid is
> the intended behavior with `stepSnapping`. Allowing off-grid typed values is handled
> separately as an opt-in (`allowInvalid`) in #2761.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Number field increment and decrement actions now respect step snapping more consistently, including off-grid values and multi-step changes.
  * Boundary checks are improved so controls only stay enabled when the next valid value still fits within the allowed range.

* **Bug Fixes**
  * Fixed cases where stepping from an empty or invalid value could produce an out-of-range result.
  * Improved behavior near minimum and maximum limits so values snap correctly instead of moving by a simple raw step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->