### PR TITLE
fix(useEmitAsProps): prevent TS2589 with void emit parameters

### DIFF
--- a/packages/core/src/shared/useEmitAsProps.test-d.ts
+++ b/packages/core/src/shared/useEmitAsProps.test-d.ts
@@ -31,6 +31,10 @@ declare const singleEmit: SingleEmit
 type LooseEmit = (name: string, ...args: any[]) => void
 declare const looseEmit: LooseEmit
 
+// Void-argument emit (regression test for #2769)
+type VoidEmit = (e: 'contentFound', payload: void) => void
+declare const voidEmit: VoidEmit
+
 // useEmitAsProps — overloaded emit maps each event to its `onXxx` handler prop
 {
   const result = useEmitAsProps(overloadedEmit)
@@ -48,6 +52,16 @@ declare const looseEmit: LooseEmit
   type _args = Expect<Equal<Parameters<NonNullable<Result['onClose']>>, [reason: string]>>
 }
 
+// useEmitAsProps — void argument emit (regression test for #2769)
+// Note: OverloadUnion normalises `void` params to optional, but this is
+// still type-safe — calling the handler with or without args is valid.
+{
+  const result = useEmitAsProps(voidEmit)
+  type Result = typeof result
+  type _keys = Expect<Equal<keyof Result, 'onContentFound'>>
+  type _args = Expect<Equal<Parameters<NonNullable<Result['onContentFound']>>, [payload?: void | undefined]>>
+}
+
 // useEmitAsProps — loose signature stays accepted (backwards compatibility)
 {
   const result = useEmitAsProps(looseEmit)
@@ -56,6 +70,7 @@ declare const looseEmit: LooseEmit
 
 // EmitAsProps utility — emit signature to handler props
 type _emitAsProps = Expect<Equal<keyof EmitAsProps<OverloadedEmit>, 'onUpdate:modelValue' | 'onChange'>>
+type _emitAsPropsVoid = Expect<Equal<keyof EmitAsProps<VoidEmit>, 'onContentFound'>>
 
 // useForwardPropsEmits — fixtures
 interface DemoProps { foo: string, bar: boolean }
@@ -67,6 +82,16 @@ declare const props: DemoProps
   type Value = typeof forwarded extends ComputedRef<infer V> ? V : never
   type _prop = Expect<Equal<Value['foo'], string>>
   type _emit = Expect<Equal<Parameters<NonNullable<Value['onChange']>>, [value: number, extra: boolean]>>
+}
+
+// With void-argument emit: must not hit TS2589 (regression test for #2769)
+// Note: OverloadUnion normalises `void` params to optional, but this is
+// still type-safe — calling the handler with or without args is valid.
+{
+  const forwarded = useForwardPropsEmits(props, voidEmit)
+  type Value = typeof forwarded extends ComputedRef<infer V> ? V : never
+  type _prop = Expect<Equal<Value['foo'], string>>
+  type _emit = Expect<Equal<Parameters<NonNullable<Value['onContentFound']>>, [payload?: void | undefined]>>
 }
 
 // Without emit: only forwarded props, no `on*` handler keys leak in

--- a/packages/core/src/shared/useEmitAsProps.ts
+++ b/packages/core/src/shared/useEmitAsProps.ts
@@ -93,17 +93,21 @@ type OverloadProps<TOverload> = Pick<TOverload, keyof TOverload>
 type OverloadUnionRecursive<
   TOverload,
   TPartialOverload = unknown,
-> = TOverload extends (...args: infer TArgs) => infer TReturn
-  ? TPartialOverload extends TOverload
-    ? never
-    : | OverloadUnionRecursive<
-            TPartialOverload & TOverload,
-            TPartialOverload
-            & ((...args: TArgs) => TReturn)
-            & OverloadProps<TOverload>
-    >
-    | ((...args: TArgs) => TReturn)
-  : never
+  Depth extends any[] = [],
+> = Depth['length'] extends 10
+  ? never
+  : TOverload extends (...args: infer TArgs) => infer TReturn
+    ? TPartialOverload extends TOverload
+      ? never
+      : | OverloadUnionRecursive<
+              TPartialOverload & TOverload,
+              TPartialOverload
+              & ((...args: TArgs) => TReturn)
+              & OverloadProps<TOverload>,
+              [...Depth, any]
+      >
+      | ((...args: TArgs) => TReturn)
+    : never
 
 type OverloadUnion<TOverload extends (...args: any[]) => any> = Exclude<
   OverloadUnionRecursive<(() => never) & TOverload>,


### PR DESCRIPTION
Fixes #2769

The `OverloadUnionRecursive` type from `@vue/shared` enters infinite recursion when processing emit signatures that contain a `void` parameter (e.g. `defineEmits<{ contentFound: [void] }>()`). This triggers TS2589: "Type instantiation is excessively deep and possibly infinite."

This PR works around the upstream TypeScript limitation by adding a depth limit (10) to the recursive type. This caps the recursion before TypeScript bails out, while still preserving correct type inference for all practical emit shapes (single / overloaded / void args).

### Changes
- Added `Depth extends any[] = []` parameter to `OverloadUnionRecursive` with a depth cap of 10
- Added regression type tests for `void`-argument emits in `useEmitAsProps.test-d.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript handling for event-forwarding helpers, including events with no payload value.
  * Reduced the chance of deep type recursion issues that could trigger compiler errors in complex projects.
  * Preserved correct optional handler parameter typing when forwarding emitted events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->