### PR TITLE
fix(Stepper): remove stale trigger element from totalStepperItems on unmount

### DIFF
--- a/packages/core/src/Stepper/Stepper.test.ts
+++ b/packages/core/src/Stepper/Stepper.test.ts
@@ -3,8 +3,10 @@ import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { nextTick } from 'vue'
 import { useTestKbd } from '@/shared'
 import Stepper from './story/_Stepper.vue'
+import StepperDynamic from './story/_StepperDynamic.vue'
 
 const steps = [{
   step: 1,
@@ -167,5 +169,31 @@ describe('stepper', async () => {
     await user.click(thirdItem)
     expect(getByTestId('stepper-item-3')).toHaveAttribute('aria-current', 'true')
     expect(getByTestId('stepper-item-4')).not.toHaveAttribute('data-disabled', '')
+  })
+
+  it('keeps the total step count in sync when triggers unmount and remount', async () => {
+    const { getByTestId, rerender } = render(StepperDynamic, { props: { visibleSteps: 5 } })
+    const totalSteps = getByTestId('total-steps')
+    await nextTick()
+    expect(totalSteps).toHaveTextContent('5')
+
+    // unmount two triggers
+    await rerender({ visibleSteps: 3 })
+    await nextTick()
+    expect(totalSteps).toHaveTextContent('3')
+
+    // remount them: count must not drift upwards
+    await rerender({ visibleSteps: 5 })
+    await nextTick()
+    expect(totalSteps).toHaveTextContent('5')
+
+    // repeated toggling must stay stable (regression: Set leaked stale elements)
+    await rerender({ visibleSteps: 1 })
+    await nextTick()
+    expect(totalSteps).toHaveTextContent('1')
+
+    await rerender({ visibleSteps: 5 })
+    await nextTick()
+    expect(totalSteps).toHaveTextContent('5')
   })
 })

--- a/packages/core/src/Stepper/StepperTrigger.vue
+++ b/packages/core/src/Stepper/StepperTrigger.vue
@@ -66,12 +66,19 @@ function handleKeyDown(event: KeyboardEvent) {
 
 const { forwardRef, currentElement } = useForwardExpose()
 
+let registeredElement: HTMLElement | null = null
+
 onMounted(() => {
-  rootContext.totalStepperItems.value.add(currentElement.value)
+  registeredElement = currentElement.value
+  if (registeredElement)
+    rootContext.totalStepperItems.value.add(registeredElement)
 })
 
 onUnmounted(() => {
-  rootContext.totalStepperItems.value.delete(currentElement.value)
+  if (registeredElement) {
+    rootContext.totalStepperItems.value.delete(registeredElement)
+    registeredElement = null
+  }
 })
 </script>
 

--- a/packages/core/src/Stepper/story/_StepperDynamic.vue
+++ b/packages/core/src/Stepper/story/_StepperDynamic.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { StepperItem, StepperRoot, StepperTitle, StepperTrigger } from '..'
+
+const props = withDefaults(defineProps<{ visibleSteps?: number }>(), {
+  visibleSteps: 5,
+})
+
+const allSteps = [1, 2, 3, 4, 5]
+const steps = computed(() => allSteps.slice(0, props.visibleSteps))
+</script>
+
+<template>
+  <StepperRoot
+    v-slot="{ totalSteps }"
+    data-testid="stepper"
+    :default-value="1"
+  >
+    <span data-testid="total-steps">{{ totalSteps }}</span>
+
+    <StepperItem
+      v-for="item in steps"
+      :key="item"
+      :step="item"
+      :data-testid="`stepper-item-${item}`"
+    >
+      <StepperTrigger :data-testid="`stepper-item-trigger-${item}`">
+        <StepperTitle>Step {{ item }}</StepperTitle>
+      </StepperTrigger>
+    </StepperItem>
+  </StepperRoot>
+</template>


### PR DESCRIPTION
### Summary

`StepperTrigger` deleted `currentElement.value` on unmount, but that ref can be `null`/stale by teardown, so the element added on mount was never removed and the `Set` kept growing across mount/unmount cycles — inflating `totalSteps`.

This captures the exact element added on mount and deletes that same reference on unmount, also skipping nullish values so `null` is never inserted into the `Set<HTMLElement>`.

### Changes

- `StepperTrigger.vue`: track the registered element in a local variable; add/delete that exact reference.
- Added a regression test that mounts/unmounts triggers (5 → 3 → 5 → 1 → 5) and asserts `totalSteps` stays in sync.
- Added a `_StepperDynamic.vue` fixture that varies the rendered triggers at runtime.

Fixes #2777


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Stepper step counts so the displayed total stays accurate when steps are shown, hidden, or remounted repeatedly.
  * Improved Stepper trigger registration to prevent the total from drifting upward after toggling.
* **Tests**
  * Added regression coverage for dynamic Stepper rendering and repeated visibility changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->