### PR TITLE
fix(FocusScope): respect tabindex order on autofocus

### DIFF
--- a/packages/core/src/Dialog/Dialog.test.ts
+++ b/packages/core/src/Dialog/Dialog.test.ts
@@ -51,6 +51,20 @@ const DialogTest = defineComponent({
 </DialogRoot>`,
 })
 
+const TabindexDialogTest = defineComponent({
+  components: { DialogRoot, DialogTrigger, DialogOverlay, DialogContent, DialogClose, DialogTitle },
+  template: `<DialogRoot>
+  <DialogTrigger>${OPEN_TEXT}</DialogTrigger>
+  <DialogOverlay />
+  <DialogContent>
+    <DialogTitle>${TITLE_TEXT}</DialogTitle>
+    <input aria-label="Second" tabindex="2">
+    <DialogClose tabindex="1">${CLOSE_TEXT}</DialogClose>
+    <input aria-label="Default">
+  </DialogContent>
+</DialogRoot>`,
+})
+
 const UnmountOnHideDialogTest = defineComponent({
   components: { DialogRoot, DialogTrigger, DialogOverlay, DialogContent, DialogClose, DialogTitle },
   template: `<DialogRoot :unmount-on-hide="false">
@@ -89,6 +103,15 @@ const NestedContentDialogTest = defineComponent({
     </DialogContent>
   </DialogOverlay>
 </DialogRoot>`,
+})
+
+describe('given a Dialog with tabindex values', () => {
+  it('should auto-focus the tabbable element with the lowest positive tabindex', async () => {
+    renderAndClickDialogTrigger(TabindexDialogTest)
+    const closeButton = await findByText(document.body, CLOSE_TEXT)
+
+    await vi.waitFor(() => expect(closeButton).toBe(document.activeElement))
+  })
 })
 
 describe('given a Dialog with unmountOnHide=false', () => {

--- a/packages/core/src/FocusScope/utils.ts
+++ b/packages/core/src/FocusScope/utils.ts
@@ -55,9 +55,15 @@ export function getTabbableCandidates(container: HTMLElement) {
     },
   })
   while (walker.nextNode()) nodes.push(walker.currentNode as HTMLElement)
-  // we do not take into account the order of nodes with positive `tabIndex` as it
-  // hinders accessibility to have tab order different from visual order.
-  return nodes
+  return nodes.sort((a, b) => {
+    if (a.tabIndex === b.tabIndex)
+      return 0
+    if (a.tabIndex === 0)
+      return 1
+    if (b.tabIndex === 0)
+      return -1
+    return a.tabIndex - b.tabIndex
+  })
 }
 
 /**


### PR DESCRIPTION
Closes #2609

## Description
- Sort tabbable candidates so positive tabindex values are focused before default tabindex=0 elements
- Preserve DOM order for candidates with equal tabindex
- Add Dialog coverage for autofocus with tabindex ordering

## Verification
- pnpm --filter reka-ui exec vitest run src/Dialog/Dialog.test.ts src/FocusScope/FocusScope.test.ts
- pnpm --filter reka-ui type-check

Note: pnpm lint currently fails with an internal ESLint plugin error: `TypeError: sourceCode.isSpaceBetweenTokens is not a function`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus behavior in dialogs so the initial focus now lands on the most appropriate focusable element, respecting positive `tabindex` order.
  * This makes dialog navigation more predictable for keyboard and assistive technology users.

* **Tests**
  * Added coverage for dialog focus order to verify the correct element receives focus when a dialog opens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->