### PR TITLE
fix(shared): create context with `Symbol.for` to fix duplicates

### DIFF
--- a/packages/core/src/shared/createContext.test.ts
+++ b/packages/core/src/shared/createContext.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { createSSRApp, defineComponent, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { createContext } from './createContext'
+
+describe('createContext', () => {
+  // Two independent `createContext()` calls with the same name simulate the
+  // library being installed twice (e.g. a version mismatch duplicated by npm).
+  // With a module-local `Symbol()` the two keys differ and injection fails
+  // (`Injection Symbol(...) not found`, #229); with the global registry
+  // (`Symbol.for`) they share identity and provide/inject keeps working.
+  it('resolves provide/inject across separate instances with the same name', async () => {
+    const [, provideFoo] = createContext<{ value: number }>('Foo') // "copy A"
+    const [injectFoo] = createContext<{ value: number }>('Foo') // "copy B"
+
+    const Child = defineComponent({
+      setup() {
+        const ctx = injectFoo()
+        return () => h('div', String(ctx.value))
+      },
+    })
+    const App = defineComponent({
+      setup() {
+        provideFoo({ value: 42 })
+        return () => h(Child)
+      },
+    })
+
+    const html = await renderToString(createSSRApp(App))
+    expect(html).toContain('42')
+  })
+
+  it('keeps distinct contexts isolated (different names do not collide)', async () => {
+    const [, provideA] = createContext<{ n: number }>('Alpha')
+    const [injectB] = createContext<{ n: number }>('Beta')
+
+    const Child = defineComponent({
+      setup() {
+        // Beta was never provided -> injecting it must throw, not pick up Alpha.
+        expect(() => injectB()).toThrow(/not found/)
+        return () => h('div', 'ok')
+      },
+    })
+    const App = defineComponent({
+      setup() {
+        provideA({ n: 1 })
+        return () => h(Child)
+      },
+    })
+
+    const html = await renderToString(createSSRApp(App))
+    expect(html).toContain('ok')
+  })
+})

--- a/packages/core/src/shared/createContext.ts
+++ b/packages/core/src/shared/createContext.ts
@@ -13,11 +13,12 @@ export function createContext<ContextValue>(
   contextName?: string,
 ) {
   const symbolDescription
-    = typeof providerComponentName === 'string' && !contextName
-      ? `${providerComponentName}Context`
-      : contextName
+    = contextName
+      ?? (typeof providerComponentName === 'string'
+        ? `${providerComponentName}Context`
+        : providerComponentName.join('/'))
 
-  const injectionKey: InjectionKey<ContextValue | null> = Symbol(symbolDescription)
+  const injectionKey: InjectionKey<ContextValue | null> = Symbol.for(`reka-ui:${symbolDescription}`)
 
   /**
    * @param fallback The context value to return if the injection fails.


### PR DESCRIPTION
### 🔗 Linked issue

#229

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`createContext` used a module-local `Symbol(description)` as the injection key. When reka-ui is installed more than once (e.g. a version mismatch between libraries that depend on it, duplicated by the package manager), each copy creates a *different* Symbol, so a child component from one copy cannot `inject` a context provided by a parent from another copy and triggers a `Injection \Symbol(...)\ not found. Component must be used within ...` error.

This PR uses the global symbol registry (`Symbol.for('reka-ui:<name>')`) instead, which resolves to the same identity across duplicate copies, so provide/inject keeps working regardless of how the dependency graph is deduplicated.

Every context already has a unique name, so there are no cross-context collisions; the array provider form (no explicit name) now derives a stable name from the provider component names.

Same approach other UI libraries like Vuetify and even React use.

### 👀 Additional notes

On a side note, this *likely* allows Nuxt UI to drop `transpile` for reka-ui, causing the first dev server request to be sped up by 0.8-1.2 **seconds**

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
