### PR TITLE
fix(focus-scope): trap focus inside a shadow root

### DIFF
--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -1,7 +1,7 @@
 import type { RenderResult } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import { FocusScope } from '.'
 import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot, ComboboxTrigger, ComboboxViewport } from '../Combobox'
@@ -149,6 +149,64 @@ describe('focusScope', () => {
   })
 
   // https://github.com/unovue/reka-ui/issues/2550
+  // https://github.com/unovue/reka-ui/issues/1667
+  // A trapped FocusScope teleported into a shadow root must keep focus inside
+  // even when focus escapes to a light-DOM element outside the shadow tree.
+  // Listening only on `document` misses intra-shadow moves (retargeted to the
+  // host); listening only on the shadow root misses the light-DOM escape (which
+  // never propagates into the root). We assert the behaviour, not the wiring.
+  describe('given a trapped FocusScope rendered inside a shadow root (#1667)', () => {
+    const ShadowScope = defineComponent({
+      components: { FocusScope },
+      template: `<FocusScope asChild loop trapped>
+        <form>
+          <input data-testid="inner-first" />
+          <input data-testid="inner-second" />
+        </form>
+      </FocusScope>`,
+    })
+
+    // document.activeElement stops at the shadow host; drill down to the real one.
+    function deepActiveElement(): Element | null {
+      let active = document.activeElement
+      while (active?.shadowRoot?.activeElement)
+        active = active.shadowRoot.activeElement
+      return active
+    }
+
+    it('recalls focus into the scope when it escapes to a light-DOM element', async () => {
+      const host = document.createElement('div')
+      const outsideButton = document.createElement('button')
+      outsideButton.textContent = 'outside'
+      document.body.append(host, outsideButton)
+
+      try {
+        const shadowRoot = host.attachShadow({ mode: 'open' })
+        const container = document.createElement('div')
+        shadowRoot.appendChild(container)
+
+        render(ShadowScope, { container })
+        await nextTick()
+
+        const innerFirst = shadowRoot.querySelector<HTMLInputElement>('[data-testid="inner-first"]')!
+        innerFirst.focus()
+        await nextTick()
+        expect(container.contains(deepActiveElement())).toBe(true)
+
+        // Focus escapes to a light-DOM button outside the shadow tree.
+        outsideButton.focus()
+        await nextTick()
+
+        // The trap must pull focus back inside the scope.
+        expect(container.contains(deepActiveElement())).toBe(true)
+      }
+      finally {
+        host.remove()
+        outsideButton.remove()
+      }
+    })
+  })
+
   describe('given a FocusScope with SelectTrigger inside Dialog (#2550)', () => {
     const DialogWithSelect = defineComponent({
       components: { DialogRoot, DialogTrigger, DialogContent, DialogTitle, SelectRoot, SelectTrigger, SelectValue, SelectContent, SelectItem },
@@ -291,69 +349,6 @@ describe('focusScope', () => {
       // The Select content traps focus; its FocusScope must pause the Dialog's
       // trap so focus lands inside the Select rather than being yanked back.
       expect(content.contains(document.activeElement)).toBe(true)
-    })
-  })
-
-  // https://github.com/unovue/reka-ui/issues/1667
-  // A trapped FocusScope teleported into a shadow root must keep focus inside
-  // even when focus escapes to a light-DOM element outside the shadow tree.
-  // Listening only on `document` misses intra-shadow moves (retargeted to the
-  // host); listening only on the shadow root misses the light-DOM escape (which
-  // never propagates into the root). We assert the behaviour, not the wiring.
-  describe('given a trapped FocusScope rendered inside a shadow root (#1667)', () => {
-    const ShadowScope = defineComponent({
-      components: { FocusScope },
-      template: `<FocusScope asChild loop trapped>
-        <form>
-          <input data-testid="inner-first" />
-          <input data-testid="inner-second" />
-        </form>
-      </FocusScope>`,
-    })
-
-    // document.activeElement stops at the shadow host; drill down to the real one.
-    function deepActiveElement(): Element | null {
-      let active = document.activeElement
-      while (active?.shadowRoot?.activeElement)
-        active = active.shadowRoot.activeElement
-      return active
-    }
-
-    let host: HTMLElement
-    let outsideButton: HTMLButtonElement
-
-    beforeEach(() => {
-      host = document.createElement('div')
-      document.body.appendChild(host)
-      outsideButton = document.createElement('button')
-      outsideButton.textContent = 'outside'
-      document.body.appendChild(outsideButton)
-    })
-
-    afterEach(() => {
-      host.remove()
-      outsideButton.remove()
-    })
-
-    it('recalls focus into the scope when it escapes to a light-DOM element', async () => {
-      const shadowRoot = host.attachShadow({ mode: 'open' })
-      const container = document.createElement('div')
-      shadowRoot.appendChild(container)
-
-      render(ShadowScope, { container })
-      await nextTick()
-
-      const innerFirst = shadowRoot.querySelector<HTMLInputElement>('[data-testid="inner-first"]')!
-      innerFirst.focus()
-      await nextTick()
-      expect(container.contains(deepActiveElement())).toBe(true)
-
-      // Focus escapes to a light-DOM button outside the shadow tree.
-      outsideButton.focus()
-      await nextTick()
-
-      // The trap must pull focus back inside the scope.
-      expect(container.contains(deepActiveElement())).toBe(true)
     })
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -293,4 +293,39 @@ describe('focusScope', () => {
       expect(content.contains(document.activeElement)).toBe(true)
     })
   })
+
+  // https://github.com/unovue/reka-ui/issues/1667
+  // A trapped FocusScope teleported into a shadow root must observe focus on its
+  // own root node. Listening on `document` sees focus events retargeted to the
+  // shadow host, so `container.contains(target)` never matches and focus is not
+  // trapped — Tab escapes to the background. jsdom does not retarget focus
+  // events, so the escape can't be reproduced behaviourally here; instead we
+  // assert the listeners are bound to the shadow root rather than `document`.
+  describe('given a trapped FocusScope rendered inside a shadow root (#1667)', () => {
+    const ShadowScope = defineComponent({
+      components: { FocusScope },
+      template: `<FocusScope asChild loop trapped>
+        <form>
+          <input data-testid="inner-first" />
+          <input data-testid="inner-second" />
+        </form>
+      </FocusScope>`,
+    })
+
+    it('should bind focus listeners to the shadow root rather than document', async () => {
+      const host = document.createElement('div')
+      document.body.appendChild(host)
+      const shadowRoot = host.attachShadow({ mode: 'open' })
+      const container = document.createElement('div')
+      shadowRoot.appendChild(container)
+
+      const rootAddSpy = vi.spyOn(shadowRoot, 'addEventListener')
+
+      render(ShadowScope, { container })
+      await nextTick()
+
+      expect(rootAddSpy).toHaveBeenCalledWith('focusin', expect.any(Function))
+      expect(rootAddSpy).toHaveBeenCalledWith('focusout', expect.any(Function))
+    })
+  })
 })

