### PR TITLE
feat(NumberField): add allowInvalid prop

### DIFF
--- a/docs/content/meta/NumberFieldRoot.md
+++ b/docs/content/meta/NumberFieldRoot.md
@@ -3,6 +3,12 @@
 <llm-exclude>
 <PropsTable :data="[
   {
+    'name': 'allowInvalid',
+    'description': '<p>When <code>true</code>, a typed value is kept as-is even if invalid (out of <code>min</code>/<code>max</code> range or off the step grid); step interactions still clamp and snap.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
     'name': 'as',
     'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
     'type': 'AsTag | Component',
@@ -149,6 +155,7 @@
 
 | Name | Description | Type | Required | Default |
 | --- | --- | --- | --- | --- |
+| `allowInvalid` | When true, a typed value is kept as-is even if invalid (out of min/max range or off the step grid); step interactions still clamp and snap. | `boolean` | No | - |
 | `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
 | `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
 | `defaultValue` |  | `number` | No | - |

--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -300,6 +300,30 @@ describe('numberField', () => {
       await fireEvent.keyDown(input, { key: kbd.ARROW_UP }) // 21 (max not snapped to step)
       expect(input.value).toBe('21')
     })
+
+    it('should snap an off-grid value to the next grid line when incrementing', async () => {
+      // Seed the off-grid value via defaultValue: typing it would snap on commit.
+      const { input, increment } = setup({ step: 1, stepSnapping: true, defaultValue: 18.98 })
+
+      await userEvent.click(increment) // snap up to the nearest grid line, not 18.98 + 1 -> 20
+      expect(input.value).toBe('19')
+    })
+
+    it('should snap an off-grid value to the previous grid line when decrementing', async () => {
+      const { input, decrement } = setup({ step: 1, stepSnapping: true, defaultValue: 18.11 })
+
+      await userEvent.click(decrement) // snap down to the nearest grid line, not 18.11 - 1 -> 17
+      expect(input.value).toBe('18')
+    })
+
+    it('should add a full step when the value is already on the grid', async () => {
+      const { input, increment, decrement } = setup({ step: 1, stepSnapping: true, defaultValue: 5 })
+
+      await userEvent.click(increment)
+      expect(input.value).toBe('6')
+      await userEvent.click(decrement)
+      expect(input.value).toBe('5')
+    })
   })
 
   describe('given setting the input value manually', async () => {

--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -364,6 +364,50 @@ describe('numberField', () => {
     })
   })
 
