### PR TITLE
feat(ScrollArea): add virtualizer

### DIFF
--- a/docs/content/docs/components/scroll-area.md
+++ b/docs/content/docs/components/scroll-area.md
@@ -36,7 +36,7 @@ Import all parts and piece them together.
 
 ```vue
 <script setup>
-import { ScrollAreaRoot, ScrollAreaScrollbar, ScrollAreaThumb, ScrollAreaViewport } from 'reka-ui'
+import { ScrollAreaRoot, ScrollAreaScrollbar, ScrollAreaThumb, ScrollAreaViewport, ScrollAreaVirtualizer } from 'reka-ui'
 </script>
 
 <template>
@@ -66,6 +66,12 @@ Contains all the parts of a scroll area.
 The viewport area of the scroll area.
 
 <!-- @include: @/meta/ScrollAreaViewport.md -->
+
+### Virtualizer
+
+Virtualizes large collections within the viewport. Place `ScrollAreaVirtualizer` inside `ScrollAreaViewport` and render each item through its default slot.
+
+<!-- @include: @/meta/ScrollAreaVirtualizer.md -->
 
 ### Scrollbar
 
@@ -110,6 +116,38 @@ The corner where both vertical and horizontal scrollbars meet.
 <!-- @include: @/meta/ScrollAreaCorner.md -->
 
 ## Examples
+
+### Virtualized list
+
+Use `ScrollAreaVirtualizer` for large collections. Only visible items and the configured overscan are mounted.
+
+```vue
+<script setup lang="ts">
+import { ScrollAreaRoot, ScrollAreaScrollbar, ScrollAreaThumb, ScrollAreaViewport, ScrollAreaVirtualizer } from 'reka-ui'
+
+const items = Array.from({ length: 10_000 }, (_, index) => `Item ${index + 1}`)
+</script>
+
+<template>
+  <ScrollAreaRoot class="h-80 overflow-hidden">
+    <ScrollAreaViewport class="h-full">
+      <ScrollAreaVirtualizer
+        v-slot="{ option }"
+        :options="items"
+        :estimate-size="32"
+      >
+        <div class="h-8">
+          {{ option }}
+        </div>
+      </ScrollAreaVirtualizer>
+    </ScrollAreaViewport>
+    <ScrollAreaScrollbar orientation="vertical">
+      <ScrollAreaThumb />
+    </ScrollAreaScrollbar>
+  </ScrollAreaRoot>
+</template>
+```
+
 ### Custom Scroll
 Use the exposed `viewport` to modify / or set the scroll position outside default methods
 ```vue line=4,18

--- a/docs/content/docs/guides/migration.md
+++ b/docs/content/docs/guides/migration.md
@@ -139,6 +139,32 @@ CSS variable and data attributes names have been updated to use the `reka` prefi
   </template>
   ```
 
+### Scroll Area
+
+Large scrollable collections can migrate from rendering every item inside `ScrollAreaViewport` to the native `ScrollAreaVirtualizer`. The item template moves into the virtualizer's default slot.
+
+```vue
+<script setup lang="ts">
+import { ScrollAreaRoot, ScrollAreaViewport, ScrollAreaVirtualizer } from 'reka-ui'
+</script>
+
+<template>
+  <ScrollAreaRoot>
+    <ScrollAreaViewport>
+      <ScrollAreaVirtualizer
+        v-slot="{ option }"
+        :options="items"
+        :estimate-size="32"
+      >
+        <div :key="option.id">
+          {{ option.label }}
+        </div>
+      </ScrollAreaVirtualizer>
+    </ScrollAreaViewport>
+  </ScrollAreaRoot>
+</template>
+```
+
 ### Presence
 
 To have better supports for SSR content, we also modify the logic around the usage of `forceMount` for component that utilize Presence:

--- a/docs/content/docs/guides/migration.md
+++ b/docs/content/docs/guides/migration.md
@@ -145,7 +145,9 @@ Large scrollable collections can migrate from rendering every item inside `Scrol
 
 ```vue
 <script setup lang="ts">
-import { ScrollAreaRoot, ScrollAreaViewport, ScrollAreaVirtualizer } from 'reka-ui'
+import { ScrollAreaRoot, ScrollAreaScrollbar, ScrollAreaThumb, ScrollAreaViewport, ScrollAreaVirtualizer } from 'reka-ui'
+
+const items = Array.from({ length: 10_000 }, (_, index) => `Item ${index + 1}`)
 </script>
 
 <template>
@@ -156,11 +158,14 @@ import { ScrollAreaRoot, ScrollAreaViewport, ScrollAreaVirtualizer } from 'reka-
         :options="items"
         :estimate-size="32"
       >
-        <div :key="option.id">
-          {{ option.label }}
+        <div>
+          {{ option }}
         </div>
       </ScrollAreaVirtualizer>
     </ScrollAreaViewport>
+    <ScrollAreaScrollbar orientation="vertical">
+      <ScrollAreaThumb />
+    </ScrollAreaScrollbar>
   </ScrollAreaRoot>
 </template>
 ```

