### PR TITLE
fix(TagsInput): keep disabled tags out of keyboard removal index

### DIFF
--- a/packages/core/src/TagsInput/TagsInput.test.ts
+++ b/packages/core/src/TagsInput/TagsInput.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
 import TagsInput from './story/_TagsInput.vue'
+import TagsInputDisabled from './story/_TagsInputDisabled.vue'
 import TagsInputObject from './story/_TagsInputObject.vue'
 
 describe('given default TagsInput', () => {
@@ -349,5 +350,41 @@ describe('given a TagsInput with objects', async () => {
       expect(tags.length).toBe(2)
       expect(tags[1].text()).toBe('hello')
     })
+  })
+})
+
+describe('given TagsInput with a disabled item before a removable one', () => {
+  // @ts-expect-error we return empty object
+  window.getComputedStyle = () => ({})
+  let wrapper: VueWrapper<InstanceType<typeof TagsInputDisabled>>
+  let input: DOMWrapper<HTMLInputElement>
+  let rootComponent: Omit<VueWrapper, 'exists'>
+
+  beforeEach(() => {
+    wrapper = mount(TagsInputDisabled, { attachTo: document.body })
+    rootComponent = wrapper.getComponent({ name: 'TagsInputRoot' })
+    input = wrapper.find('input')
+    input.element.focus()
+  })
+
+  it('removes the selected removable tag, not the disabled one', async () => {
+    // First Backspace selects the last removable tag, second removes it.
+    await input.trigger('keydown', { key: 'Backspace' })
+    await input.trigger('keydown', { key: 'Backspace' })
+
+    const tags = wrapper.findAll('[data-reka-collection-item]')
+    expect(tags.map(tag => tag.text())).toEqual(['Disabled'])
+    expect(rootComponent.emitted('removeTag')?.[0]?.[0]).toEqual('Removable')
+  })
+
+  it('does not remove the disabled tag when it is the only remaining tag', async () => {
+    await input.trigger('keydown', { key: 'Backspace' })
+    await input.trigger('keydown', { key: 'Backspace' })
+    // Only the disabled tag remains; further backspaces must not remove it.
+    await input.trigger('keydown', { key: 'Backspace' })
+    await input.trigger('keydown', { key: 'Backspace' })
+
+    const tags = wrapper.findAll('[data-reka-collection-item]')
+    expect(tags.map(tag => tag.text())).toEqual(['Disabled'])
   })
 })

--- a/packages/core/src/TagsInput/TagsInputRoot.vue
+++ b/packages/core/src/TagsInput/TagsInputRoot.vue
@@ -70,6 +70,7 @@ export const [injectTagsInputRootContext, provideTagsInputRootContext]
 
 <script setup lang="ts" generic="T extends AcceptableInputValue = string">
 import { useFocusWithin, useVModel } from '@vueuse/core'
+import { isEqual } from 'ohash'
 import { useCollection } from '@/Collection'
 import { Primitive } from '@/Primitive'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