+  describe('given allowInvalid prop', async () => {
+    it('should keep a typed value above max without clamping', async () => {
+      const { input } = setup({ max: 10, allowInvalid: true })
+
+      input.value = '50'
+      await fireEvent.keyDown(input, { key: kbd.ENTER })
+      expect(input.value).toBe('50')
+    })
+
+    it('should keep a typed value below min without clamping', async () => {
+      const { input } = setup({ min: 5, allowInvalid: true })
+
+      input.value = '1'
+      await fireEvent.keyDown(input, { key: kbd.ENTER })
+      expect(input.value).toBe('1')
+    })
+
+    it('should keep an off-grid typed value without snapping', async () => {
+      const { input } = setup({ step: 1, stepSnapping: true, allowInvalid: true })
+
+      input.value = '2.5'
+      await fireEvent.keyDown(input, { key: kbd.ENTER })
+      expect(input.value).toBe('2.5')
+    })
+
+    it('should still clamp and snap a typed value when allowInvalid is false', async () => {
+      const { input } = setup({ max: 10 })
+
+      input.value = '50'
+      await fireEvent.keyDown(input, { key: kbd.ENTER })
+      expect(input.value).toBe('10')
+    })
+
+    it('should still clamp step interactions even when allowInvalid is true', async () => {
+      const { input, decrement } = setup({ max: 10, allowInvalid: true })
+
+      input.value = '50'
+      await fireEvent.keyDown(input, { key: kbd.ENTER })
+      expect(input.value).toBe('50')
+      await userEvent.click(decrement) // stepping clamps back into range
+      expect(input.value).toBe('10')
+    })
+  })
+
   describe('given setting the input value manually', async () => {
     it('should it increase/decrease the value appropriately', async () => {
       const { input, increment, decrement } = setup({ defaultValue: 6 })

--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -354,6 +354,14 @@ describe('numberField', () => {
 
       expect(decrement).toHaveAttribute('disabled')
     })
+
+    it('should clamp the empty/NaN fallback to the range', async () => {
+      const { input, increment } = setup({ max: -5 })
+
+      // Empty input: the bare fallback would be 0, which is above max; it must be clamped.
+      await userEvent.click(increment)
+      expect(input.value).toBe('-5')
+    })
   })
 
   describe('given setting the input value manually', async () => {

--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -326,6 +326,36 @@ describe('numberField', () => {
     })
   })
 
+  describe('given step alignment near min/max boundaries', () => {
+    it('should keep increment enabled when an off-grid value can still align below max', async () => {
+      const { input, increment } = setup({ max: 10, step: 3, stepSnapping: true, defaultValue: 8 })
+
+      expect(increment).not.toHaveAttribute('disabled')
+      await userEvent.click(increment) // aligns to 9, not 8 + 3
+      expect(input.value).toBe('9')
+    })
+
+    it('should keep decrement enabled when an off-grid value can still align above min', async () => {
+      const { input, decrement } = setup({ min: 2, step: 3, stepSnapping: true, defaultValue: 4 })
+
+      expect(decrement).not.toHaveAttribute('disabled')
+      await userEvent.click(decrement) // aligns to 2, not 4 - 3
+      expect(input.value).toBe('2')
+    })
+
+    it('should disable increment once the next aligned value cannot exceed max', async () => {
+      const { increment } = setup({ max: 10, step: 3, stepSnapping: true, defaultValue: 9 })
+
+      expect(increment).toHaveAttribute('disabled')
+    })
+
+    it('should disable decrement once the next aligned value cannot go below min', async () => {
+      const { decrement } = setup({ min: 2, step: 3, stepSnapping: true, defaultValue: 2 })
+
+      expect(decrement).toHaveAttribute('disabled')
+    })
+  })
+
   describe('given setting the input value manually', async () => {
     it('should it increase/decrease the value appropriately', async () => {
       const { input, increment, decrement } = setup({ defaultValue: 6 })

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -94,22 +94,50 @@ const locale = useLocale(propLocale)
 const isFormControl = useFormControl(currentElement)
 const inputEl = ref<HTMLInputElement>()
 
-const isDecreaseDisabled = computed(() => (
-  !isNullish(modelValue.value) && (
-    clampInputValue(modelValue.value) === min.value
-    || (min.value && !isNaN(modelValue.value)
-    )
-      ? (handleDecimalOperation('-', modelValue.value, step.value) < min.value)
-      : false)),
-)
-const isIncreaseDisabled = computed(() => (
-  !isNullish(modelValue.value) && (
-    clampInputValue(modelValue.value) === max.value
-    || (max.value && !isNaN(modelValue.value)
-    )
-      ? (handleDecimalOperation('+', modelValue.value, step.value) > max.value)
-      : false)),
-)
+const isDecreaseDisabled = computed(() => {
+  if (isNullish(modelValue.value) || isNaN(modelValue.value))
+    return false
+  // Disabled when a decrement can't produce a smaller in-range value.
+  return getNextValue('decrease', modelValue.value) >= modelValue.value
+})
+const isIncreaseDisabled = computed(() => {
+  if (isNullish(modelValue.value) || isNaN(modelValue.value))
+    return false
+  // Disabled when an increment can't produce a larger in-range value.
+  return getNextValue('increase', modelValue.value) <= modelValue.value
+})
+
+// Compute the clamped value a single increment/decrement (or multi-step key) would land on.
+// When snapping is enabled and `from` is off the step grid, a tick snaps to the nearest grid
+// line in the requested direction (HTML stepUp/stepDown semantics), instead of adding a whole
+// step and rounding to nearest — which overshoots (e.g. 18.98 + step 1 -> 19.98 -> 20 not 19).
+function getNextValue(type: 'increase' | 'decrease', from: number, multiplier = 1): number {
+  const stepValue = step.value ?? 1
+  const operator = type === 'increase' ? '+' : '-'
+  let nextValue: number
+
+  if (stepSnapping.value && !isNaN(stepValue)) {
+    const snapped = snapValueToStep(from, min.value, max.value, stepValue)
+    if (snapped === from) {
+      nextValue = handleDecimalOperation(operator, from, stepValue * multiplier)
+    }
+    else {
+      // Align to the grid line in the requested direction first…
+      const aligned = type === 'increase'
+        ? (snapped > from ? snapped : handleDecimalOperation('+', snapped, stepValue))
+        : (snapped < from ? snapped : handleDecimalOperation('-', snapped, stepValue))
+      // …then apply any remaining steps for multi-step keys (PageUp/PageDown).
+      nextValue = multiplier > 1
+        ? handleDecimalOperation(operator, aligned, stepValue * (multiplier - 1))
+        : aligned
+    }
+  }
+  else {
+    nextValue = handleDecimalOperation(operator, from, stepValue * multiplier)
+  }
+
+  return clampInputValue(nextValue)
+}
 
 function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
   if (props.focusOnChange) {
@@ -123,35 +151,7 @@ function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
     return
   }
 
-  const stepValue = step.value ?? 1
-  const operator = type === 'increase' ? '+' : '-'
-  let nextValue: number
-
-  // When snapping is enabled and the current value is off the step grid, a single tick should
-  // snap to the nearest grid line in the requested direction (HTML stepUp/stepDown semantics),
-  // not add a whole step and then round to nearest — which overshoots
-  // (e.g. 18.98 + step 1 -> 19.98 -> 20 instead of 19).
-  if (stepSnapping.value && !isNaN(stepValue)) {
-    const snapped = snapValueToStep(currentInputValue, min.value, max.value, stepValue)
-    if (snapped === currentInputValue) {
-      nextValue = handleDecimalOperation(operator, currentInputValue, stepValue * multiplier)
-    }
-    else {
-      // Align to the grid line in the requested direction first…
-      const aligned = type === 'increase'
-        ? (snapped > currentInputValue ? snapped : handleDecimalOperation('+', snapped, stepValue))
-        : (snapped < currentInputValue ? snapped : handleDecimalOperation('-', snapped, stepValue))
-      // …then apply any remaining steps for multi-step keys (PageUp/PageDown).
-      nextValue = multiplier > 1
-        ? handleDecimalOperation(operator, aligned, stepValue * (multiplier - 1))
-        : aligned
-    }
-  }
-  else {
-    nextValue = handleDecimalOperation(operator, currentInputValue, stepValue * multiplier)
-  }
-
-  modelValue.value = clampInputValue(nextValue)
+  modelValue.value = getNextValue(type, currentInputValue, multiplier)
 }
 
 function handleIncrease(multiplier = 1) {

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -147,7 +147,9 @@ function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
     return
   const currentInputValue = numberParser.parse(inputEl.value?.value ?? '')
   if (isNaN(currentInputValue)) {
-    modelValue.value = min.value ?? 0
+    // Route the fallback through clampInputValue so the min/max contract still holds
+    // (e.g. a negative max would otherwise be violated by the bare 0 fallback).
+    modelValue.value = clampInputValue(min.value ?? 0)
     return
   }
 

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -17,6 +17,8 @@ export interface NumberFieldRootProps extends PrimitiveProps, FormFieldProps {
   step?: number
   /** When `false`, prevents the value from snapping to the nearest increment of the step value */
   stepSnapping?: boolean
+  /** When `true`, a typed value is kept as-is even if invalid (out of `min`/`max` range or off the step grid); step interactions still clamp and snap. */
+  allowInvalid?: boolean
   /** When `true`, the input will be focused when the value changes. */
   focusOnChange?: boolean
   /** Formatting options for the value displayed in the number field. This also affects what characters are allowed to be typed by the user. */
@@ -81,7 +83,7 @@ const props = withDefaults(defineProps<NumberFieldRootProps>(), {
   focusOnChange: true,
 })
 const emits = defineEmits<NumberFieldRootEmits>()
-const { disabled, readonly, disableWheelChange, invertWheelChange, min, max, step, stepSnapping, formatOptions, id, locale: propLocale } = toRefs(props)
+const { disabled, readonly, disableWheelChange, invertWheelChange, min, max, step, stepSnapping, allowInvalid, formatOptions, id, locale: propLocale } = toRefs(props)
 
 const modelValue = useVModel(props, 'modelValue', emits, {
   defaultValue: props.defaultValue,
@@ -211,7 +213,13 @@ function clampInputValue(val: number) {
 
 function applyInputValue(val: string) {
   const parsedValue = numberParser.parse(val)
-  modelValue.value = isNaN(parsedValue) ? undefined : clampInputValue(parsedValue)
+  if (isNaN(parsedValue))
+    modelValue.value = undefined
+  else if (allowInvalid.value)
+    // Keep the typed value as-is, only normalize formatting precision
+    modelValue.value = numberParser.parse(numberFormatter.format(parsedValue))
+  else
+    modelValue.value = clampInputValue(parsedValue)
   // Set to empty state if input value is empty
   if (!val.length)
     return setInputValue(val)

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -120,13 +120,38 @@ function handleChangingValue(type: 'increase' | 'decrease', multiplier = 1) {
   const currentInputValue = numberParser.parse(inputEl.value?.value ?? '')
   if (isNaN(currentInputValue)) {
     modelValue.value = min.value ?? 0
+    return
+  }
+
+  const stepValue = step.value ?? 1
+  const operator = type === 'increase' ? '+' : '-'
+  let nextValue: number
+
+  // When snapping is enabled and the current value is off the step grid, a single tick should
+  // snap to the nearest grid line in the requested direction (HTML stepUp/stepDown semantics),
+  // not add a whole step and then round to nearest — which overshoots
+  // (e.g. 18.98 + step 1 -> 19.98 -> 20 instead of 19).
+  if (stepSnapping.value && !isNaN(stepValue)) {
+    const snapped = snapValueToStep(currentInputValue, min.value, max.value, stepValue)
+    if (snapped === currentInputValue) {
+      nextValue = handleDecimalOperation(operator, currentInputValue, stepValue * multiplier)
+    }
+    else {
+      // Align to the grid line in the requested direction first…
+      const aligned = type === 'increase'
+        ? (snapped > currentInputValue ? snapped : handleDecimalOperation('+', snapped, stepValue))
+        : (snapped < currentInputValue ? snapped : handleDecimalOperation('-', snapped, stepValue))
+      // …then apply any remaining steps for multi-step keys (PageUp/PageDown).
+      nextValue = multiplier > 1
+        ? handleDecimalOperation(operator, aligned, stepValue * (multiplier - 1))
+        : aligned
+    }
   }
   else {
-    if (type === 'increase')
-      modelValue.value = clampInputValue(currentInputValue + ((step.value ?? 1) * multiplier))
-    else
-      modelValue.value = clampInputValue(currentInputValue - ((step.value ?? 1) * multiplier))
+    nextValue = handleDecimalOperation(operator, currentInputValue, stepValue * multiplier)
   }
+
+  modelValue.value = clampInputValue(nextValue)
 }
 
 function handleIncrease(multiplier = 1) {


### PR DESCRIPTION
### 🔗 Linked issue

#2760

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds an `allowInvalid` prop to `NumberField`.

When `true`, a directly typed value is kept exactly as entered even if it is invalid — out of the `min`/`max` range or off the step grid (only its formatting precision is normalized). Step-based interactions (keyboard arrows, +/- buttons, wheel) still clamp and snap to the range/grid. Defaults to `false`, so existing behavior is unchanged.

"Invalid" maps to the HTML constraint-validation states (`rangeUnderflow`/`rangeOverflow` and `stepMismatch`), which is why a single prop covers both the range and the step-grid axes. I went with `allowInvalid` over `allowOutOfRange` for that reason — open to a different name if you'd prefer.

> ⚠️ **Stacked PR — contains the fix PR's commits.**
> Built on top of #2759 (the off-grid stepping fix), because `allowInvalid`
> reuses the same commit path. Targeting `v2` directly, so the diff currently also shows
> those fix commits; it will reduce to just the `allowInvalid` commit once #2759
> is merged. **Please review/merge #2759 first.**

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `allowInvalid` option to keep typed number field values as entered, even when out of range or off the step grid (while normal step interactions still snap/clamp).

* **Bug Fixes**
  * Refined increment/decrement behavior to snap to the correct step grid and properly clamp values near minimum/maximum bounds, including better handling of empty/NaN fallback behavior.

* **Documentation**
  * Updated the number field docs to describe the new typing behavior with `allowInvalid`.

* **Tests**
  * Expanded coverage for step snapping, boundary disabling, and `allowInvalid` interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->