--- a/docs/content/meta/ScrollAreaVirtualizer.md
+++ b/docs/content/meta/ScrollAreaVirtualizer.md
@@ -1,0 +1,69 @@
+<!-- This file was automatically generated. Do not edit it manually -->
+
+<llm-exclude>
+<PropsTable :data="[
+  {
+    'name': 'estimateSize',
+    'description': '<p>Estimated size (in px) of each item</p>\n',
+    'type': 'number | ((index: number) =&gt; number)',
+    'required': false
+  },
+  {
+    'name': 'horizontal',
+    'description': '<p>Whether to virtualize items horizontally.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
+    'name': 'options',
+    'description': '<p>List of items</p>\n',
+    'type': 'T',
+    'required': true
+  },
+  {
+    'name': 'overscan',
+    'description': '<p>Number of items rendered outside the visible area</p>\n',
+    'type': 'number',
+    'required': false
+  }
+]" />
+
+<SlotsTable :data="[
+  {
+    'name': 'option',
+    'description': '',
+    'type': 'T'
+  },
+  {
+    'name': 'virtualizer',
+    'description': '',
+    'type': 'Virtualizer&lt;HTMLElement, Element&gt;'
+  },
+  {
+    'name': 'virtualItem',
+    'description': '',
+    'type': 'VirtualItem'
+  }
+]" />
+</llm-exclude>
+
+<llm-only>
+
+**Props**
+
+| Name | Description | Type | Required | Default |
+| --- | --- | --- | --- | --- |
+| `estimateSize` | Estimated size (in px) of each item | `number \| ((index: number) => number)` | No | - |
+| `horizontal` | Whether to virtualize items horizontally. | `boolean` | No | - |
+| `options` | List of items | `T` | Yes | - |
+| `overscan` | Number of items rendered outside the visible area | `number` | No | - |
+
+**Slots**
+
+| Name | Description | Type |
+| --- | --- | --- |
+| `option` |  | `T` |
+| `virtualizer` |  | `Virtualizer<HTMLElement, Element>` |
+| `virtualItem` |  | `VirtualItem` |
+
+</llm-only>

