### PR TITLE
fix(Select): prevent placeholder flash when closing after selecting a value

### DIFF
--- a/packages/core/src/Select/Select.test.ts
+++ b/packages/core/src/Select/Select.test.ts
@@ -412,3 +412,29 @@ describe('given Select in a form', async () => {
     })
   })
 })
+
+describe('placeholder flash on close (#2638)', () => {
+  it('should keep showing the selected value while the content is closing', async () => {
+    document.body.innerHTML = ''
+    const wrapper = mount(Select, { attachTo: document.body })
+    const valueBox = wrapper.find('[aria-label="Customise options"]')
+
+    // Open then select an item, which closes the content in a single-select.
+    await wrapper.find('button').trigger('pointerdown', { button: 0, ctrlKey: false })
+    await nextTick()
+    const selection = wrapper.findAll('[role=option]')[1];
+    (selection.element as HTMLElement).focus()
+    await selection.trigger('pointerup')
+    // Needs 2 pointerup because SelectContentImpl prevents accidental pointerup's
+    await fireEvent.pointerUp(selection.element)
+
+    // While closing, `Presence` unmounts the popper items (clearing `optionsSet`)
+    // a few microtasks before the fallback fragment remounts them on the
+    // `renderPresence` setTimeout (macrotask). Draining only microtasks keeps us
+    // inside that handoff window, where the placeholder used to flash.
+    for (let i = 0; i < 5; i++) {
+      await nextTick()
+      expect(valueBox.text()).toBe('Banana')
+    }
+  })
+})

--- a/packages/core/src/Select/SelectValue.vue
+++ b/packages/core/src/Select/SelectValue.vue
@@ -10,7 +10,7 @@ export interface SelectValueProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { Primitive } from '@/Primitive'
 import { useForwardExpose } from '@/shared'
 import { injectSelectRootContext } from './SelectRoot.vue'
@@ -28,7 +28,7 @@ onMounted(() => {
   rootContext.valueElement = currentElement
 })
 
-const selectedLabel = computed(() => {
+const resolvedLabel = computed(() => {
   let list: string[] = []
   const options = Array.from(rootContext.optionsSet.value)
   const getOption = (value?: AcceptableValue) => options.find(option => valueComparator(value, option.value, rootContext.by))
@@ -40,6 +40,15 @@ const selectedLabel = computed(() => {
   }
   return list.filter(Boolean)
 })
+
+// Keep the last resolved label so the placeholder doesn't flash when the
+// options are transiently unregistered, e.g. while the content is closing and
+// the items are being moved between the popper and the fallback fragment.
+const selectedLabel = ref<string[]>(resolvedLabel.value)
+watch(resolvedLabel, (value) => {
+  if (value.length || rootContext.isEmptyModelValue.value)
+    selectedLabel.value = value
+}, { immediate: true })
 
 const slotText = computed(() => {
   return selectedLabel.value.length ? selectedLabel.value.join(', ') : props.placeholder


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2767

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a single-select `Select` closes after picking a value, the trigger label
briefly flashed the placeholder before showing the selected value again.

**Root cause:** on close, `SelectContent` moves the `SelectItem`s from the popper (`Presence`) to the fallback `DocumentFragment` so they stay mounted and keep `optionsSet` populated. But `Presence` unmounts the popper items a few microtasks *before* the fragment remounts them (the fragment branch only activates on the `renderPresence` `setTimeout` / macrotask). During that handoff window `optionsSet` is transiently empty, so `SelectValue` could not resolve the selected label and fell back to the placeholder — a one-frame flash.

**Fix:** `SelectValue` now keeps the last resolved label and only falls back to the placeholder when the model value is actually empty (`isEmptyModelValue`). This is a localized fix that doesn't touch `SelectContent`'s closing/animation timing (previously tuned in #1865 / #2638).

Added a self-contained regression test that stays inside the close handoff window (drains microtasks without firing the `setTimeout` macrotask) — it fails without the fix and passes with it.

### Fix in video

https://github.com/user-attachments/assets/699e970d-1b86-48bd-91d9-8bfb6ea72d1b

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the selected value from briefly flashing back to the placeholder when closing a single-select dropdown.
  * Kept the chosen label visible during the close/unmount transition for a smoother experience.

* **Tests**
  * Added coverage for the close animation timing to verify the selected option remains displayed while the dropdown is shutting down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->