### PR TITLE
fix: only consume Enter/Space keydown when no modifier key is held

### DIFF
--- a/packages/core/src/Calendar/Calendar.test.ts
+++ b/packages/core/src/Calendar/Calendar.test.ts
@@ -540,11 +540,13 @@ describe('calendar', async () => {
       }
     }
     document.addEventListener('keydown', handler)
-
-    await user.keyboard(kbd.ENTER)
-    await user.keyboard(`{Control>}${kbd.ENTER}{/Control}`)
-
-    document.removeEventListener('keydown', handler)
+    try {
+      await user.keyboard(kbd.ENTER)
+      await user.keyboard(`{Control>}${kbd.ENTER}{/Control}`)
+    }
+    finally {
+      document.removeEventListener('keydown', handler)
+    }
 
     // plain Enter is handled by the cell (selection) → propagation stopped
     expect(plainEnterBubbled).toBe(false)

--- a/packages/core/src/Calendar/Calendar.test.ts
+++ b/packages/core/src/Calendar/Calendar.test.ts
@@ -518,6 +518,40 @@ describe('calendar', async () => {
     expect(heading).toHaveTextContent('December 1979')
   })
 
+  it('stops propagation for plain Enter but lets Ctrl+Enter bubble to parent listeners', async () => {
+    const { getByTestId, user } = setup({
+      calendarProps: {
+        modelValue: calendarDate,
+      },
+    })
+
+    const cell = getByTestId('date-1-20')
+    cell.focus()
+    expect(cell).toHaveFocus()
+
+    let plainEnterBubbled = false
+    let ctrlEnterBubbled = false
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        if (e.ctrlKey)
+          ctrlEnterBubbled = true
+        else
+          plainEnterBubbled = true
+      }
+    }
+    document.addEventListener('keydown', handler)
+
+    await user.keyboard(kbd.ENTER)
+    await user.keyboard(`{Control>}${kbd.ENTER}{/Control}`)
+
+    document.removeEventListener('keydown', handler)
+
+    // plain Enter is handled by the cell (selection) → propagation stopped
+    expect(plainEnterBubbled).toBe(false)
+    // Ctrl+Enter is not handled by the cell → bubbles so parents can react
+    expect(ctrlEnterBubbled).toBe(true)
+  })
+
   it('handles unavailable dates appropriately', async () => {
     const { getByTestId, user } = setup({
       calendarProps: {

--- a/packages/core/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/core/src/Calendar/CalendarCellTrigger.vue
@@ -111,6 +111,10 @@ function handleClick() {
 function handleArrowKey(e: KeyboardEvent) {
   if (isDisabled.value)
     return
+  // Modifier combos on Enter/Space (e.g. Ctrl+Enter) are not handled by the cell —
+  // let them bubble so parent listeners can react (e.g. submit a form).
+  if ((e.code === kbd.ENTER || e.code === kbd.SPACE_CODE) && (e.ctrlKey || e.metaKey || e.altKey))
+    return
   e.preventDefault()
   e.stopPropagation()
   const parentElement = rootContext.parentElement.value!
@@ -188,7 +192,6 @@ function handleArrowKey(e: KeyboardEvent) {
     :tabindex="isFocusedDate ? 0 : isOutsideView || isDisabled ? undefined : -1"
     @click="handleClick"
     @keydown.up.down.left.right.space.enter="handleArrowKey"
-    @keydown.enter.prevent
   >
     <slot
       :day-value="dayValue"

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -188,6 +188,11 @@ function highlightItem(value: T) {
 
 function onKeydownEnter(event: KeyboardEvent) {
   if (highlightedElement.value && highlightedElement.value.isConnected) {
+    // Modifier combos (e.g. Ctrl+Enter) are not handled here —
+    // let them bubble so parent listeners can react (e.g. submit a form).
+    if (event.ctrlKey || event.metaKey || event.altKey)
+      return
+
     event.preventDefault()
     event.stopPropagation()
 

--- a/packages/core/src/MonthPicker/MonthPickerCellTrigger.vue
+++ b/packages/core/src/MonthPicker/MonthPickerCellTrigger.vue
@@ -86,6 +86,10 @@ function handleClick() {
 function handleArrowKey(e: KeyboardEvent) {
   if (isDisabled.value)
     return
+  // Modifier combos on Enter/Space (e.g. Ctrl+Enter) are not handled by the cell —
+  // let them bubble so parent listeners can react (e.g. submit a form).
+  if ((e.code === kbd.ENTER || e.code === kbd.SPACE_CODE) && (e.ctrlKey || e.metaKey || e.altKey))
+    return
   e.preventDefault()
   e.stopPropagation()
   const parentElement = rootContext.parentElement.value!
@@ -199,7 +203,6 @@ function handleArrowKey(e: KeyboardEvent) {
     :tabindex="isFocusedMonth ? 0 : isDisabled ? undefined : -1"
     @click="handleClick"
     @keydown.up.down.left.right.space.enter.page-up.page-down="handleArrowKey"
-    @keydown.enter.prevent
   >
     <slot
       :month-value="shortMonthValue"

--- a/packages/core/src/MonthRangePicker/MonthRangePickerCellTrigger.vue
+++ b/packages/core/src/MonthRangePicker/MonthRangePickerCellTrigger.vue
@@ -165,6 +165,10 @@ function handleFocus() {
 function handleArrowKey(e: KeyboardEvent) {
   if (isDisabled.value)
     return
+  // Modifier combos on Enter/Space (e.g. Ctrl+Enter) are not handled by the cell —
+  // let them bubble so parent listeners can react (e.g. submit a form).
+  if ((e.code === kbd.ENTER || e.code === kbd.SPACE_CODE) && (e.ctrlKey || e.metaKey || e.altKey))
+    return
   e.preventDefault()
   e.stopPropagation()
   const parentElement = rootContext.parentElement.value!
@@ -289,7 +293,6 @@ function handleArrowKey(e: KeyboardEvent) {
     @focusin="handleFocus"
     @mouseenter="handleFocus"
     @keydown.up.down.left.right.space.enter.page-up.page-down="handleArrowKey"
-    @keydown.enter.prevent
   >
     <slot
       :month-value="shortMonthValue"

--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -187,6 +187,10 @@ function handleFocus() {
 function handleArrowKey(e: KeyboardEvent) {
   if (isDisabled.value)
     return
+  // Modifier combos on Enter/Space (e.g. Ctrl+Enter) are not handled by the cell —
+  // let them bubble so parent listeners can react (e.g. submit a form).
+  if ((e.code === kbd.ENTER || e.code === kbd.SPACE_CODE) && (e.ctrlKey || e.metaKey || e.altKey))
+    return
   e.preventDefault()
   e.stopPropagation()
   const parentElement = rootContext.parentElement.value!

--- a/packages/core/src/YearPicker/YearPickerCellTrigger.vue
+++ b/packages/core/src/YearPicker/YearPickerCellTrigger.vue
@@ -85,6 +85,10 @@ function handleClick() {
 function handleArrowKey(e: KeyboardEvent) {
   if (isDisabled.value)
     return
+  // Modifier combos on Enter/Space (e.g. Ctrl+Enter) are not handled by the cell —
+  // let them bubble so parent listeners can react (e.g. submit a form).
+  if ((e.code === kbd.ENTER || e.code === kbd.SPACE_CODE) && (e.ctrlKey || e.metaKey || e.altKey))
+    return
   e.preventDefault()
   e.stopPropagation()
   const parentElement = rootContext.parentElement.value!
@@ -203,7 +207,6 @@ function handleArrowKey(e: KeyboardEvent) {
     :tabindex="isFocusedYear ? 0 : isDisabled ? undefined : -1"
     @click="handleClick"
     @keydown.up.down.left.right.space.enter.page-up.page-down="handleArrowKey"
-    @keydown.enter.prevent
   >
     <slot
       :year-value="yearValue"

--- a/packages/core/src/YearRangePicker/YearRangePickerCellTrigger.vue
+++ b/packages/core/src/YearRangePicker/YearRangePickerCellTrigger.vue
@@ -165,6 +165,10 @@ function handleFocus() {
 function handleArrowKey(e: KeyboardEvent) {
   if (isDisabled.value)
     return
+  // Modifier combos on Enter/Space (e.g. Ctrl+Enter) are not handled by the cell —
+  // let them bubble so parent listeners can react (e.g. submit a form).
+  if ((e.code === kbd.ENTER || e.code === kbd.SPACE_CODE) && (e.ctrlKey || e.metaKey || e.altKey))
+    return
   e.preventDefault()
   e.stopPropagation()
   const parentElement = rootContext.parentElement.value!
@@ -291,7 +295,6 @@ function handleArrowKey(e: KeyboardEvent) {
     @focusin="handleFocus"
     @mouseenter="handleFocus"
     @keydown.up.down.left.right.space.enter.page-up.page-down="handleArrowKey"
-    @keydown.enter.prevent
   >
     <slot
       :year-value="yearValue"


### PR DESCRIPTION
## Description

Fixes #2400 — components with arrow navigation called `stopPropagation` on every keydown, preventing parents from listening for combos like <kbd>Ctrl</kbd>+<kbd>Enter</kbd>.

This is an alternative to #2746 that fixes the same issue at the root, while avoiding two regressions that the per-key approach introduces.

### Root cause

`CalendarCellTrigger` (and its RangeCalendar / MonthPicker / YearPicker / MonthRangePicker / YearRangePicker variants) and `ListboxRoot` unconditionally called `e.preventDefault()` + `e.stopPropagation()` at the top of their keydown handlers, before checking the key. Any keydown bound to these handlers — including modifier combos the component doesn't act on — was swallowed, so parents never received <kbd>Ctrl</kbd>+<kbd>Enter</kbd>.

### The principle

The right discriminator is **"did the component handle this event"**, not "which key". For Enter/Space that depends on the modifier keys:

- **plain Enter/Space** → the component selects → it should fully consume the event (`preventDefault` + `stopPropagation`).
- **Ctrl/Cmd/Alt + Enter/Space** → not handled → let it bubble untouched so parents can react (e.g. submit a form).

This is the same pattern `NavigationMenuTrigger` already uses (it only stops propagation for the specific key it handles), which is why that component is left unchanged.

### Fix

- **CellTrigger variants (6 files):** guard `handleArrowKey` so a modifier-held Enter/Space returns early — no `preventDefault`, no `stopPropagation`, no selection. All other keys (arrows, page up/down, plain Enter/Space) keep their existing `preventDefault` + `stopPropagation`.
- **ListboxRoot:** `onKeydownEnter` returns early when a modifier is held, so the combo bubbles and the highlighted item is not toggled as a side effect.
- Removed the now-redundant `@keydown.enter.prevent` template modifiers (preventDefault for plain Enter now lives in the handler; this also stops the modifier from prevent-defaulting the combos we want to pass through).

### Why not #2746's approach

That PR removes `stopPropagation`/`preventDefault` from the Enter/Space path entirely. That reintroduces the exact concern raised in the issue thread — **plain Enter now bubbles**, so a calendar inside a form fires the parent's Enter handler when the user only meant to pick a date — and it drops `preventDefault` for **Space**, so pressing Space on a focused cell scrolls the page. Guarding on the modifier keys keeps plain Enter/Space fully consumed while still letting the combos through.

### Testing

- Added a regression test: plain Enter is stopped at the calendar cell, <kbd>Ctrl</kbd>+<kbd>Enter</kbd> bubbles to a parent listener.
- All affected suites pass (`Calendar`, `RangeCalendar`, `MonthPicker`, `YearPicker`, `MonthRangePicker`, `YearRangePicker`, `Listbox`).
- `type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard event handling across calendar and picker cells so modified shortcuts (Ctrl/Meta/Alt + Enter/Space) are no longer intercepted and can bubble to parent listeners.
  * Preserved existing behavior for unmodified Enter/Space, including selection and navigation.
  * Expanded keydown handling to cover arrow keys, Space/Enter, and page up/down for smoother focus movement.
* **Tests**
  * Added coverage to verify Enter vs Ctrl+Enter propagation behavior for focused calendar date cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->