--- a/packages/core/constant/components.ts
+++ b/packages/core/constant/components.ts
@@ -402,6 +402,7 @@ export const components = {
   scrollArea: [
     'ScrollAreaRoot',
     'ScrollAreaViewport',
+    'ScrollAreaVirtualizer',
     'ScrollAreaScrollbar',
     'ScrollAreaThumb',
     'ScrollAreaCorner',

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.ts
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.ts
@@ -1,5 +1,5 @@
 import type { VueWrapper } from '@vue/test-utils'
-import { fireEvent, findAllByRole, findByRole, render } from '@testing-library/vue'
+import { findAllByRole, findByRole, fireEvent, render } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'

--- a/packages/core/src/ScrollArea/ScrollArea.test.ts
+++ b/packages/core/src/ScrollArea/ScrollArea.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 import { defineComponent, h } from 'vue'
 import { sleep } from '@/test'
@@ -9,7 +9,73 @@ import ScrollAreaRoot from './ScrollAreaRoot.vue'
 import ScrollAreaScrollbar from './ScrollAreaScrollbar.vue'
 import ScrollAreaThumb from './ScrollAreaThumb.vue'
 import ScrollAreaViewport from './ScrollAreaViewport.vue'
+import ScrollAreaVirtualizer from './ScrollAreaVirtualizer.vue'
 import ScrollArea from './story/_ScrollArea.vue'
+
+describe('given a virtualized ScrollArea', () => {
+  const options = Array.from({ length: 100 }, (_, index) => `Item ${index}`)
+  const originalGetBoundingClientRect = window.HTMLElement.prototype.getBoundingClientRect
+
+  beforeAll(() => {
+    window.HTMLElement.prototype.getBoundingClientRect = function () {
+      return { width: 200, height: 200, top: 0, left: 0, right: 200, bottom: 200, x: 0, y: 0, toJSON() {} }
+    }
+  })
+
+  afterAll(() => {
+    window.HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+  })
+
+  function createVirtualScrollArea(horizontal = false) {
+    return defineComponent({
+      setup() {
+        return () => h(ScrollAreaRoot, null, {
+          default: () => h(ScrollAreaViewport, { style: 'width: 200px; height: 200px' }, {
+            default: () => h(ScrollAreaVirtualizer, {
+              options,
+              estimateSize: 25,
+              horizontal,
+            }, {
+              default: ({ option, virtualItem }: any) => h('div', { 'data-testid': 'item' }, `${virtualItem.index}:${option}`),
+            }),
+          }),
+        })
+      },
+    })
+  }
+
+  const VirtualScrollArea = createVirtualScrollArea()
+
+  async function flush() {
+    await new Promise(resolve => requestAnimationFrame(() => resolve(null)))
+    await sleep(0)
+  }
+
+  it('renders only the visible subset with matching slot data', async () => {
+    const wrapper = mount(VirtualScrollArea, { attachTo: document.body })
+    await flush()
+
+    const items = wrapper.findAll('[data-testid="item"]')
+    expect(items.length).toBeGreaterThan(0)
+    expect(items.length).toBeLessThan(options.length)
+    expect(items[0].text()).toBe('0:Item 0')
+    expect(wrapper.find('[data-reka-virtualizer]').attributes('style')).toContain('height: 2500px')
+
+    wrapper.unmount()
+  })
+
+  it('supports horizontal virtualization', async () => {
+    const wrapper = mount(createVirtualScrollArea(true), { attachTo: document.body })
+    await flush()
+
+    const virtualizer = wrapper.find('[data-reka-virtualizer]')
+    expect(virtualizer.attributes('style')).toContain('width: 2500px')
+    expect(virtualizer.attributes('style')).toContain('height: 100%')
+    expect(wrapper.find('[data-testid="item"]').attributes('style')).toContain('translateX(0px)')
+
+    wrapper.unmount()
+  })
+})
 
 describe('given default ScrollArea', () => {
   let wrapper: VueWrapper<InstanceType<typeof ScrollArea>>

--- a/packages/core/src/ScrollArea/ScrollAreaVirtualizer.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaVirtualizer.vue
@@ -58,7 +58,6 @@ const virtualizedItems = computed(() => virtualizer.value.getVirtualItems().map(
   return {
     item,
     is: cloneVNode(targetNode, {
-      'key': `${item.key}`,
       'data-index': item.index,
       'style': {
         position: 'absolute',

--- a/packages/core/src/ScrollArea/ScrollAreaVirtualizer.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaVirtualizer.vue
@@ -1,0 +1,92 @@
+<script lang="ts">
+export interface ScrollAreaVirtualizerProps<T = any> {
+  /** List of items */
+  options: T[]
+  /** Number of items rendered outside the visible area */
+  overscan?: number
+  /** Estimated size (in px) of each item */
+  estimateSize?: number | ((index: number) => number)
+  /** Whether to virtualize items horizontally. */
+  horizontal?: boolean
+}
+</script>
+
+<script setup lang="ts" generic="T = any">
+import type { VirtualItem, Virtualizer } from '@tanstack/vue-virtual'
+import type { VNode } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { cloneVNode, computed, Fragment, useSlots } from 'vue'
+import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
+
+const props = defineProps<ScrollAreaVirtualizerProps<T>>()
+
+defineSlots<{
+  default?: (props: {
+    option: T
+    virtualizer: Virtualizer<HTMLElement, Element>
+    virtualItem: VirtualItem
+  }) => any
+}>()
+
+const slots = useSlots()
+const rootContext = injectScrollAreaRootContext()
+
+const virtualizer = useVirtualizer({
+  get count() { return props.options.length },
+  get horizontal() { return props.horizontal ?? false },
+  estimateSize(index) {
+    if (typeof props.estimateSize === 'function')
+      return props.estimateSize(index)
+
+    return props.estimateSize ?? 28
+  },
+  getScrollElement() { return rootContext.viewport.value ?? null },
+  overscan: props.overscan ?? 12,
+})
+
+const virtualizedItems = computed(() => virtualizer.value.getVirtualItems().map((item) => {
+  const defaultNode = slots.default!({
+    option: props.options[item.index],
+    virtualizer: virtualizer.value,
+    virtualItem: item,
+  })[0]
+
+  const targetNode = defaultNode.type === Fragment && Array.isArray(defaultNode.children)
+    ? defaultNode.children.find(child => typeof (child as VNode).type !== 'symbol') as VNode
+    : defaultNode
+
+  return {
+    item,
+    is: cloneVNode(targetNode, {
+      'key': `${item.key}`,
+      'data-index': item.index,
+      'style': {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        transform: props.horizontal
+          ? `translateX(${item.start}px)`
+          : `translateY(${item.start}px)`,
+        overflowAnchor: 'none',
+      },
+    }),
+  }
+}))
+</script>
+
+<template>
+  <div
+    data-reka-virtualizer
+    :style="{
+      position: 'relative',
+      width: horizontal ? `${virtualizer.getTotalSize()}px` : '100%',
+      height: horizontal ? '100%' : `${virtualizer.getTotalSize()}px`,
+    }"
+  >
+    <component
+      :is="is"
+      v-for="{ is, item } in virtualizedItems"
+      :key="item.key"
+    />
+  </div>
+</template>

--- a/packages/core/src/ScrollArea/index.ts
+++ b/packages/core/src/ScrollArea/index.ts
@@ -24,3 +24,7 @@ export {
   default as ScrollAreaViewport,
   type ScrollAreaViewportProps,
 } from './ScrollAreaViewport.vue'
+export {
+  default as ScrollAreaVirtualizer,
+  type ScrollAreaVirtualizerProps,
+} from './ScrollAreaVirtualizer.vue'

--- a/packages/core/src/ScrollArea/story/ScrollAreaBasic.story.vue
+++ b/packages/core/src/ScrollArea/story/ScrollAreaBasic.story.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { reactive } from 'vue'
+import { ScrollAreaRoot, ScrollAreaScrollbar, ScrollAreaThumb, ScrollAreaViewport, ScrollAreaVirtualizer } from '..'
 import ScrollAreaCopy from './_ScrollAreaCopy.vue'
 import ScrollAreaStory from './_ScrollAreaStory.vue'
 
@@ -13,6 +14,8 @@ const contentChangeState = reactive({
   verticalCount: 1,
   horizontalCount: 1,
 })
+
+const virtualItems = Array.from({ length: 10_000 }, (_, index) => `Item ${index + 1}`)
 </script>
 
 <template>
@@ -80,6 +83,31 @@ const contentChangeState = reactive({
           :step="1"
         />
       </template>
+    </Variant>
+
+    <Variant
+      auto-props-disabled
+      title="Virtualized"
+    >
+      <ScrollAreaRoot class="w-[200px] h-[200px] overflow-hidden rounded bg-white shadow-lg">
+        <ScrollAreaViewport class="w-full h-full">
+          <ScrollAreaVirtualizer
+            v-slot="{ option }"
+            :options="virtualItems"
+            :estimate-size="32"
+          >
+            <div class="h-8 px-4 flex items-center border-b border-gray-200">
+              {{ option }}
+            </div>
+          </ScrollAreaVirtualizer>
+        </ScrollAreaViewport>
+        <ScrollAreaScrollbar
+          class="flex select-none touch-none p-0.5 bg-black/10 w-2.5"
+          orientation="vertical"
+        >
+          <ScrollAreaThumb class="flex-1 bg-gray-400 rounded" />
+        </ScrollAreaScrollbar>
+      </ScrollAreaRoot>
     </Variant>
 
     <Variant


### PR DESCRIPTION
Closes #2491

## Description
- Add ScrollAreaVirtualizer powered by @tanstack/vue-virtual
- Export the new ScrollArea part and include it in generated component metadata
- Add vertical and horizontal virtualization regression tests
- Document usage in ScrollArea docs and migration guide

## Verification
- pnpm --filter reka-ui exec vitest run src/ScrollArea/ScrollArea.test.ts
- pnpm --filter reka-ui type-check
- pnpm exec eslint packages/core/src/ScrollArea/ScrollAreaVirtualizer.vue packages/core/src/ScrollArea/ScrollArea.test.ts packages/core/src/ScrollArea/index.ts packages/core/src/ScrollArea/story/ScrollAreaBasic.story.vue packages/core/constant/components.ts docs/content/docs/components/scroll-area.md docs/content/docs/guides/migration.md
- pnpm docs:gen
- pnpm lint (passes with existing warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **ScrollAreaVirtualizer** to enable virtualized scrolling for large lists, rendering only visible items for better performance.
  * Added a new **virtualized** variant to the Scroll Area story with a large dataset example.

* **Documentation**
  * Updated Scroll Area docs to include **ScrollAreaVirtualizer**, added a **Virtualizer** API section, and introduced a **virtualized list** example.
  * Extended the migration guide with a breaking-change section for virtualizing large scrollable lists.

* **Tests**
  * Added tests validating visible-item rendering, total size behavior, and horizontal virtualization styling/positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->