--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -1,7 +1,7 @@
 import type { RenderResult } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import { FocusScope } from '.'
 import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot, ComboboxTrigger, ComboboxViewport } from '../Combobox'
@@ -295,12 +295,11 @@ describe('focusScope', () => {
   })
 
   // https://github.com/unovue/reka-ui/issues/1667
-  // A trapped FocusScope teleported into a shadow root must observe focus on its
-  // own root node. Listening on `document` sees focus events retargeted to the
-  // shadow host, so `container.contains(target)` never matches and focus is not
-  // trapped — Tab escapes to the background. jsdom does not retarget focus
-  // events, so the escape can't be reproduced behaviourally here; instead we
-  // assert the listeners are bound to the shadow root rather than `document`.
+  // A trapped FocusScope teleported into a shadow root must keep focus inside
+  // even when focus escapes to a light-DOM element outside the shadow tree.
+  // Listening only on `document` misses intra-shadow moves (retargeted to the
+  // host); listening only on the shadow root misses the light-DOM escape (which
+  // never propagates into the root). We assert the behaviour, not the wiring.
   describe('given a trapped FocusScope rendered inside a shadow root (#1667)', () => {
     const ShadowScope = defineComponent({
       components: { FocusScope },
@@ -312,20 +311,49 @@ describe('focusScope', () => {
       </FocusScope>`,
     })
 
-    it('should bind focus listeners to the shadow root rather than document', async () => {
-      const host = document.createElement('div')
+    // document.activeElement stops at the shadow host; drill down to the real one.
+    function deepActiveElement(): Element | null {
+      let active = document.activeElement
+      while (active?.shadowRoot?.activeElement)
+        active = active.shadowRoot.activeElement
+      return active
+    }
+
+    let host: HTMLElement
+    let outsideButton: HTMLButtonElement
+
+    beforeEach(() => {
+      host = document.createElement('div')
       document.body.appendChild(host)
+      outsideButton = document.createElement('button')
+      outsideButton.textContent = 'outside'
+      document.body.appendChild(outsideButton)
+    })
+
+    afterEach(() => {
+      host.remove()
+      outsideButton.remove()
+    })
+
+    it('recalls focus into the scope when it escapes to a light-DOM element', async () => {
       const shadowRoot = host.attachShadow({ mode: 'open' })
       const container = document.createElement('div')
       shadowRoot.appendChild(container)
 
-      const rootAddSpy = vi.spyOn(shadowRoot, 'addEventListener')
-
       render(ShadowScope, { container })
       await nextTick()
 
-      expect(rootAddSpy).toHaveBeenCalledWith('focusin', expect.any(Function))
-      expect(rootAddSpy).toHaveBeenCalledWith('focusout', expect.any(Function))
+      const innerFirst = shadowRoot.querySelector<HTMLInputElement>('[data-testid="inner-first"]')!
+      innerFirst.focus()
+      await nextTick()
+      expect(container.contains(deepActiveElement())).toBe(true)
+
+      // Focus escapes to a light-DOM button outside the shadow tree.
+      outsideButton.focus()
+      await nextTick()
+
+      // The trap must pull focus back inside the scope.
+      expect(container.contains(deepActiveElement())).toBe(true)
     })
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -92,6 +92,13 @@ watchEffect((cleanupFn) => {
   if (!props.trapped)
     return
 
+  // Attach focus listeners to the scope's root node (a shadow root when
+  // teleported into one, otherwise the document). On `document`, focus events
+  // originating inside a shadow root are retargeted to the host, so
+  // `container.contains(target)` never matches and focus escapes the trap.
+  // -- related: https://github.com/unovue/reka-ui/issues/1667
+  const ownerRoot = (container?.getRootNode() as Document | ShadowRoot | null) ?? document
+
   function handleFocusIn(event: FocusEvent) {
     if (focusScope.paused || !container)
       return
@@ -153,15 +160,15 @@ watchEffect((cleanupFn) => {
       focus(container)
   }
 
-  document.addEventListener('focusin', handleFocusIn)
-  document.addEventListener('focusout', handleFocusOut)
+  ownerRoot.addEventListener('focusin', handleFocusIn as EventListener)
+  ownerRoot.addEventListener('focusout', handleFocusOut as EventListener)
   const mutationObserver = new MutationObserver(handleMutations)
   if (container)
     mutationObserver.observe(container, { childList: true, subtree: true })
 
   cleanupFn(() => {
-    document.removeEventListener('focusin', handleFocusIn)
-    document.removeEventListener('focusout', handleFocusOut)
+    ownerRoot.removeEventListener('focusin', handleFocusIn as EventListener)
+    ownerRoot.removeEventListener('focusout', handleFocusOut as EventListener)
     mutationObserver.disconnect()
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -51,6 +51,7 @@ import { createFocusScopesStack } from './stack'
 import {
   AUTOFOCUS_ON_MOUNT,
   AUTOFOCUS_ON_UNMOUNT,
+  containsComposed,
   EVENT_OPTIONS,
   focus,
   focusFirst,
@@ -97,7 +98,8 @@ watchEffect((cleanupFn) => {
   // originating inside a shadow root are retargeted to the host, so
   // `container.contains(target)` never matches and focus escapes the trap.
   // -- related: https://github.com/unovue/reka-ui/issues/1667
-  const ownerRoot = (container?.getRootNode() as Document | ShadowRoot | null) ?? document
+  const ownerDocument = container?.ownerDocument ?? document
+  const root = container ? (container.getRootNode() as Document | ShadowRoot) : ownerDocument
 
   function handleFocusIn(event: FocusEvent) {
     if (focusScope.paused || !container)
@@ -160,15 +162,32 @@ watchEffect((cleanupFn) => {
       focus(container)
   }
 
-  ownerRoot.addEventListener('focusin', handleFocusIn as EventListener)
-  ownerRoot.addEventListener('focusout', handleFocusOut as EventListener)
+  // A shadow root never sees a light-DOM `focusin`: when focus escapes to an
+  // element outside the shadow tree, the event fires on the owner document, not
+  // the root. So when the scope lives in a shadow root we also listen on the
+  // document and use a composed (deep) containment check, since `event.target`
+  // is retargeted to the shadow host at the document level.
+  function handleDocumentFocusIn(event: FocusEvent) {
+    if (focusScope.paused || !container)
+      return
+    const target = event.composedPath()[0] as HTMLElement | null
+    if (!containsComposed(container, target))
+      focus(lastFocusedElementRef.value, { select: true })
+  }
+
+  root.addEventListener('focusin', handleFocusIn as EventListener)
+  root.addEventListener('focusout', handleFocusOut as EventListener)
+  if (root !== ownerDocument)
+    ownerDocument.addEventListener('focusin', handleDocumentFocusIn as EventListener)
   const mutationObserver = new MutationObserver(handleMutations)
   if (container)
     mutationObserver.observe(container, { childList: true, subtree: true })
 
   cleanupFn(() => {
-    ownerRoot.removeEventListener('focusin', handleFocusIn as EventListener)
-    ownerRoot.removeEventListener('focusout', handleFocusOut as EventListener)
+    root.removeEventListener('focusin', handleFocusIn as EventListener)
+    root.removeEventListener('focusout', handleFocusOut as EventListener)
+    if (root !== ownerDocument)
+      ownerDocument.removeEventListener('focusin', handleDocumentFocusIn as EventListener)
     mutationObserver.disconnect()
   })
 })

--- a/packages/core/src/FocusScope/utils.ts
+++ b/packages/core/src/FocusScope/utils.ts
@@ -6,6 +6,17 @@ export const EVENT_OPTIONS = { bubbles: false, cancelable: true }
 
 type FocusableTarget = HTMLElement | { focus: () => void }
 
+/** Like `Node.contains`, but crosses shadow boundaries by walking up through host elements. */
+export function containsComposed(container: Node, node: Node | null): boolean {
+  let current: Node | null = node
+  while (current) {
+    if (container.contains(current))
+      return true
+    current = (current.getRootNode() as ShadowRoot).host ?? null
+  }
+  return false
+}
+
 /**
  * Attempts focusing the first element in a list of candidates.
  * Stops when focus has actually moved.


### PR DESCRIPTION
FocusScope attaches its focusin/focusout listeners to `document`. When the scope is teleported into a shadow root, those events are retargeted to the host, so `container.contains(target)` never matches and focus is not trapped — Tab escapes to the background.

Resolve the scope's root node via `getRootNode()` (the shadow root when teleported, otherwise the document) and attach the listeners there.

Related: #1667

<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus trapping and focus redirection when a focus scope is rendered inside a shadow root.
  * Focus listeners now attach to the appropriate document or shadow root, with matching cleanup.
  * Improved focus detection across shadow DOM boundaries.

* **Tests**
  * Added coverage for focus scopes inside open shadow roots, including focus restoration after focus moves to light DOM elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->