@@ -111,9 +112,9 @@ const currentModelValue = computed(() => Array.isArray(modelValue.value) ? [...m
 
 function handleRemoveTag(index: number) {
   if (index !== -1) {
-    const collection = getItems().filter(i => i.ref.dataset.disabled !== '')
+    const removedValue = modelValue.value[index] as T
     modelValue.value = modelValue.value.filter((_, i) => i !== index)
-    emits('removeTag', collection[index].value)
+    emits('removeTag', removedValue)
   }
 }
 
@@ -172,7 +173,9 @@ provideTagsInputRootContext({
 
         if (selectedElement.value) {
           const index = collection.findIndex(i => i === selectedElement.value)
-          handleRemoveTag(index)
+          const selectedItem = getItems().find(i => i.ref === selectedElement.value)
+          const modelIndex = selectedItem ? modelValue.value.findIndex(v => isEqual(v, selectedItem.value)) : -1
+          handleRemoveTag(modelIndex)
           selectedElement.value = selectedElement.value === lastTag ? collection.at(index - 1) : collection.at(index + 1)
           event.preventDefault()
         }

--- a/packages/core/src/TagsInput/story/_TagsInputDisabled.vue
+++ b/packages/core/src/TagsInput/story/_TagsInputDisabled.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { ref } from 'vue'
+import { TagsInputInput, TagsInputItem, TagsInputItemDelete, TagsInputItemText, TagsInputRoot } from '..'
+
+const modelValue = ref(['Disabled', 'Removable'])
+const isDisabled = (value: string) => value === 'Disabled'
+</script>
+
+<template>
+  <TagsInputRoot
+    v-model="modelValue"
+    class="flex gap-2 items-center border p-2 rounded-lg bg-blackA7 w-[300px] flex-wrap border-blackA7"
+  >
+    <TagsInputItem
+      v-for="item in modelValue"
+      :key="item"
+      :value="item"
+      :disabled="isDisabled(item)"
+      class="flex items-center justify-center gap-2 bg-green8 aria-[selected=true]:bg-green9 rounded px-2 py-1"
+    >
+      <TagsInputItemText class="text-sm">
+        {{ item }}
+      </TagsInputItemText>
+      <TagsInputItemDelete v-if="!isDisabled(item)">
+        <Icon icon="lucide:x" />
+      </TagsInputItemDelete>
+    </TagsInputItem>
+
+    <TagsInputInput
+      placeholder="Anything..."
+      class="focus:outline-none flex-1 rounded bg-transparent text-white placeholder:text-mauve10 px-1"
+    />
+  </TagsInputRoot>
+</template>


### PR DESCRIPTION
Closes #2785

## Description

`TagsInput` removed the **wrong** tag on keyboard delete when a `disabled` `TagsInputItem` was present.

The keyboard handler computes the selected tag's index against a **disabled-filtered** collection:

```ts
const collection = getItems().map(i => i.ref).filter(i => i.dataset.disabled !== '') // removable-only
const index = collection.findIndex(i => i === selectedElement.value)
handleRemoveTag(index)
```

…but `handleRemoveTag` applied that index to the **full** model:

```ts
modelValue.value = modelValue.value.filter((_, i) => i !== index)
```

Since `getItems()` already excludes disabled items, the filtered index doesn't match the model index whenever a disabled item exists. Symptoms:

- A disabled tag placed **before** removable ones gets deleted instead of the selected tag.
- With only disabled tags left, Backspace could still remove one.

`TagsInputItemDelete` was unaffected because it already resolves the model index by value (`modelValue.findIndex(isEqual(...))`).

## Fix

- Resolve the keyboard-selected tag to its index in `modelValue` **by value** (via `ohash`'s `isEqual`, mirroring `TagsInputItemDelete`) before removing.
- Make `handleRemoveTag` emit the value that was actually removed (`modelValue[index]`) instead of indexing the disabled-filtered collection — this also fixes an incorrect `removeTag` payload from the delete button when disabled items are present.

Navigation still uses the disabled-filtered collection, so disabled items remain unreachable/unselectable.

## Repro (before this PR)

```vue
<script setup lang="ts">
import { ref } from 'vue'
import { TagsInputRoot, TagsInputItem, TagsInputItemText, TagsInputItemDelete, TagsInputInput } from 'reka-ui'
const modelValue = ref(['admin@acme.com', 'user@gmail.com'])
const isDisabled = (v: string) => v === 'admin@acme.com'
</script>

<template>
  <TagsInputRoot v-model="modelValue">
    <TagsInputItem v-for="item in modelValue" :key="item" :value="item" :disabled="isDisabled(item)">
      <TagsInputItemText />
      <TagsInputItemDelete v-if="!isDisabled(item)" />
    </TagsInputItem>
    <TagsInputInput placeholder="Add..." />
  </TagsInputRoot>
</template>
```

Focus the input → Backspace (selects `user@gmail.com`) → Backspace again.
- Before: `admin@acme.com` (disabled) is removed.
- After: `user@gmail.com` is removed. ✅

## Tests

Added a colocated test fixture (`story/_TagsInputDisabled.vue`) and cases in `TagsInput.test.ts`:
- keyboard delete removes the selected removable tag (not the disabled one),
- the disabled tag is never removed when it's the only tag left.

All `TagsInput` tests pass; `type-check` and lint are green.

