### PR TITLE
perf(DismissableLayer): centralized layer stack manager (#2724, Tasks 1-7)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-2724-overlay-render-perf.md
+++ b/docs/superpowers/plans/2026-07-11-2724-overlay-render-perf.md
@@ -2,215 +2,237 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-> Tracks GitHub issue **#2724** (Phase 2 — Built on the foundation), part of the reka-ui v3 roadmap **#2721**. The stack-manager work is independent of #2722 (`useRender`); only the final wrapper-removal step (Task 8) depends on it.
+> Tracks GitHub issue **#2724** (Phase 2), part of the reka-ui v3 roadmap **#2721**. Tasks 1–7 are independent of #2722; the wrapper-removal (Task 8) depends on `useRender`. **This plan lands before #2725 (Shadow DOM) and builds the shadow-safe composed-target reads into `layerStack.ts` from day one** (so #2725 does not re-patch `DismissableLayer/utils.ts`).
 
-**Goal:** Replace `DismissableLayer`'s per-layer global listeners (3+ `document`/`window` listeners **per open layer**) and per-read O(n) `Array.from(...).indexOf()` scans with a **single centralized stack manager** exposing exactly one shared set of `document` listeners regardless of layer count, plus benchmarks that quantify the wins. Then remove the wrapper render instance via `useRender`.
+**Goal:** Replace `DismissableLayer`'s per-layer global listeners (3 `document`/`window` listeners **per open layer**) and per-read O(n) `Array.from(...).indexOf()` scans with a **single centralized stack manager** exposing exactly one shared listener of each kind regardless of layer count, one `querySelectorAll` snapshot per event, plus benchmarks that quantify the wins. Then remove the wrapper render instance via `useRender`.
 
-**Architecture:** A new plain-module singleton `layerStack.ts` holds an ordered array of layer handles, the branch set, and the "outside-pointer-events-disabled" set; it installs exactly one `pointerdown` + one `focusin` + one `keydown` `document` listener on first registration and tears them down when the last layer unregisters. Each listener does **one** `querySelectorAll` snapshot per event and dispatches to the relevant handle(s), preserving today's exact dismissal semantics (top-only Escape; all-qualifying-layers pointer/focus outside; `disableOutsidePointerEvents` body lock; branches; touch-click deferral; `setTimeout(0)` arming). `usePointerDownOutside`/`useFocusOutside` keep their exact signatures but become thin subscriptions to the manager.
+**Architecture:** A plain-module singleton `layerStack.ts` acting as **transport only** — it owns the shared listeners, the per-event `querySelectorAll` snapshot, subscriber iteration, arming, and the touch-click deferral map. It does **not** re-implement dismissal logic: each `DismissableLayer/utils.ts` composable ports its current `handlePointerDown`/`handleFocus` body **verbatim** into a subscriber closure that the manager invokes with the hoisted snapshot; the component-level branch/present checks stay in the component callbacks. Two **separate** registries model the two populations with different lifetimes: an ordered presence-driven **stack** (Escape routing, indexing, pointer-events accounting) and a setup/enabled-driven **outside-subscriber** list (pointer/focus dispatch). Target reads go through `event.composedPath()[0] ?? event.target` so overlays work inside shadow roots, and the captured target is threaded into `handleAndDispatchCustomEvent`.
 
-**Tech Stack:** Vue 3 (`shallowReactive`, `watch`, `watchEffect`), TypeScript, vitest 4 (`bench`/tinybench built in), jsdom, `@vue/test-utils`.
+**Tech Stack:** Vue 3 (`shallowReactive`, `watch`, `watchEffect`), TypeScript, vitest 4 (`bench`/tinybench), jsdom, `@vue/test-utils`.
 
 ## Global Constraints
 
 - Node ≥ 22, pnpm 10. All commands from repo root.
 - Test (one-shot): `pnpm --filter reka-ui exec vitest run <path>` — never `pnpm test` (watch).
 - Type-check: `pnpm --filter reka-ui type-check`. Build: `pnpm --filter reka-ui build`. Lint fix: `pnpm lint:fix`.
-- **Behavior is frozen.** Every existing test in `packages/core/src/DismissableLayer/DismissableLayer.test.ts` (incl. the #2674 `disableOutsidePointerEvents` suite and the `present:false` tests) and every consumer suite must pass **unchanged**. `usePointerDownOutside`/`useFocusOutside` **signatures** `(handler?, element?, enabled?)` must not change — `Editable/EditableRoot.vue` calls them directly.
-- Consumers to regression-test (blast radius): Dialog, Drawer, Menu (→ DropdownMenu/ContextMenu/Menubar), Popover, Tooltip, HoverCard, Combobox, Select, NavigationMenu, Toast (Branch), Editable.
-- Preserve the #2674 body-pointer-events ordering comments (`DismissableLayer.vue:159-164,176-183`) — they encode hard-won semantics; port them verbatim.
-- Module singleton must be SSR-safe (no `document` at import; install lazily, `isClient`-gated) and test-isolated (export `resetLayerStack()` for `beforeEach`).
-- Conventional Commits, scope `DismissableLayer`: `perf(DismissableLayer): …`. commitlint enforces.
+- **Behavior is frozen.** Every existing `DismissableLayer.test.ts` case (incl. the #2674 `disableOutsidePointerEvents` suite, the `present:false` tests, and the **`isLayerExist` unit tests at `:9,15-21` — the export must stay**) and every consumer suite must pass **unchanged**. `usePointerDownOutside`/`useFocusOutside` **signatures** `(handler?, element?, enabled?)` must not change (`Editable/EditableRoot.vue:183-184` calls them).
+- **Manager = transport, not logic.** Move only listener ownership, the snapshot, arming, and the touch map into `layerStack.ts`. Port `utils.ts:61-112` (`handlePointerDown`) and `utils.ts:162-180` (`handleFocus`) **branch-for-branch** into subscriber closures — do NOT paraphrase the branch order or the flag-clear points. Keep the component-level branch/present filtering in the `DismissableLayer.vue` callbacks.
+- **Dispatch is synchronous.** Non-touch pointer dispatch runs **inside the bubble**, exactly as `utils.ts:103` does today. Do NOT introduce a `nextTick` before dispatch (the `nextTick`s in the repo are the component's `DismissableLayer.vue:126` after emit, and the focus path's double `nextTick` at `utils.ts:166-167` — both stay, neither is a pre-dispatch defer).
+- **Shadow-safe targets.** Read the event target via `event.composedPath?.()[0] ?? event.target` and **capture it synchronously** before any `await`. Thread it into `handleAndDispatchCustomEvent(name, handler, detail, target?)` (additive param). This makes #2725's `utils.ts` retargeting patches unnecessary.
+- Preserve the #2674 body-pointer-events ordering comments (`DismissableLayer.vue:159-164,176-183`) verbatim.
+- Module singleton SSR-safe (no `document` at import; install lazily, `isClient`-gated) and test-isolated: `resetLayerStack()` clears **all** state (both registries, disabled list, branches, touch map + its click listener, arming timers, `originalBodyPointerEvents`, and restores `document.body.style.pointerEvents`).
+- Conventional Commits, scope `DismissableLayer`. commitlint enforces.
 
 ---
 
 ## File Structure
 
 Current relevant files (verified against `v2`, HEAD `47c433a84`):
-- `packages/core/src/DismissableLayer/DismissableLayer.vue` — module-scoped `context = reactive({ layersRoot, layersWithOutsidePointerEventsDisabled, originalBodyPointerEvents, branches })` (L57-62); `index` computed via `Array.from(layers).indexOf()` (L99-103); `isPointerEventsEnabled` (L109-115, two more O(n) conversions); body-pointer-events lock `watch` (L165-196); stack membership `watch` on `[layerElement, present]` (L203-214) + safety-net cleanup (L216-223); Escape via `onKeyStroke('Escape', …)` (L144-157, one `window` listener per layer); renders `Primitive` (L226-245).
-- `packages/core/src/DismissableLayer/utils.ts` — `usePointerDownOutside` (attaches `document` `pointerdown` deferred via `setTimeout(0)` at L126-128, plus a re-armed `click` `{once}` for touch at L98-100) and `useFocusOutside` (attaches `document` `focusin` at L182); `isLayerExist` (L16-40, `querySelectorAll('[data-dismissable-layer]')` per handler call); dead `CONTEXT_UPDATE`/`dispatchUpdate` (L12,203-206).
-- `packages/core/src/DismissableLayer/DismissableLayerBranch.vue` — imports `context` from `DismissableLayer.vue` (L11), does `context.branches.add/delete` (L16-21).
-- `packages/core/src/DismissableLayer/index.ts` — family exports (internal; root barrel only re-exports the two event *types*).
-- `packages/core/src/shared/handleAndDispatchCustomEvent.ts` — dispatches the cancelable `dismissableLayer.pointerDownOutside`/`.focusOutside` CustomEvent on the target.
-- `packages/core/vite.config.ts` (test block L14-34, jsdom), `packages/core/package.json` (scripts L76-86; vitest 4.1.8).
+- `DismissableLayer/DismissableLayer.vue` — `context = reactive({ layersRoot, layersWithOutsidePointerEventsDisabled, originalBodyPointerEvents, branches })` (L57-62); `index` via `Array.from(...).indexOf()` (L99-103); `isPointerEventsEnabled` (L109-115); body-lock `watch` (L165-196, #2674 comments 159-164/176-183); membership `watch` (L203-214); unmount safety-net `watchEffect` (L216-223, runs cleanup on **unmount only** — no reactive deps); Escape via `onKeyStroke('Escape', …)` on **window** (L144-157); branch/present checks in the outside callbacks (L117-142); renders `Primitive` (L226-245).
+- `DismissableLayer/utils.ts` — `usePointerDownOutside`: `handlePointerDown` body L61-112 (isLayerExist first → dispatch-vs-cancel fork on `isPointerInside` → flag cleared every path L111; touch `click {once}` re-arm L95-100, cancel L106-110), listener attached deferred via `setTimeout(0)` L126-128; per-instance `handleClickRef` L56; `useFocusOutside`: `handleFocus` body L162-180 (double `nextTick` 166-167; `event.target` reads at :62,:72,:168,:172; focus flag cleared only by `onBlurCapture` L194-199, NOT in `handleFocus`); `isLayerExist` L16-40 (exported + unit-tested); `ownerDocument` captured at setup L52-53 (element still undefined → effectively `globalThis.document`); dead `CONTEXT_UPDATE`/`dispatchUpdate` L12,203-206.
+- `DismissableLayerBranch.vue` — imports `context` (L11), `context.branches.add/delete` (L16-21).
+- `Editable/EditableRoot.vue` — **has `data-dismissable-layer` (L227)**; calls `usePointerDownOutside`/`useFocusOutside` with the `enabled: isEditing` arg (L183-184); **never** uses Escape/keydown; the `querySelector` fallback in `isLayerExist` (`utils.ts:26-28`) is for a ref pointing above the attributed element, not for Editable.
+- `shared/handleAndDispatchCustomEvent.ts` — L11 reads `detail.originalEvent.target` at dispatch time (the stale/null-in-browsers read #2725 flagged; fixed here via the threaded target).
+- `packages/core/vite.config.ts` (test block L14-34, jsdom, default `isolate: true` → fresh module registry **per test file**, singleton persists within a file), `packages/core/package.json` (vitest 4.1.8).
 
 Files this plan creates/modifies:
-- **Create** `packages/core/src/DismissableLayer/layerStack.ts` — the manager + `resetLayerStack()`.
-- **Create** `packages/core/src/DismissableLayer/layerStack.test.ts` — manager unit tests.
-- **Modify** `packages/core/src/DismissableLayer/utils.ts` — reimplement the two composables as manager subscriptions; fold `isLayerExist` into a hoisted snapshot; delete dead `CONTEXT_UPDATE`/`dispatchUpdate`.
-- **Modify** `packages/core/src/DismissableLayer/DismissableLayer.vue` — remove `context` reactive + `onKeyStroke`; register a handle; keep both `watch`es' semantics; (Task 8, after #2722) swap `Primitive` → `useRender`.
-- **Modify** `packages/core/src/DismissableLayer/DismissableLayerBranch.vue` — register via `layerStack.branches`.
-- **Create** `packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts` — listener/`querySelectorAll` count regressions.
-- **Create** `packages/core/src/DismissableLayer/DismissableLayer.bench.ts` — benchmarks.
-- **Modify** `packages/core/vite.config.ts` (`benchmark.include`), `packages/core/package.json` (`"bench"` script).
+- **Create** `DismissableLayer/layerStack.ts` (+ `layerStack.test.ts`).
+- **Modify** `DismissableLayer/utils.ts` (composables become subscribers; `isLayerExist` gains an optional pre-computed-snapshot param, export kept; delete dead code), `DismissableLayer.vue` (registries + drop `onKeyStroke`/`context`), `DismissableLayerBranch.vue` (registerBranch), `shared/handleAndDispatchCustomEvent.ts` (additive `target?` param).
+- **Create** `DismissableLayer.listeners.test.ts` (count regressions), `DismissableLayer.bench.ts`; **Modify** `vite.config.ts` (`benchmark.include`), `package.json` (`"bench"`).
 
 ---
 
-## Task 1: The stack manager `layerStack.ts` (TDD, pure DOM)
+## Task 1: The stack manager `layerStack.ts` — two registries (TDD, pure DOM)
 
 **Files:**
-- Create: `packages/core/src/DismissableLayer/layerStack.ts`
-- Test: `packages/core/src/DismissableLayer/layerStack.test.ts`
+- Create: `packages/core/src/DismissableLayer/layerStack.ts`, `packages/core/src/DismissableLayer/layerStack.test.ts`
 
 **Interfaces:**
-- Produces:
+- Produces two **separate** registries (the load-bearing fix — one array cannot represent both lifetimes/populations):
   ```ts
-  export interface LayerHandle {
+  // Ordered participation stack — PRESENCE-driven (component membership watch).
+  // Sole source for Escape routing, indexOfLayer, isTopLayer, pointer-events accounting.
+  // Editable never enters this array (it never entered context.layersRoot today).
+  export interface StackLayer {
     element: () => HTMLElement | undefined
     isPresent: () => boolean
-    isPointerEventsEnabled: () => boolean
-    isPointerInside: boolean
-    isFocusInside: boolean
-    armed: boolean
-    participatesInStack: boolean // false for standalone Editable usage — excluded from Escape/top-layer accounting
-    onPointerDownOutside?: (event: PointerEvent) => void
-    onFocusOutside?: (event: FocusEvent) => void
+    disableOutsidePointerEvents: () => boolean
     onEscapeKeyDown?: (event: KeyboardEvent) => void
   }
-  export const layers: LayerHandle[] // ordered: [0]=bottom, last=top (shallowReactive)
+  export const layers: StackLayer[] // shallowReactive; [0]=bottom, last=top
+  export function registerStackLayer(layer: StackLayer): () => void
+  export function indexOfLayer(layer: StackLayer): number
+  export function isTopLayer(layer: StackLayer): boolean
+  export function highestDisabledIndex(): number // for isPointerEventsEnabled
+
+  // Outside-event subscribers — SETUP/enabled-driven (composable watchEffect(enabled)).
+  // DismissableLayer: setup lifetime; Editable: isEditing lifetime. Dispatch only.
+  // NEVER affects Escape/index/pointer-events accounting.
+  export interface OutsideSubscriber {
+    armed: boolean
+    isPointerInside: boolean
+    isFocusInside: boolean
+    // Ported verbatim from utils.ts handlePointerDown/handleFocus bodies:
+    handlePointerDown?: (event: PointerEvent, ctx: DispatchContext) => void
+    handleFocus?: (event: FocusEvent, ctx: DispatchContext) => void
+  }
+  export interface DispatchContext {
+    target: EventTarget | null // getEventTarget(event), captured synchronously
+    nodeList: Element[] // one hoisted querySelectorAll('[data-dismissable-layer]')
+    layerIndex: (el: Element) => number // built from a Map over nodeList — O(1), not indexOf
+    branches: HTMLElement[]
+    deferTouch: (sub: OutsideSubscriber, dispatch: () => void) => void
+    cancelTouch: (sub: OutsideSubscriber) => void
+  }
+  export const outsideSubscribers: OutsideSubscriber[]
+  export function registerOutsideSubscriber(sub: OutsideSubscriber): () => void
+
   export const branches: HTMLElement[]
-  export function registerLayer(handle: LayerHandle): () => void // returns unregister
   export function registerBranch(el: HTMLElement): () => void
-  export function isTopLayer(handle: LayerHandle): boolean
-  export function indexOfLayer(handle: LayerHandle): number
-  export function resetLayerStack(): void // test-only reset
+  export function resetLayerStack(): void // clears ALL state (see Global Constraints)
   ```
-- Consumes: nothing (plain module; Vue `shallowReactive` for the arrays).
+- Listener install/teardown: **`pointerdown` + `focusin` on `document`** (bubble phase), **`keydown` on `window`** (matching today's `onKeyStroke` default target — zero observability change vs a document keydown). Install `pointerdown`/`focusin` while `outsideSubscribers` is non-empty; install `keydown` while `layers` is non-empty (so Editable, which adds only outside subscribers, never triggers a keydown listener — exact footprint parity). Teardown each when its driving registry empties.
 
 - [ ] **Step 1: Write the failing manager tests**
 
 ```ts
 // packages/core/src/DismissableLayer/layerStack.test.ts
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { isTopLayer, layers, registerLayer, resetLayerStack } from './layerStack'
-
-function makeHandle(overrides = {}) {
-  return {
-    element: () => document.body,
-    isPresent: () => true,
-    isPointerEventsEnabled: () => true,
-    isPointerInside: false,
-    isFocusInside: false,
-    armed: true,
-    participatesInStack: true,
-    ...overrides,
-  }
-}
+import { isTopLayer, layers, outsideSubscribers, registerOutsideSubscriber, registerStackLayer, resetLayerStack } from './layerStack'
 
 afterEach(() => resetLayerStack())
 
+function stackLayer(over = {}) {
+  return { element: () => document.body, isPresent: () => true, disableOutsidePointerEvents: () => false, ...over }
+}
+function subscriber(over = {}) {
+  return { armed: true, isPointerInside: false, isFocusInside: false, ...over }
+}
+
 describe('layerStack', () => {
-  it('installs exactly one document listener of each kind for N layers', () => {
+  it('installs one pointerdown/focusin while subscribers exist and one keydown while stack layers exist', () => {
     const add = vi.spyOn(document, 'addEventListener')
-    registerLayer(makeHandle())
-    registerLayer(makeHandle())
-    registerLayer(makeHandle())
-    const kinds = add.mock.calls.map(c => c[0])
-    expect(kinds.filter(k => k === 'pointerdown')).toHaveLength(1)
-    expect(kinds.filter(k => k === 'focusin')).toHaveLength(1)
-    expect(kinds.filter(k => k === 'keydown')).toHaveLength(1)
+    const winAdd = vi.spyOn(window, 'addEventListener')
+    registerStackLayer(stackLayer())
+    registerOutsideSubscriber(subscriber())
+    registerOutsideSubscriber(subscriber())
+    expect(add.mock.calls.filter(c => c[0] === 'pointerdown')).toHaveLength(1)
+    expect(add.mock.calls.filter(c => c[0] === 'focusin')).toHaveLength(1)
+    expect(winAdd.mock.calls.filter(c => c[0] === 'keydown')).toHaveLength(1)
     add.mockRestore()
+    winAdd.mockRestore()
   })
 
-  it('removes all document listeners when the last layer unregisters', () => {
+  it('an Editable-like subscriber (no stack layer) installs NO keydown listener', () => {
+    const winAdd = vi.spyOn(window, 'addEventListener')
+    registerOutsideSubscriber(subscriber())
+    expect(winAdd.mock.calls.filter(c => c[0] === 'keydown')).toHaveLength(0)
+    winAdd.mockRestore()
+  })
+
+  it('removes the pointerdown/focusin listeners when the last subscriber unregisters', () => {
     const remove = vi.spyOn(document, 'removeEventListener')
-    const off1 = registerLayer(makeHandle())
-    const off2 = registerLayer(makeHandle())
+    const off1 = registerOutsideSubscriber(subscriber())
+    const off2 = registerOutsideSubscriber(subscriber())
     off1()
-    expect(remove).not.toHaveBeenCalled() // still one layer left
+    expect(remove.mock.calls.filter(c => c[0] === 'pointerdown')).toHaveLength(0) // one left
     off2()
-    const kinds = remove.mock.calls.map(c => c[0])
-    expect(kinds).toContain('pointerdown')
-    expect(kinds).toContain('focusin')
-    expect(kinds).toContain('keydown')
+    expect(remove.mock.calls.filter(c => c[0] === 'pointerdown')).toHaveLength(1)
     remove.mockRestore()
   })
 
-  it('maintains registration order and isTopLayer', () => {
-    const a = makeHandle()
-    const b = makeHandle()
-    registerLayer(a)
-    registerLayer(b)
+  it('maintains stack order and isTopLayer', () => {
+    const a = stackLayer()
+    const b = stackLayer()
+    registerStackLayer(a)
+    registerStackLayer(b)
     expect(layers[0]).toBe(a)
     expect(isTopLayer(b)).toBe(true)
     expect(isTopLayer(a)).toBe(false)
   })
 
-  it('routes Escape only to the top present participating layer', () => {
-    const bottom = makeHandle({ onEscapeKeyDown: vi.fn() })
-    const top = makeHandle({ onEscapeKeyDown: vi.fn() })
-    registerLayer(bottom)
-    registerLayer(top)
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+  it('routes Escape only to the top present stack layer', () => {
+    const bottom = stackLayer({ onEscapeKeyDown: vi.fn() })
+    const top = stackLayer({ onEscapeKeyDown: vi.fn() })
+    registerStackLayer(bottom)
+    registerStackLayer(top)
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
     expect(top.onEscapeKeyDown).toHaveBeenCalledOnce()
     expect(bottom.onEscapeKeyDown).not.toHaveBeenCalled()
+  })
+
+  it('arms a freshly-registered subscriber a macrotask later', async () => {
+    const sub = subscriber({ armed: false })
+    registerOutsideSubscriber(sub)
+    expect(sub.armed).toBe(false)
+    await new Promise(r => setTimeout(r, 0))
+    expect(sub.armed).toBe(true)
   })
 })
 ```
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer/layerStack.test.ts`
-Expected: FAIL — module not found.
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer/layerStack.test.ts` → FAIL (module not found).
 
-- [ ] **Step 3: Implement the manager**
+- [ ] **Step 3: Implement the manager (transport only)**
 
-Implement `layerStack.ts` with: `shallowReactive` `layers`/`branches` arrays; lazy `installListeners(doc)` on first `registerLayer` (guarded by `isClient`), `teardownListeners(doc)` when `layers.length === 0`; `handleKeyDown` finds `[...layers].reverse().find(h => h.participatesInStack && h.isPresent())` and calls its `onEscapeKeyDown` (only for `event.key === 'Escape'`); `handlePointerDown`/`handleFocusIn` fold the current `utils.ts` bodies (see Task 2) using **one** hoisted `querySelectorAll` snapshot per event and iterate `[...layers]` (snapshot — dismiss handlers mutate `layers`); `registerLayer` sets `armed=false` then `setTimeout(() => handle.armed = true, 0)` and returns an unregister that clears the timer, splices, and tears down if empty; `resetLayerStack()` clears arrays + force-removes listeners (for tests).
+Implement per the Interfaces: `shallowReactive` arrays; lazy install (`isClient`-gated) keyed per registry as specified; `handleKeyDown` finds `[...layers].reverse().find(l => l.isPresent())` and calls its `onEscapeKeyDown` (only `event.key === 'Escape'`); `handlePointerDown`/`handleFocusIn` build **one** `DispatchContext` (`target = event.composedPath?.()[0] ?? event.target`, `nodeList = Array.from(doc.querySelectorAll('[data-dismissable-layer]'))`, `layerIndex` from a `Map<Element, number>` over `nodeList`, `branches`), then iterate `[...outsideSubscribers]` (snapshot — dispatch mutates the array) invoking each `sub.handlePointerDown?.(event, ctx)` / `sub.handleFocus?.(event, ctx)` **synchronously**; the touch map is `Map<OutsideSubscriber, () => void>` with one persistent `document` `click` listener active while the map is non-empty (`deferTouch` = `map.set` (replace = re-arm), `cancelTouch` = `map.delete`, on click run all + clear); `registerOutsideSubscriber` sets `armed = false` then `setTimeout(() => sub.armed = true, 0)` and returns an unregister that clears the timer, splices, `cancelTouch`, and tears down listeners if empty; `resetLayerStack()` clears everything incl. the touch map + click listener + `document.body.style.pointerEvents` restore.
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer/layerStack.test.ts`
-Expected: PASS.
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer/layerStack.test.ts` → PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add packages/core/src/DismissableLayer/layerStack.ts packages/core/src/DismissableLayer/layerStack.test.ts
-git commit -m "perf(DismissableLayer): add centralized layer stack manager"
+git commit -m "perf(DismissableLayer): add centralized layer stack manager (two registries)"
 ```
 
 ---
 
-## Task 2: Migrate Escape to the manager (smallest surface first)
+## Task 2: Migrate Escape to the stack registry (smallest surface first)
 
 **Files:**
 - Modify: `packages/core/src/DismissableLayer/DismissableLayer.vue`
 
 **Interfaces:**
-- Consumes: `registerLayer`, `isTopLayer` from `layerStack.ts`.
+- Consumes: `registerStackLayer`, `isTopLayer`, `indexOfLayer`.
 - Produces: Escape dismissal identical to today (top present layer only; respects `defaultPrevented`).
 
-- [ ] **Step 1: Register a handle and route Escape through it**
+- [ ] **Step 1: Register a `StackLayer` ALONGSIDE the existing Set, route Escape through it**
 
-In `DismissableLayer.vue` setup: build a `LayerHandle` whose `onEscapeKeyDown` runs the **current** `onKeyStroke('Escape', …)` callback body (L144-157) — emit `escapeKeyDown`, and if not `defaultPrevented`, `dismiss`. Register in the existing membership `watch` (L203-214) replacing `layers.value.add/delete`. **Delete** the `onKeyStroke('Escape', …)` call (removes one `window` listener per layer). Keep `index`/`isPointerEventsEnabled`/body-lock as-is for now (still reading the old `context`) — this task only moves Escape.
+In `DismissableLayer.vue` setup, build a `StackLayer` whose `onEscapeKeyDown` runs the **current** `onKeyStroke('Escape', …)` body (L144-157) — emit `escapeKeyDown`, and if not `defaultPrevented`, `dismiss`. In the membership `watch` (L203-214), call `registerStackLayer(layer)` **in addition to** `context.layersRoot.add/delete` (do NOT remove the Set yet — `index`/`isPointerEventsEnabled` still read it until Task 5; removing it now makes `-1 >= -1` enable pointer events on every layer). **Delete** the `onKeyStroke('Escape', …)` call (removes one window listener per layer; the shared keydown is on window too, so no observability change).
 
-> Transitional note: during Tasks 2–4 the component briefly holds both the old `context` reactive and a manager handle. That is intentional — each task migrates one concern and keeps the suite green. The old `context` is fully removed in Task 5.
+> Transitional note: during Tasks 2–4 the component briefly holds both the old `context` reactive and the new registries. Intentional — each task migrates one concern with the suite green. The `context` Set is removed in Task 5.
 
 - [ ] **Step 2: Run the DismissableLayer suite + add a stacking test**
 
 Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer`
-Add a test: two stacked layers → only the top emits `escapeKeyDown`; after dismissing the top, Escape falls through to the lower layer. Existing Escape tests must pass unchanged.
+Add: two stacked layers → only the top emits `escapeKeyDown`; after dismissing the top, Escape falls through. Existing Escape tests pass unchanged.
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add packages/core/src/DismissableLayer/DismissableLayer.vue
-git commit -m "perf(DismissableLayer): route Escape through the shared stack manager"
+git commit -m "perf(DismissableLayer): route Escape through the shared stack registry"
 ```
 
 ---
 
-## Task 3: Migrate `useFocusOutside` to a manager subscription
+## Task 3: Migrate `useFocusOutside` to a manager subscriber
 
 **Files:**
-- Modify: `packages/core/src/DismissableLayer/utils.ts`
+- Modify: `packages/core/src/DismissableLayer/utils.ts`, `packages/core/src/DismissableLayer/layerStack.ts` (only if the `DispatchContext` needs a field)
 
 **Interfaces:**
-- Consumes: `registerLayer`, `layers`, `branches`.
-- Produces: `useFocusOutside(onFocusOutside?, element?, enabled?)` — **unchanged signature**, still returns `{ onFocusCapture, onBlurCapture }`. Internally builds a minimal handle (only `onFocusOutside` + the inside flags), registers/unregisters in the same `watchEffect(enabled)`. The shared `focusin` dispatch lives in `layerStack.ts` (folded from the current `handleFocus` body at `utils.ts:162-180`, preserving the double `nextTick`).
+- Consumes: `registerOutsideSubscriber`.
+- Produces: `useFocusOutside(onFocusOutside?, element?, enabled?)` — **unchanged signature**, still returns `{ onFocusCapture, onBlurCapture }`.
 
-- [ ] **Step 1: Reimplement `useFocusOutside`**
+- [ ] **Step 1: Port `handleFocus` into a subscriber closure**
 
-Move the `handleFocus` logic into the manager's `handleFocusIn`: for each handle with an `onFocusOutside`, run the current checks (target in a branch → skip; `isLayerExist`-equivalent via the hoisted snapshot → skip; `isFocusInside` flag consume) then `handleAndDispatchCustomEvent(FOCUS_OUTSIDE, handle.onFocusOutside, { originalEvent })`. The composable's returned `onFocusCapture`/`onBlurCapture` now write `handle.isFocusInside` instead of a local ref.
+Reimplement `useFocusOutside` to register an `OutsideSubscriber` (in the existing `watchEffect(enabled)`) whose `handleFocus(event, ctx)` is **`utils.ts:162-180` ported verbatim**: keep the double `nextTick` (166-167); read the target from **`ctx.target`** (already the composed, synchronously-captured target — do NOT re-read `event.target` after the awaits); the `event.target && !isFocusInsideDOMTree` gate that today reads `event.target` at both **:168 and :172** now reads `ctx.target`; the `isLayerExist`-equivalent uses `ctx.nodeList`/`ctx.layerIndex`; then `handleAndDispatchCustomEvent(FOCUS_OUTSIDE, onFocusOutside, { originalEvent: event }, ctx.target)`. **Do NOT clear `isFocusInside` in `handleFocus`** — today only `onBlurCapture` clears it (`utils.ts:194-199`); `onFocusCapture` sets it. The returned `onFocusCapture`/`onBlurCapture` write `sub.isFocusInside`.
 
 - [ ] **Step 2: Run focus tests + Editable**
 
@@ -226,29 +248,37 @@ git commit -m "perf(DismissableLayer): route focusOutside through the shared man
 
 ---
 
-## Task 4: Migrate `usePointerDownOutside` (incl. touch-click deferral + arming)
+## Task 4: Migrate `usePointerDownOutside` (touch deferral + arming + shadow target)
 
 **Files:**
-- Modify: `packages/core/src/DismissableLayer/utils.ts`, `packages/core/src/DismissableLayer/layerStack.ts`
+- Modify: `packages/core/src/DismissableLayer/utils.ts`, `packages/core/src/DismissableLayer/layerStack.ts`, `packages/core/src/shared/handleAndDispatchCustomEvent.ts`
 
 **Interfaces:**
-- Consumes: manager pointerdown dispatch.
-- Produces: `usePointerDownOutside(onPointerDownOutside?, element?, enabled?)` — unchanged signature, returns `{ onPointerDownCapture }`. The `setTimeout(0)` self-dismiss guard becomes the per-handle `armed` flag; the touch `click` `{once:true}` deferral becomes **one shared** re-armed slot in the manager.
+- Consumes: `registerOutsideSubscriber`, `ctx.deferTouch`/`ctx.cancelTouch`.
+- Produces: `usePointerDownOutside(onPointerDownOutside?, element?, enabled?)` — unchanged signature, returns `{ onPointerDownCapture }`.
 
-- [ ] **Step 1: Fold `handlePointerDown` into the manager**
+- [ ] **Step 1: Add the threaded target param to `handleAndDispatchCustomEvent`**
 
-In `layerStack.ts` `handlePointerDown`: hoist **one** `querySelectorAll('[data-dismissable-layer]')` snapshot + `target.closest(...)` + `branches.some(...)` per event. For each `[...layers]` handle with `onPointerDownOutside`: skip if `!handle.armed`; consume `handle.isPointerInside`; apply the `isLayerExist`-equivalent DOM-order check against the snapshot (preserving the `mainLayer` fallback for non-`data-dismissable-layer` elements like Editable); for touch (`pointerType === 'touch'`), defer to a single shared `click` `{once:true}` handler (re-armed/cleared with today's rules); else `nextTick()` then `handleAndDispatchCustomEvent(POINTER_DOWN_OUTSIDE, handle.onPointerDownOutside, …)`. Delete the per-layer `document.addEventListener('pointerdown', …)` and the dead `CONTEXT_UPDATE`/`dispatchUpdate`.
+`handleAndDispatchCustomEvent(name, handler, detail, target?: EventTarget)` — additive; default `target = detail.originalEvent.target`. Use `target` (not `detail.originalEvent.target`) for the `addEventListener`/`dispatchEvent`. **Why:** for shadow-origin events the original target is nulled post-dispatch in real browsers (spec *clearTargets*) → `null.addEventListener` crash; jsdom masks it by retaining the host. Both dismiss paths pass the synchronously-captured `ctx.target`.
 
-- [ ] **Step 2: Run the full DismissableLayer suite (incl. #2674)**
+- [ ] **Step 2: Port `handlePointerDown` into a subscriber closure (branch-for-branch)**
 
-Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer`
-Expected: all pass unchanged, including the touch-deferral and #2674 `disableOutsidePointerEvents` cases.
+Reimplement `usePointerDownOutside` to register an `OutsideSubscriber` whose `handlePointerDown(event, ctx)` is **`utils.ts:61-112` ported verbatim, in the same branch order**: `if (!sub.armed) return`; then the `isLayerExist`-equivalent using `ctx.nodeList`/`ctx.layerIndex` (target = `ctx.target`, reads at both **:62 and :72**) with **early return + flag clear** as today; then the dispatch-vs-cancel fork on `sub.isPointerInside`; for touch (`event.pointerType === 'touch'`) call `ctx.deferTouch(sub, dispatch)` (the manager's shared click listener replaces the per-instance `handleClickRef`), and the cancel branch (today `utils.ts:106-110`) calls `ctx.cancelTouch(sub)`; non-touch dispatches **synchronously** (no `nextTick`): `handleAndDispatchCustomEvent(POINTER_DOWN_OUTSIDE, onPointerDownOutside, { originalEvent: event }, ctx.target)`; clear `sub.isPointerInside` at the end of every path (today `:111`). Delete the per-layer `document.addEventListener('pointerdown', …)` + `setTimeout(0)` wiring (arming now lives in the manager) and the dead `CONTEXT_UPDATE`/`dispatchUpdate` (zero consumers).
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Keep `isLayerExist` exported; add optional snapshot param**
+
+`isLayerExist(el, target, nodeList?)` — when `nodeList` is passed, skip the internal `querySelectorAll` and use it (the manager hoists one snapshot); default preserves the old signature so `DismissableLayer.test.ts:9,15-21` passes unchanged. Build the `layerIndex` `Map` from `nodeList` so per-subscriber lookups are O(1), not O(n²).
+
+- [ ] **Step 4: Run the full DismissableLayer suite (incl. #2674) + add Editable/touch tests**
+
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer src/Editable`
+Add: (a) **Editable-vs-Dialog DOM-order** — Editable in edit mode (it HAS `data-dismissable-layer`, so it appears in the snapshot) + open Dialog: a pointerdown on the Editable dismisses the Dialog iff DOM order says so (today's behavior). (b) touch pointerdown defers to click; a second inside pointerdown before the click cancels only that subscriber's pending dispatch. (c) persistent menu (`unmountOnHide:false`) reopened → immediate outside pointerdown still dismisses (arming-window parity).
+
+- [ ] **Step 5: Commit**
 
 ```bash
-git add packages/core/src/DismissableLayer/utils.ts packages/core/src/DismissableLayer/layerStack.ts
-git commit -m "perf(DismissableLayer): route pointerDownOutside through the shared manager"
+git add packages/core/src/DismissableLayer/utils.ts packages/core/src/DismissableLayer/layerStack.ts packages/core/src/shared/handleAndDispatchCustomEvent.ts
+git commit -m "perf(DismissableLayer): route pointerDownOutside through the shared manager (shadow-safe)"
 ```
 
 ---
@@ -256,21 +286,21 @@ git commit -m "perf(DismissableLayer): route pointerDownOutside through the shar
 ## Task 5: Remove the reactive `context`; move branches + body-lock to the manager
 
 **Files:**
-- Modify: `packages/core/src/DismissableLayer/DismissableLayer.vue`, `packages/core/src/DismissableLayer/DismissableLayerBranch.vue`
+- Modify: `packages/core/src/DismissableLayer/DismissableLayer.vue`, `packages/core/src/DismissableLayer/DismissableLayerBranch.vue`, `packages/core/src/DismissableLayer/layerStack.ts`
 
 **Interfaces:**
-- Consumes: `layers`, `branches`, `layersWithOutsidePointerEventsDisabled` from the manager.
-- Produces: `index`/`isPointerEventsEnabled`/`isBodyPointerEventsDisabled` read the manager arrays with array `indexOf` (no `Array.from`); body-pointer-events lock keeps the exact #2674 formulas + comments; `DismissableLayerBranch` registers via `registerBranch`.
+- Consumes: `layers`, `indexOfLayer`, `highestDisabledIndex`, `branches`, and a shared `originalBodyPointerEvents` field on the manager.
+- Produces: `index`/`isPointerEventsEnabled`/`isBodyPointerEventsDisabled` read the manager (array `indexOf`, no `Array.from`); body-lock keeps the exact #2674 formulas + comments; `DismissableLayerBranch` registers via `registerBranch`.
 
 - [ ] **Step 1: Replace `context` reads**
 
-Delete the module `context = reactive({...})`. Rewrite `index` as `indexOfLayer(handle)`; `isPointerEventsEnabled` using `layersWithOutsidePointerEventsDisabled` (array). Port the body-lock `watch` (L165-196) verbatim except array-backed, keeping comments L159-164/176-183 and the size-0-after-delete restore (#2674). Make `originalBodyPointerEvents` a manager field (or keep local — but preserve single-restore semantics).
+Delete `context = reactive({...})`. `index` → `indexOfLayer(layer)`; `isPointerEventsEnabled` → compares `indexOfLayer(layer) >= highestDisabledIndex()`. Track disabling layers in the manager (a `disableOutsidePointerEvents()` getter on `StackLayer` + a derived highest-index). **Port the body-lock `watch` (L165-196) as a `watch` with explicit sources** (never `watchEffect`, so it does not track membership churn — this is why Risk "reactive granularity" is satisfied), keeping comments 159-164/176-183 and the size-0-after-delete restore. **`originalBodyPointerEvents` MUST be a shared manager field** (strike "keep local": layer A saves the original, A unmounts while disabling layer B is open, B's cleanup restores A's saved value — a component-local copy dies with A). Keep using the layer's `ownerDocument` computed (`DismissableLayer.vue:93-95`) for `body.style`. Port the L216-223 safety-net as an **unmount-only** cleanup (it has no reactive deps; element swaps are handled by the membership watch's `[layerElement]` source).
 
 - [ ] **Step 2: Migrate the Branch**
 
-`DismissableLayerBranch.vue`: replace `import { context } from './DismissableLayer.vue'` + `context.branches.add/delete` with `registerBranch(currentElement.value)` in `onMounted`/unregister in `onUnmounted`.
+`DismissableLayerBranch.vue`: replace `import { context }` + `context.branches.add/delete` with `registerBranch(currentElement.value)` on mount / unregister on unmount.
 
-- [ ] **Step 3: Run DismissableLayer + Toast (branch consumer) + broad overlay sweep**
+- [ ] **Step 3: Run DismissableLayer + Toast + broad overlay sweep**
 
 Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer src/Toast src/Dialog src/Menu src/Popover src/Select src/Combobox src/Tooltip src/HoverCard src/NavigationMenu src/Drawer src/Editable`
 Expected: all pass unchanged.
@@ -290,33 +320,37 @@ git commit -m "perf(DismissableLayer): remove reactive context in favor of the s
 **Files:**
 - Create: `packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts`
 
-- [ ] **Step 1: Write the count-regression tests**
+- [ ] **Step 1: Write count-regression tests (diff before/after mount to be robust)**
 
 ```ts
 // packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts
-import { describe, expect, it, vi } from 'vitest'
-// mount N DismissableLayers (open) via a fixture, then assert:
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetLayerStack } from './layerStack'
+
+beforeEach(() => resetLayerStack())
+afterEach(() => resetLayerStack())
+
 describe('DismissableLayer listener consolidation', () => {
-  it('registers exactly one document pointerdown/focusin/keydown for many layers', () => {
+  it('adds one document pointerdown/focusin regardless of layer count', () => {
     const add = vi.spyOn(document, 'addEventListener')
-    // mount 10 open layers
-    const kinds = add.mock.calls.map(c => c[0])
-    expect(kinds.filter(k => k === 'pointerdown')).toHaveLength(1)
-    expect(kinds.filter(k => k === 'focusin')).toHaveLength(1)
-    expect(kinds.filter(k => k === 'keydown')).toHaveLength(1)
+    const before = { pd: count(add, 'pointerdown'), fi: count(add, 'focusin') }
+    // mount 10 open DismissableLayers via a wrapper fixture
+    expect(count(add, 'pointerdown') - before.pd).toBe(1)
+    expect(count(add, 'focusin') - before.fi).toBe(1)
     add.mockRestore()
   })
   it('runs querySelectorAll once per outside pointerdown regardless of layer count', () => {
     const qsa = vi.spyOn(document, 'querySelectorAll')
-    // mount 5 open layers, dispatch one outside pointerdown
-    // assert qsa called once for '[data-dismissable-layer]'
+    // mount 5 open layers; clear; dispatch ONE outside pointerdown
+    // assert exactly one call for '[data-dismissable-layer]'
     qsa.mockRestore()
   })
-  it('removes all document listeners after every layer unmounts', () => {})
+  it('removes all shared listeners after every layer unmounts', () => {})
 })
+// helper: count(spy, kind) = spy.mock.calls.filter(c => c[0] === kind).length
 ```
 
-Fill fixture bodies using `@vue/test-utils` `mount` of a small wrapper rendering N `DismissableLayer`s. Reset the manager in `beforeEach`.
+Fill fixtures with `@vue/test-utils` `mount` of a wrapper rendering N `DismissableLayer`s. (Note: vitest default `isolate:true` gives a fresh module registry per **file**; the singleton persists **within** a file, so the `beforeEach` reset is required.)
 
 - [ ] **Step 2: Run + commit**
 
@@ -329,43 +363,45 @@ git commit -m "test(DismissableLayer): assert single shared listener + one query
 
 ---
 
-## Task 7: Benchmarks
+## Task 7: Benchmarks (honest measurement)
 
 **Files:**
 - Create: `packages/core/src/DismissableLayer/DismissableLayer.bench.ts`
 - Modify: `packages/core/vite.config.ts`, `packages/core/package.json`
 
-- [ ] **Step 1: Add the bench config + script**
+- [ ] **Step 1: Add bench config + script (self-contained commit)**
 
-In `packages/core/vite.config.ts` `test` block add `benchmark: { include: ['./**/*.bench.{ts,js}'] }`. In `packages/core/package.json` scripts add `"bench": "vitest bench --run"`.
+`vite.config.ts` test block: `benchmark: { include: ['./**/*.bench.{ts,js}'] }`. `package.json`: `"bench": "vitest bench --run"`. Keep this a self-contained commit so the baseline can be captured on `v2`.
 
-- [ ] **Step 2: Write the benchmarks**
+- [ ] **Step 2: Write benchmarks (flush arming timers)**
 
 ```ts
 // packages/core/src/DismissableLayer/DismissableLayer.bench.ts
 import { bench, describe } from 'vitest'
-
+// Each bench mounts real DismissableLayers, then FLUSHES arming (await a macrotask
+// or vi.runAllTimers) before dispatching — otherwise pointerdown benches measure
+// unarmed no-ops. jsdom benches measure JS-only cost (no layout/paint); the Task 6
+// structural counts are the proof, benches are directional.
 describe('DismissableLayer', () => {
-  bench('mount + unmount 50 stacked layers', () => { /* mount 50, unmount */ })
-  bench('100 outside pointerdowns against 20 open layers', () => { /* dispatch loop */ })
-  bench('Escape dispatch against 20 open layers', () => { /* dispatch keydown */ })
+  bench('mount + unmount 50 stacked layers', () => {})
+  bench('100 outside pointerdowns against 20 open (armed) layers', () => {})
+  bench('Escape dispatch against 20 open layers', () => {})
 })
 ```
 
-- [ ] **Step 3: Run + record numbers in the PR body**
+- [ ] **Step 3: Capture before/after (worktree baseline)**
 
-Run: `pnpm --filter reka-ui bench`
-Capture the before/after (run once on `v2`, once on this branch) in the PR description.
+The bench files don't exist on `v2`, so: `git worktree add ../reka-v2-bench v2`, copy the three bench/config files into it (or `git -C ../reka-v2-bench cherry-pick <bench-commit-sha>`), run `pnpm --filter reka-ui bench` in both trees, record numbers in the PR. Remove the worktree after.
 
-- [ ] **Step 4: Add a render-count assertion (plain test)**
+- [ ] **Step 4: Parity check — do NOT claim a render-count reduction without proving it on v2 first**
 
-An `onUpdated`-counter child inside one layer while sibling layers mount/unmount — assert the counter does not increment (proves the reactive-Set churn is gone). Add to the listeners test file.
+Run the "sibling churn does not re-render an open layer" probe (an `onUpdated` counter **on the layer component itself**, not a slotted child — slot content is parent-owned and won't fire) on **`v2` first**. Under Vue ≥ 3.4 (dev 3.5.17) unchanged computeds don't trigger effects, so this very likely **already passes on v2** — if so, frame it as "render count unchanged (parity)", NOT a reduction, and drop "render count" from the PR narrative. The provable wins are: listener count (Task 6), one `querySelectorAll` per event (Task 6), and O(1) pointer-events accounting replacing the O(n) `Array.from().indexOf()` scans.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add packages/core/src/DismissableLayer/DismissableLayer.bench.ts packages/core/vite.config.ts packages/core/package.json
-git commit -m "perf(DismissableLayer): add overlay interaction + render benchmarks"
+git commit -m "perf(DismissableLayer): add overlay interaction benchmarks"
 ```
 
 ---
@@ -375,16 +411,15 @@ git commit -m "perf(DismissableLayer): add overlay interaction + render benchmar
 **Files:**
 - Modify: `packages/core/src/DismissableLayer/DismissableLayer.vue`, `packages/core/src/DismissableLayer/DismissableLayerBranch.vue`
 
-> **Blocked on #2722.** Do not start until `useRender` is merged. Everything above lands independently.
+> **Blocked on #2722.** Do not start until `useRender` is merged. Tasks 1–7 land independently.
 
 - [ ] **Step 1: Swap `Primitive` for `useRender`**
 
-Replace `<Primitive :ref="forwardRef" v-bind="...">` with `<component :is="tag" v-bind="renderProps" :ref="elementRef">`, moving the current bound attributes (incl. `style.pointerEvents` from `isBodyPointerEventsDisabled`/`isPointerEventsEnabled`) into the `props`/`state` passed to `useRender`. Removes one component instance per overlay part.
+Replace `<Primitive :ref="forwardRef" v-bind="...">` with `<component :is="tag" v-bind="renderProps" :ref="elementRef">`, moving the bound attributes (incl. `style.pointerEvents` from `isBodyPointerEventsDisabled`/`isPointerEventsEnabled`) into `useRender`'s `props`/`state`. Removes one component instance per overlay part (measured ~1.6× faster mount on the common path in the #2722 plan).
 
-- [ ] **Step 2: Full suite + render-count assertion**
+- [ ] **Step 2: Full suite + consumer sweep**
 
-Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer` and the consumer sweep from Task 5.
-Add a render-count assertion showing one fewer instance in the overlay chain.
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer` + the Task 5 consumer sweep. Verify `style.pointerEvents` still binds correctly through `renderProps`.
 
 - [ ] **Step 3: Type-check + commit**
 
@@ -398,24 +433,26 @@ git commit -m "perf(DismissableLayer): render via useRender, dropping the Primit
 
 ## Self-Review
 
-- **Spec coverage:** "single shared listener + one centralized stack manager" → Tasks 1–5; "remove wrapper render overhead via useRender" → Task 8; "measurable reductions" → Tasks 6 (counts) + 7 (benchmarks). Covered.
-- **Semantics preserved:** top-only Escape (Task 2), all-qualifying-layers pointer/focus outside (Tasks 3–4), `disableOutsidePointerEvents` body lock + #2674 comments (Task 5), branches (Task 5), touch-click deferral + `setTimeout(0)` arming (Task 4), custom-event `preventDefault` path (unchanged — reuses `handleAndDispatchCustomEvent`).
-- **Type consistency:** `LayerHandle` fields (`armed`, `isPointerInside`, `isFocusInside`, `participatesInStack`, `onPointerDownOutside`/`onFocusOutside`/`onEscapeKeyDown`) used identically across Tasks 1–5. `registerLayer`/`registerBranch`/`isTopLayer`/`resetLayerStack` names stable.
-- **Signature freeze:** `usePointerDownOutside`/`useFocusOutside` `(handler?, element?, enabled?)` unchanged (Tasks 3–4) — Editable compiles untouched.
+- **Spec coverage:** "single shared listener + one centralized stack manager" → Tasks 1–5; "remove wrapper render overhead via useRender" → Task 8; "measurable reductions" → Task 6 (counts, the real proof) + Task 7 (directional benches). Covered.
+- **Semantics preserved:** top-only Escape on window (Task 2); all-qualifying-layers pointer/focus outside via ported closures (Tasks 3–4); synchronous non-touch dispatch (Task 4); per-subscriber touch deferral + arming (Tasks 1, 4); #2674 body-lock as a `watch` with shared `originalBodyPointerEvents` (Task 5); dual ordering (presence for Escape/index, DOM for `isLayerExist`) kept independent; `isLayerExist` export + unit tests intact (Task 4).
+- **Shadow-readiness:** composed-target reads + `handleAndDispatchCustomEvent` target threading (Task 4) mean #2725 does not re-patch `utils.ts`.
+- **Type consistency:** `StackLayer` vs `OutsideSubscriber` are distinct types with distinct registries; `DispatchContext` is the single object passed to every ported closure.
 
 ## Risks / Gotchas
 
-1. **Capture vs bubble** — keep the shared `pointerdown`/`focusin` on **bubble** phase (element guards are capture); moving to capture breaks inside-detection for portal'd content that relies on the flags, not DOM containment.
-2. **Handler order** — iterate a `[...layers]` snapshot in registration order (matches today); dismiss handlers unregister mid-dispatch.
-3. **Stack order ≠ DOM order** — Escape uses presence/registration order; outside-detection uses DOM (`querySelectorAll`) order. Preserve both independently; don't unify.
-4. **`setTimeout(0)` arming** — the per-handle `armed` flag is load-bearing (mount-via-pointerdown self-dismiss guard, `utils.ts:113-125`).
-5. **`ownerDocument`** — today effectively always `globalThis.document` (captured before the element ref exists); match that as parity; a per-`Document` listener map is the correct generalization but out of scope here (overlaps #2725).
-6. **SSR** — no `document` at import; install listeners lazily on first `registerLayer`, `isClient`-gated.
-7. **Teardown** — last-layer teardown must also clear the shared touch-`click` deferred listener and any arming timers; keep an equivalent of the safety-net cleanup (`DismissableLayer.vue:216-223`) for `forwardRef` element swaps.
-8. **Reactive granularity** — `shallowReactive` arrays: `isPointerEventsEnabled`'s style binding must still update on other layers registering, but the #2674 body-lock `watch` must NOT become reactive to membership churn (see comments L159-164).
-9. **Test isolation** — the module singleton persists across vitest files in a worker; `resetLayerStack()` in `beforeEach` or listener-count assertions flake.
-10. **#2722 dependency** — only Task 8 needs `useRender`; land Tasks 1–7 first.
+1. **Two populations, two registries** — `layers` (presence-driven; Escape/index/pointer-events) and `outsideSubscribers` (setup-driven; dispatch/arming/touch). Never merge them; Editable joins only `outsideSubscribers`, so it never affects Escape/index (and never installs a keydown listener).
+2. **Manager = transport** — port `utils.ts:61-112`/`162-180` branch-for-branch into subscriber closures; keep component-level branch/present filtering in `DismissableLayer.vue`'s callbacks; the manager only owns listeners + snapshot + arming + touch map.
+3. **Synchronous dispatch** — non-touch pointer dispatch runs in the bubble; do NOT add a pre-dispatch `nextTick`. The focus path keeps its double `nextTick` (`utils.ts:166-167`) and the component keeps its post-emit `nextTick` (`DismissableLayer.vue:126`).
+4. **Editable HAS `data-dismissable-layer`** (`EditableRoot.vue:227`) — it participates in the snapshot and affects other layers' DOM-order checks; the `querySelector` fallback in `isLayerExist` is for the ref-above-element edge, not Editable.
+5. **Touch deferral is per-subscriber** — `Map<OutsideSubscriber, dispatch>` + one shared click listener; "layer A cancels, B stays armed" must hold (multi-touch); per-subscriber cleanup on unregister.
+6. **`isLayerExist` stays exported** — add an optional `nodeList` param; the test imports it (`:9`). Build an index `Map` to avoid O(n²).
+7. **Body-lock is a `watch` with explicit sources** — never `watchEffect`; `originalBodyPointerEvents` is a shared manager field; body mutations use the layer's `ownerDocument`; the L216-223 safety-net ports as unmount-only cleanup. `shallowReactive` array `indexOf`/`.length` reads inside the `index`/`isPointerEventsEnabled` computeds DO track mutations, so the style binding updates when other layers register.
+8. **Escape stays on window** — the shared keydown installs on `window` (matching today's `onKeyStroke` default), so nothing that stops propagation at document level is affected.
+9. **Render-count is parity, not reduction** — verify on v2 first (Vue ≥ 3.4 skips unchanged-computed effects); do not claim a reduction. `onUpdated` probe goes on the layer, not a slotted child.
+10. **SSR + isolation** — lazy `isClient`-gated install; `resetLayerStack()` clears every field incl. the touch click listener + body-style restore; vitest isolates per file (singleton persists within a file → `beforeEach` reset).
+11. **Shadow targets** — capture `composedPath()[0]` synchronously (it's `[]` after dispatch); thread into `handleAndDispatchCustomEvent` to avoid the null-target browser crash.
+12. **#2722 dependency** — only Task 8 needs `useRender`; land Tasks 1–7 first.
 
 ## Execution Handoff
 
-Recommended: **Subagent-Driven** (superpowers:subagent-driven-development). Task 1 (pure manager) is a clean isolated unit; Tasks 2–5 migrate one concern each with the full suite as the gate (highest scrutiny on Task 5's #2674 body-lock port); Tasks 6–7 quantify; Task 8 waits on #2722. Run the consumer sweep after Tasks 5 and 8.
+Recommended: **Subagent-Driven** (superpowers:subagent-driven-development). Task 1 (pure manager, two registries) is the foundation; Tasks 2–5 migrate one concern each with the full suite as the gate (highest scrutiny on Task 4's ported branch structure + Task 5's #2674 body-lock/shared-`originalBodyPointerEvents`); Task 6 is the real proof; Task 7 measures honestly; Task 8 waits on #2722. Run the consumer sweep after Tasks 5 and 8. Because the composed-target work lands here, #2725 can drop its `DismissableLayer/utils.ts` patches entirely.

--- a/docs/superpowers/plans/2026-07-11-2724-overlay-render-perf.md
+++ b/docs/superpowers/plans/2026-07-11-2724-overlay-render-perf.md
@@ -1,0 +1,421 @@
+# Overlay & Render Performance Overhaul — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> Tracks GitHub issue **#2724** (Phase 2 — Built on the foundation), part of the reka-ui v3 roadmap **#2721**. The stack-manager work is independent of #2722 (`useRender`); only the final wrapper-removal step (Task 8) depends on it.
+
+**Goal:** Replace `DismissableLayer`'s per-layer global listeners (3+ `document`/`window` listeners **per open layer**) and per-read O(n) `Array.from(...).indexOf()` scans with a **single centralized stack manager** exposing exactly one shared set of `document` listeners regardless of layer count, plus benchmarks that quantify the wins. Then remove the wrapper render instance via `useRender`.
+
+**Architecture:** A new plain-module singleton `layerStack.ts` holds an ordered array of layer handles, the branch set, and the "outside-pointer-events-disabled" set; it installs exactly one `pointerdown` + one `focusin` + one `keydown` `document` listener on first registration and tears them down when the last layer unregisters. Each listener does **one** `querySelectorAll` snapshot per event and dispatches to the relevant handle(s), preserving today's exact dismissal semantics (top-only Escape; all-qualifying-layers pointer/focus outside; `disableOutsidePointerEvents` body lock; branches; touch-click deferral; `setTimeout(0)` arming). `usePointerDownOutside`/`useFocusOutside` keep their exact signatures but become thin subscriptions to the manager.
+
+**Tech Stack:** Vue 3 (`shallowReactive`, `watch`, `watchEffect`), TypeScript, vitest 4 (`bench`/tinybench built in), jsdom, `@vue/test-utils`.
+
+## Global Constraints
+
+- Node ≥ 22, pnpm 10. All commands from repo root.
+- Test (one-shot): `pnpm --filter reka-ui exec vitest run <path>` — never `pnpm test` (watch).
+- Type-check: `pnpm --filter reka-ui type-check`. Build: `pnpm --filter reka-ui build`. Lint fix: `pnpm lint:fix`.
+- **Behavior is frozen.** Every existing test in `packages/core/src/DismissableLayer/DismissableLayer.test.ts` (incl. the #2674 `disableOutsidePointerEvents` suite and the `present:false` tests) and every consumer suite must pass **unchanged**. `usePointerDownOutside`/`useFocusOutside` **signatures** `(handler?, element?, enabled?)` must not change — `Editable/EditableRoot.vue` calls them directly.
+- Consumers to regression-test (blast radius): Dialog, Drawer, Menu (→ DropdownMenu/ContextMenu/Menubar), Popover, Tooltip, HoverCard, Combobox, Select, NavigationMenu, Toast (Branch), Editable.
+- Preserve the #2674 body-pointer-events ordering comments (`DismissableLayer.vue:159-164,176-183`) — they encode hard-won semantics; port them verbatim.
+- Module singleton must be SSR-safe (no `document` at import; install lazily, `isClient`-gated) and test-isolated (export `resetLayerStack()` for `beforeEach`).
+- Conventional Commits, scope `DismissableLayer`: `perf(DismissableLayer): …`. commitlint enforces.
+
+---
+
+## File Structure
+
+Current relevant files (verified against `v2`, HEAD `47c433a84`):
+- `packages/core/src/DismissableLayer/DismissableLayer.vue` — module-scoped `context = reactive({ layersRoot, layersWithOutsidePointerEventsDisabled, originalBodyPointerEvents, branches })` (L57-62); `index` computed via `Array.from(layers).indexOf()` (L99-103); `isPointerEventsEnabled` (L109-115, two more O(n) conversions); body-pointer-events lock `watch` (L165-196); stack membership `watch` on `[layerElement, present]` (L203-214) + safety-net cleanup (L216-223); Escape via `onKeyStroke('Escape', …)` (L144-157, one `window` listener per layer); renders `Primitive` (L226-245).
+- `packages/core/src/DismissableLayer/utils.ts` — `usePointerDownOutside` (attaches `document` `pointerdown` deferred via `setTimeout(0)` at L126-128, plus a re-armed `click` `{once}` for touch at L98-100) and `useFocusOutside` (attaches `document` `focusin` at L182); `isLayerExist` (L16-40, `querySelectorAll('[data-dismissable-layer]')` per handler call); dead `CONTEXT_UPDATE`/`dispatchUpdate` (L12,203-206).
+- `packages/core/src/DismissableLayer/DismissableLayerBranch.vue` — imports `context` from `DismissableLayer.vue` (L11), does `context.branches.add/delete` (L16-21).
+- `packages/core/src/DismissableLayer/index.ts` — family exports (internal; root barrel only re-exports the two event *types*).
+- `packages/core/src/shared/handleAndDispatchCustomEvent.ts` — dispatches the cancelable `dismissableLayer.pointerDownOutside`/`.focusOutside` CustomEvent on the target.
+- `packages/core/vite.config.ts` (test block L14-34, jsdom), `packages/core/package.json` (scripts L76-86; vitest 4.1.8).
+
+Files this plan creates/modifies:
+- **Create** `packages/core/src/DismissableLayer/layerStack.ts` — the manager + `resetLayerStack()`.
+- **Create** `packages/core/src/DismissableLayer/layerStack.test.ts` — manager unit tests.
+- **Modify** `packages/core/src/DismissableLayer/utils.ts` — reimplement the two composables as manager subscriptions; fold `isLayerExist` into a hoisted snapshot; delete dead `CONTEXT_UPDATE`/`dispatchUpdate`.
+- **Modify** `packages/core/src/DismissableLayer/DismissableLayer.vue` — remove `context` reactive + `onKeyStroke`; register a handle; keep both `watch`es' semantics; (Task 8, after #2722) swap `Primitive` → `useRender`.
+- **Modify** `packages/core/src/DismissableLayer/DismissableLayerBranch.vue` — register via `layerStack.branches`.
+- **Create** `packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts` — listener/`querySelectorAll` count regressions.
+- **Create** `packages/core/src/DismissableLayer/DismissableLayer.bench.ts` — benchmarks.
+- **Modify** `packages/core/vite.config.ts` (`benchmark.include`), `packages/core/package.json` (`"bench"` script).
+
+---
+
+## Task 1: The stack manager `layerStack.ts` (TDD, pure DOM)
+
+**Files:**
+- Create: `packages/core/src/DismissableLayer/layerStack.ts`
+- Test: `packages/core/src/DismissableLayer/layerStack.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface LayerHandle {
+    element: () => HTMLElement | undefined
+    isPresent: () => boolean
+    isPointerEventsEnabled: () => boolean
+    isPointerInside: boolean
+    isFocusInside: boolean
+    armed: boolean
+    participatesInStack: boolean // false for standalone Editable usage — excluded from Escape/top-layer accounting
+    onPointerDownOutside?: (event: PointerEvent) => void
+    onFocusOutside?: (event: FocusEvent) => void
+    onEscapeKeyDown?: (event: KeyboardEvent) => void
+  }
+  export const layers: LayerHandle[] // ordered: [0]=bottom, last=top (shallowReactive)
+  export const branches: HTMLElement[]
+  export function registerLayer(handle: LayerHandle): () => void // returns unregister
+  export function registerBranch(el: HTMLElement): () => void
+  export function isTopLayer(handle: LayerHandle): boolean
+  export function indexOfLayer(handle: LayerHandle): number
+  export function resetLayerStack(): void // test-only reset
+  ```
+- Consumes: nothing (plain module; Vue `shallowReactive` for the arrays).
+
+- [ ] **Step 1: Write the failing manager tests**
+
+```ts
+// packages/core/src/DismissableLayer/layerStack.test.ts
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isTopLayer, layers, registerLayer, resetLayerStack } from './layerStack'
+
+function makeHandle(overrides = {}) {
+  return {
+    element: () => document.body,
+    isPresent: () => true,
+    isPointerEventsEnabled: () => true,
+    isPointerInside: false,
+    isFocusInside: false,
+    armed: true,
+    participatesInStack: true,
+    ...overrides,
+  }
+}
+
+afterEach(() => resetLayerStack())
+
+describe('layerStack', () => {
+  it('installs exactly one document listener of each kind for N layers', () => {
+    const add = vi.spyOn(document, 'addEventListener')
+    registerLayer(makeHandle())
+    registerLayer(makeHandle())
+    registerLayer(makeHandle())
+    const kinds = add.mock.calls.map(c => c[0])
+    expect(kinds.filter(k => k === 'pointerdown')).toHaveLength(1)
+    expect(kinds.filter(k => k === 'focusin')).toHaveLength(1)
+    expect(kinds.filter(k => k === 'keydown')).toHaveLength(1)
+    add.mockRestore()
+  })
+
+  it('removes all document listeners when the last layer unregisters', () => {
+    const remove = vi.spyOn(document, 'removeEventListener')
+    const off1 = registerLayer(makeHandle())
+    const off2 = registerLayer(makeHandle())
+    off1()
+    expect(remove).not.toHaveBeenCalled() // still one layer left
+    off2()
+    const kinds = remove.mock.calls.map(c => c[0])
+    expect(kinds).toContain('pointerdown')
+    expect(kinds).toContain('focusin')
+    expect(kinds).toContain('keydown')
+    remove.mockRestore()
+  })
+
+  it('maintains registration order and isTopLayer', () => {
+    const a = makeHandle()
+    const b = makeHandle()
+    registerLayer(a)
+    registerLayer(b)
+    expect(layers[0]).toBe(a)
+    expect(isTopLayer(b)).toBe(true)
+    expect(isTopLayer(a)).toBe(false)
+  })
+
+  it('routes Escape only to the top present participating layer', () => {
+    const bottom = makeHandle({ onEscapeKeyDown: vi.fn() })
+    const top = makeHandle({ onEscapeKeyDown: vi.fn() })
+    registerLayer(bottom)
+    registerLayer(top)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(top.onEscapeKeyDown).toHaveBeenCalledOnce()
+    expect(bottom.onEscapeKeyDown).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer/layerStack.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the manager**
+
+Implement `layerStack.ts` with: `shallowReactive` `layers`/`branches` arrays; lazy `installListeners(doc)` on first `registerLayer` (guarded by `isClient`), `teardownListeners(doc)` when `layers.length === 0`; `handleKeyDown` finds `[...layers].reverse().find(h => h.participatesInStack && h.isPresent())` and calls its `onEscapeKeyDown` (only for `event.key === 'Escape'`); `handlePointerDown`/`handleFocusIn` fold the current `utils.ts` bodies (see Task 2) using **one** hoisted `querySelectorAll` snapshot per event and iterate `[...layers]` (snapshot — dismiss handlers mutate `layers`); `registerLayer` sets `armed=false` then `setTimeout(() => handle.armed = true, 0)` and returns an unregister that clears the timer, splices, and tears down if empty; `resetLayerStack()` clears arrays + force-removes listeners (for tests).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer/layerStack.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/DismissableLayer/layerStack.ts packages/core/src/DismissableLayer/layerStack.test.ts
+git commit -m "perf(DismissableLayer): add centralized layer stack manager"
+```
+
+---
+
+## Task 2: Migrate Escape to the manager (smallest surface first)
+
+**Files:**
+- Modify: `packages/core/src/DismissableLayer/DismissableLayer.vue`
+
+**Interfaces:**
+- Consumes: `registerLayer`, `isTopLayer` from `layerStack.ts`.
+- Produces: Escape dismissal identical to today (top present layer only; respects `defaultPrevented`).
+
+- [ ] **Step 1: Register a handle and route Escape through it**
+
+In `DismissableLayer.vue` setup: build a `LayerHandle` whose `onEscapeKeyDown` runs the **current** `onKeyStroke('Escape', …)` callback body (L144-157) — emit `escapeKeyDown`, and if not `defaultPrevented`, `dismiss`. Register in the existing membership `watch` (L203-214) replacing `layers.value.add/delete`. **Delete** the `onKeyStroke('Escape', …)` call (removes one `window` listener per layer). Keep `index`/`isPointerEventsEnabled`/body-lock as-is for now (still reading the old `context`) — this task only moves Escape.
+
+> Transitional note: during Tasks 2–4 the component briefly holds both the old `context` reactive and a manager handle. That is intentional — each task migrates one concern and keeps the suite green. The old `context` is fully removed in Task 5.
+
+- [ ] **Step 2: Run the DismissableLayer suite + add a stacking test**
+
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer`
+Add a test: two stacked layers → only the top emits `escapeKeyDown`; after dismissing the top, Escape falls through to the lower layer. Existing Escape tests must pass unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/DismissableLayer/DismissableLayer.vue
+git commit -m "perf(DismissableLayer): route Escape through the shared stack manager"
+```
+
+---
+
+## Task 3: Migrate `useFocusOutside` to a manager subscription
+
+**Files:**
+- Modify: `packages/core/src/DismissableLayer/utils.ts`
+
+**Interfaces:**
+- Consumes: `registerLayer`, `layers`, `branches`.
+- Produces: `useFocusOutside(onFocusOutside?, element?, enabled?)` — **unchanged signature**, still returns `{ onFocusCapture, onBlurCapture }`. Internally builds a minimal handle (only `onFocusOutside` + the inside flags), registers/unregisters in the same `watchEffect(enabled)`. The shared `focusin` dispatch lives in `layerStack.ts` (folded from the current `handleFocus` body at `utils.ts:162-180`, preserving the double `nextTick`).
+
+- [ ] **Step 1: Reimplement `useFocusOutside`**
+
+Move the `handleFocus` logic into the manager's `handleFocusIn`: for each handle with an `onFocusOutside`, run the current checks (target in a branch → skip; `isLayerExist`-equivalent via the hoisted snapshot → skip; `isFocusInside` flag consume) then `handleAndDispatchCustomEvent(FOCUS_OUTSIDE, handle.onFocusOutside, { originalEvent })`. The composable's returned `onFocusCapture`/`onBlurCapture` now write `handle.isFocusInside` instead of a local ref.
+
+- [ ] **Step 2: Run focus tests + Editable**
+
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer src/Editable`
+Expected: existing focus-outside tests (`DismissableLayer.test.ts:178-193`) and Editable focus tests pass unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/DismissableLayer/utils.ts packages/core/src/DismissableLayer/layerStack.ts
+git commit -m "perf(DismissableLayer): route focusOutside through the shared manager"
+```
+
+---
+
+## Task 4: Migrate `usePointerDownOutside` (incl. touch-click deferral + arming)
+
+**Files:**
+- Modify: `packages/core/src/DismissableLayer/utils.ts`, `packages/core/src/DismissableLayer/layerStack.ts`
+
+**Interfaces:**
+- Consumes: manager pointerdown dispatch.
+- Produces: `usePointerDownOutside(onPointerDownOutside?, element?, enabled?)` — unchanged signature, returns `{ onPointerDownCapture }`. The `setTimeout(0)` self-dismiss guard becomes the per-handle `armed` flag; the touch `click` `{once:true}` deferral becomes **one shared** re-armed slot in the manager.
+
+- [ ] **Step 1: Fold `handlePointerDown` into the manager**
+
+In `layerStack.ts` `handlePointerDown`: hoist **one** `querySelectorAll('[data-dismissable-layer]')` snapshot + `target.closest(...)` + `branches.some(...)` per event. For each `[...layers]` handle with `onPointerDownOutside`: skip if `!handle.armed`; consume `handle.isPointerInside`; apply the `isLayerExist`-equivalent DOM-order check against the snapshot (preserving the `mainLayer` fallback for non-`data-dismissable-layer` elements like Editable); for touch (`pointerType === 'touch'`), defer to a single shared `click` `{once:true}` handler (re-armed/cleared with today's rules); else `nextTick()` then `handleAndDispatchCustomEvent(POINTER_DOWN_OUTSIDE, handle.onPointerDownOutside, …)`. Delete the per-layer `document.addEventListener('pointerdown', …)` and the dead `CONTEXT_UPDATE`/`dispatchUpdate`.
+
+- [ ] **Step 2: Run the full DismissableLayer suite (incl. #2674)**
+
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer`
+Expected: all pass unchanged, including the touch-deferral and #2674 `disableOutsidePointerEvents` cases.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/DismissableLayer/utils.ts packages/core/src/DismissableLayer/layerStack.ts
+git commit -m "perf(DismissableLayer): route pointerDownOutside through the shared manager"
+```
+
+---
+
+## Task 5: Remove the reactive `context`; move branches + body-lock to the manager
+
+**Files:**
+- Modify: `packages/core/src/DismissableLayer/DismissableLayer.vue`, `packages/core/src/DismissableLayer/DismissableLayerBranch.vue`
+
+**Interfaces:**
+- Consumes: `layers`, `branches`, `layersWithOutsidePointerEventsDisabled` from the manager.
+- Produces: `index`/`isPointerEventsEnabled`/`isBodyPointerEventsDisabled` read the manager arrays with array `indexOf` (no `Array.from`); body-pointer-events lock keeps the exact #2674 formulas + comments; `DismissableLayerBranch` registers via `registerBranch`.
+
+- [ ] **Step 1: Replace `context` reads**
+
+Delete the module `context = reactive({...})`. Rewrite `index` as `indexOfLayer(handle)`; `isPointerEventsEnabled` using `layersWithOutsidePointerEventsDisabled` (array). Port the body-lock `watch` (L165-196) verbatim except array-backed, keeping comments L159-164/176-183 and the size-0-after-delete restore (#2674). Make `originalBodyPointerEvents` a manager field (or keep local — but preserve single-restore semantics).
+
+- [ ] **Step 2: Migrate the Branch**
+
+`DismissableLayerBranch.vue`: replace `import { context } from './DismissableLayer.vue'` + `context.branches.add/delete` with `registerBranch(currentElement.value)` in `onMounted`/unregister in `onUnmounted`.
+
+- [ ] **Step 3: Run DismissableLayer + Toast (branch consumer) + broad overlay sweep**
+
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer src/Toast src/Dialog src/Menu src/Popover src/Select src/Combobox src/Tooltip src/HoverCard src/NavigationMenu src/Drawer src/Editable`
+Expected: all pass unchanged.
+
+- [ ] **Step 4: Type-check + commit**
+
+```bash
+pnpm --filter reka-ui type-check
+git add packages/core/src/DismissableLayer/DismissableLayer.vue packages/core/src/DismissableLayer/DismissableLayerBranch.vue packages/core/src/DismissableLayer/layerStack.ts
+git commit -m "perf(DismissableLayer): remove reactive context in favor of the stack manager"
+```
+
+---
+
+## Task 6: Listener/query-count regression tests
+
+**Files:**
+- Create: `packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts`
+
+- [ ] **Step 1: Write the count-regression tests**
+
+```ts
+// packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts
+import { describe, expect, it, vi } from 'vitest'
+// mount N DismissableLayers (open) via a fixture, then assert:
+describe('DismissableLayer listener consolidation', () => {
+  it('registers exactly one document pointerdown/focusin/keydown for many layers', () => {
+    const add = vi.spyOn(document, 'addEventListener')
+    // mount 10 open layers
+    const kinds = add.mock.calls.map(c => c[0])
+    expect(kinds.filter(k => k === 'pointerdown')).toHaveLength(1)
+    expect(kinds.filter(k => k === 'focusin')).toHaveLength(1)
+    expect(kinds.filter(k => k === 'keydown')).toHaveLength(1)
+    add.mockRestore()
+  })
+  it('runs querySelectorAll once per outside pointerdown regardless of layer count', () => {
+    const qsa = vi.spyOn(document, 'querySelectorAll')
+    // mount 5 open layers, dispatch one outside pointerdown
+    // assert qsa called once for '[data-dismissable-layer]'
+    qsa.mockRestore()
+  })
+  it('removes all document listeners after every layer unmounts', () => {})
+})
+```
+
+Fill fixture bodies using `@vue/test-utils` `mount` of a small wrapper rendering N `DismissableLayer`s. Reset the manager in `beforeEach`.
+
+- [ ] **Step 2: Run + commit**
+
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer/DismissableLayer.listeners.test.ts`
+
+```bash
+git add packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts
+git commit -m "test(DismissableLayer): assert single shared listener + one query per event"
+```
+
+---
+
+## Task 7: Benchmarks
+
+**Files:**
+- Create: `packages/core/src/DismissableLayer/DismissableLayer.bench.ts`
+- Modify: `packages/core/vite.config.ts`, `packages/core/package.json`
+
+- [ ] **Step 1: Add the bench config + script**
+
+In `packages/core/vite.config.ts` `test` block add `benchmark: { include: ['./**/*.bench.{ts,js}'] }`. In `packages/core/package.json` scripts add `"bench": "vitest bench --run"`.
+
+- [ ] **Step 2: Write the benchmarks**
+
+```ts
+// packages/core/src/DismissableLayer/DismissableLayer.bench.ts
+import { bench, describe } from 'vitest'
+
+describe('DismissableLayer', () => {
+  bench('mount + unmount 50 stacked layers', () => { /* mount 50, unmount */ })
+  bench('100 outside pointerdowns against 20 open layers', () => { /* dispatch loop */ })
+  bench('Escape dispatch against 20 open layers', () => { /* dispatch keydown */ })
+})
+```
+
+- [ ] **Step 3: Run + record numbers in the PR body**
+
+Run: `pnpm --filter reka-ui bench`
+Capture the before/after (run once on `v2`, once on this branch) in the PR description.
+
+- [ ] **Step 4: Add a render-count assertion (plain test)**
+
+An `onUpdated`-counter child inside one layer while sibling layers mount/unmount — assert the counter does not increment (proves the reactive-Set churn is gone). Add to the listeners test file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/DismissableLayer/DismissableLayer.bench.ts packages/core/vite.config.ts packages/core/package.json
+git commit -m "perf(DismissableLayer): add overlay interaction + render benchmarks"
+```
+
+---
+
+## Task 8: (Depends on #2722) Remove the wrapper render instance via `useRender`
+
+**Files:**
+- Modify: `packages/core/src/DismissableLayer/DismissableLayer.vue`, `packages/core/src/DismissableLayer/DismissableLayerBranch.vue`
+
+> **Blocked on #2722.** Do not start until `useRender` is merged. Everything above lands independently.
+
+- [ ] **Step 1: Swap `Primitive` for `useRender`**
+
+Replace `<Primitive :ref="forwardRef" v-bind="...">` with `<component :is="tag" v-bind="renderProps" :ref="elementRef">`, moving the current bound attributes (incl. `style.pointerEvents` from `isBodyPointerEventsDisabled`/`isPointerEventsEnabled`) into the `props`/`state` passed to `useRender`. Removes one component instance per overlay part.
+
+- [ ] **Step 2: Full suite + render-count assertion**
+
+Run: `pnpm --filter reka-ui exec vitest run src/DismissableLayer` and the consumer sweep from Task 5.
+Add a render-count assertion showing one fewer instance in the overlay chain.
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm --filter reka-ui type-check
+git add packages/core/src/DismissableLayer/DismissableLayer.vue packages/core/src/DismissableLayer/DismissableLayerBranch.vue
+git commit -m "perf(DismissableLayer): render via useRender, dropping the Primitive wrapper"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** "single shared listener + one centralized stack manager" → Tasks 1–5; "remove wrapper render overhead via useRender" → Task 8; "measurable reductions" → Tasks 6 (counts) + 7 (benchmarks). Covered.
+- **Semantics preserved:** top-only Escape (Task 2), all-qualifying-layers pointer/focus outside (Tasks 3–4), `disableOutsidePointerEvents` body lock + #2674 comments (Task 5), branches (Task 5), touch-click deferral + `setTimeout(0)` arming (Task 4), custom-event `preventDefault` path (unchanged — reuses `handleAndDispatchCustomEvent`).
+- **Type consistency:** `LayerHandle` fields (`armed`, `isPointerInside`, `isFocusInside`, `participatesInStack`, `onPointerDownOutside`/`onFocusOutside`/`onEscapeKeyDown`) used identically across Tasks 1–5. `registerLayer`/`registerBranch`/`isTopLayer`/`resetLayerStack` names stable.
+- **Signature freeze:** `usePointerDownOutside`/`useFocusOutside` `(handler?, element?, enabled?)` unchanged (Tasks 3–4) — Editable compiles untouched.
+
+## Risks / Gotchas
+
+1. **Capture vs bubble** — keep the shared `pointerdown`/`focusin` on **bubble** phase (element guards are capture); moving to capture breaks inside-detection for portal'd content that relies on the flags, not DOM containment.
+2. **Handler order** — iterate a `[...layers]` snapshot in registration order (matches today); dismiss handlers unregister mid-dispatch.
+3. **Stack order ≠ DOM order** — Escape uses presence/registration order; outside-detection uses DOM (`querySelectorAll`) order. Preserve both independently; don't unify.
+4. **`setTimeout(0)` arming** — the per-handle `armed` flag is load-bearing (mount-via-pointerdown self-dismiss guard, `utils.ts:113-125`).
+5. **`ownerDocument`** — today effectively always `globalThis.document` (captured before the element ref exists); match that as parity; a per-`Document` listener map is the correct generalization but out of scope here (overlaps #2725).
+6. **SSR** — no `document` at import; install listeners lazily on first `registerLayer`, `isClient`-gated.
+7. **Teardown** — last-layer teardown must also clear the shared touch-`click` deferred listener and any arming timers; keep an equivalent of the safety-net cleanup (`DismissableLayer.vue:216-223`) for `forwardRef` element swaps.
+8. **Reactive granularity** — `shallowReactive` arrays: `isPointerEventsEnabled`'s style binding must still update on other layers registering, but the #2674 body-lock `watch` must NOT become reactive to membership churn (see comments L159-164).
+9. **Test isolation** — the module singleton persists across vitest files in a worker; `resetLayerStack()` in `beforeEach` or listener-count assertions flake.
+10. **#2722 dependency** — only Task 8 needs `useRender`; land Tasks 1–7 first.
+
+## Execution Handoff
+
+Recommended: **Subagent-Driven** (superpowers:subagent-driven-development). Task 1 (pure manager) is a clean isolated unit; Tasks 2–5 migrate one concern each with the full suite as the gate (highest scrutiny on Task 5's #2674 body-lock port); Tasks 6–7 quantify; Task 8 waits on #2722. Run the consumer sweep after Tasks 5 and 8.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,6 +81,7 @@
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "test-update": "vitest -u",
+    "bench": "vitest bench --run",
     "pub:release": "npm publish --access public --provenance",
     "size": "size-limit"
   },

--- a/packages/core/src/DismissableLayer/DismissableLayer.bench.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.bench.ts
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils'
+import { bench, describe } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { DismissableLayer as DismissableLayerPrimitive } from '.'
+import { resetLayerStack } from './layerStack'
+
+// NOTE: jsdom benchmarks measure JS-only cost (no layout/paint) and are
+// DIRECTIONAL. The definitive proof of the listener consolidation is the
+// structural assertion in `DismissableLayer.listeners.test.ts` (one shared
+// document listener + one `querySelectorAll` per event, independent of layer
+// count). Render count is unchanged (parity), not reduced — under Vue >= 3.4
+// an open layer does not re-render on sibling membership churn either way.
+//
+// Run: `pnpm --filter reka-ui bench`
+
+function mountLayers(n: number) {
+  return mount(defineComponent({
+    setup() {
+      return () => h('div', Array.from({ length: n }, (_, i) => h(DismissableLayerPrimitive, { key: i, present: true })))
+    },
+  }), { attachTo: document.body })
+}
+
+describe('dismissableLayer', () => {
+  bench('mount + unmount 50 stacked layers', () => {
+    resetLayerStack()
+    const wrapper = mountLayers(50)
+    wrapper.unmount()
+  })
+
+  bench('mount 20 layers + one outside pointerdown + unmount', () => {
+    resetLayerStack()
+    const wrapper = mountLayers(20)
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    outside.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    outside.remove()
+    wrapper.unmount()
+  })
+
+  bench('escape dispatch against 20 open layers', () => {
+    resetLayerStack()
+    const wrapper = mountLayers(20)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    wrapper.unmount()
+  })
+})

--- a/packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts
@@ -1,0 +1,62 @@
+import { fireEvent } from '@testing-library/vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { DismissableLayer as DismissableLayerPrimitive } from '.'
+import { resetLayerStack } from './layerStack'
+
+beforeEach(() => {
+  resetLayerStack()
+  document.body.innerHTML = ''
+})
+afterEach(() => resetLayerStack())
+
+function mountLayers(n: number) {
+  return mount(defineComponent({
+    setup() {
+      return () => h('div', Array.from({ length: n }, (_, i) => h(DismissableLayerPrimitive, { key: i, present: true })))
+    },
+  }), { attachTo: document.body })
+}
+
+function count(spy: ReturnType<typeof vi.spyOn>, kind: string) {
+  return spy.mock.calls.filter(c => c[0] === kind).length
+}
+
+describe('dismissableLayer listener consolidation', () => {
+  it('adds exactly one shared document pointerdown/focusin + one window keydown for many layers', () => {
+    const add = vi.spyOn(document, 'addEventListener')
+    const winAdd = vi.spyOn(window, 'addEventListener')
+    const wrapper = mountLayers(10)
+    expect(count(add, 'pointerdown')).toBe(1)
+    expect(count(add, 'focusin')).toBe(1)
+    expect(count(winAdd, 'keydown')).toBe(1)
+    add.mockRestore()
+    winAdd.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('runs querySelectorAll once per outside pointerdown regardless of layer count', async () => {
+    const wrapper = mountLayers(5)
+    await new Promise(r => setTimeout(r, 0)) // let the subscribers arm
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    const qsa = vi.spyOn(document, 'querySelectorAll')
+    await fireEvent.pointerDown(outside)
+    expect(count(qsa as any, '[data-dismissable-layer]')).toBe(1)
+    qsa.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('removes all shared listeners after every layer unmounts', () => {
+    const remove = vi.spyOn(document, 'removeEventListener')
+    const winRemove = vi.spyOn(window, 'removeEventListener')
+    const wrapper = mountLayers(3)
+    wrapper.unmount()
+    expect(count(remove, 'pointerdown')).toBe(1)
+    expect(count(remove, 'focusin')).toBe(1)
+    expect(count(winRemove, 'keydown')).toBe(1)
+    remove.mockRestore()
+    winRemove.mockRestore()
+  })
+})

--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { sleep } from '@/test'
 import { DismissableLayer as DismissableLayerPrimitive } from '.'
+import { resetLayerStack } from './layerStack'
 import DismissableLayer from './story/_DismissableLayer.vue'
 import { isLayerExist } from './utils'
 
@@ -280,5 +281,31 @@ describe('given a not-present DismissableLayer (e.g. unmountOnHide hidden)', () 
 
     expect(wrapper.emitted('escapeKeyDown')?.length).toBe(1)
     expect(wrapper.emitted('dismiss')?.length).toBe(1)
+  })
+})
+
+describe('stacked layers Escape routing', () => {
+  beforeEach(() => {
+    resetLayerStack()
+    document.body.innerHTML = ''
+  })
+
+  it('routes Escape to the top present layer, then falls through after it dismisses', async () => {
+    const bottom = mount(DismissableLayerPrimitive, { attachTo: document.body, props: { present: true } })
+    const top = mount(DismissableLayerPrimitive, { attachTo: document.body, props: { present: true } })
+    await nextTick()
+
+    await fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(top.emitted('escapeKeyDown')?.length).toBe(1)
+    expect(bottom.emitted('escapeKeyDown')).toBeUndefined()
+
+    // Top layer closes → leaves the stack; Escape now targets the lower layer.
+    top.unmount()
+    await nextTick()
+
+    await fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(bottom.emitted('escapeKeyDown')?.length).toBe(1)
+
+    bottom.unmount()
   })
 })

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -63,10 +63,11 @@ export const context = reactive({
 </script>
 
 <script setup lang="ts">
-import { onKeyStroke } from '@vueuse/core'
+import type { StackLayer } from './layerStack'
 import {
   Primitive,
 } from '@/Primitive'
+import { registerStackLayer } from './layerStack'
 import {
   useFocusOutside,
   usePointerDownOutside,
@@ -141,20 +142,20 @@ const focusOutside = useFocusOutside((event) => {
     emits('dismiss')
 }, layerElement)
 
-onKeyStroke('Escape', (event) => {
-  // A layer that stays mounted while hidden (e.g. a Dialog with
-  // `unmountOnHide: false`) is out of the layer stack, so its `index` is `-1`.
-  // When no layer is visible (`size === 0`), `-1 === size - 1` would otherwise
-  // make it look like the highest layer and emit `escapeKeyDown` / `dismiss`.
-  if (!props.present)
-    return
-  const isHighestLayer = index.value === layers.value.size - 1
-  if (!isHighestLayer)
-    return
-  emits('escapeKeyDown', event)
-  if (!event.defaultPrevented)
-    emits('dismiss')
-})
+// Participation in the shared stack manager. The manager routes Escape to the
+// top *present* layer only (replacing the per-layer `window` keydown listener),
+// so `onEscapeKeyDown` here just carries the emit + dismiss. Membership is driven
+// by the presence watch below.
+const stackLayer: StackLayer = {
+  element: () => layerElement.value,
+  isPresent: () => props.present,
+  disableOutsidePointerEvents: () => props.disableOutsidePointerEvents,
+  onEscapeKeyDown: (event) => {
+    emits('escapeKeyDown', event)
+    if (!event.defaultPrevented)
+      emits('dismiss')
+  },
+}
 
 // Use `watch` with explicit sources (instead of `watchEffect`) so this effect
 // only re-runs when `layerElement` or `disableOutsidePointerEvents` change.
@@ -206,8 +207,10 @@ watch(
     if (!element || !present)
       return
     layers.value.add(element)
+    const unregisterStackLayer = registerStackLayer(stackLayer)
     onCleanup(() => {
       layers.value.delete(element)
+      unregisterStackLayer()
     })
   },
   { immediate: true },

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -8,11 +8,9 @@ import type { PrimitiveProps } from '@/Primitive'
 import {
   computed,
   nextTick,
-  reactive,
   watch,
-  watchEffect,
 } from 'vue'
-import { isNullish, useForwardExpose } from '@/shared'
+import { useForwardExpose } from '@/shared'
 
 export interface DismissableLayerProps extends PrimitiveProps {
   /**
@@ -53,13 +51,6 @@ export type DismissableLayerPrivateEmits = DismissableLayerEmits & {
    */
   dismiss: []
 }
-
-export const context = reactive({
-  layersRoot: new Set<HTMLElement>(),
-  layersWithOutsidePointerEventsDisabled: new Set<HTMLElement>(),
-  originalBodyPointerEvents: undefined as string | undefined,
-  branches: new Set<HTMLElement>(),
-})
 </script>
 
 <script setup lang="ts">
@@ -67,7 +58,14 @@ import type { StackLayer } from './layerStack'
 import {
   Primitive,
 } from '@/Primitive'
-import { registerStackLayer } from './layerStack'
+import {
+  acquireBodyPointerEventsLock,
+  branches,
+  highestDisabledIndex,
+  indexOfLayer,
+  registerStackLayer,
+  releaseBodyPointerEventsLock,
+} from './layerStack'
 import {
   useFocusOutside,
   usePointerDownOutside,
@@ -95,53 +93,6 @@ const ownerDocument = computed(
   () => layerElement.value?.ownerDocument ?? globalThis.document,
 )
 
-const layers = computed(() => context.layersRoot)
-
-const index = computed(() => {
-  return layerElement.value
-    ? Array.from(layers.value).indexOf(layerElement.value)
-    : -1
-})
-
-const isBodyPointerEventsDisabled = computed(() => {
-  return context.layersWithOutsidePointerEventsDisabled.size > 0
-})
-
-const isPointerEventsEnabled = computed(() => {
-  const localLayers = Array.from(layers.value)
-  const [highestLayerWithOutsidePointerEventsDisabled] = [...context.layersWithOutsidePointerEventsDisabled].slice(-1)
-  const highestLayerWithOutsidePointerEventsDisabledIndex = localLayers.indexOf(highestLayerWithOutsidePointerEventsDisabled)
-
-  return index.value >= highestLayerWithOutsidePointerEventsDisabledIndex
-})
-
-const pointerDownOutside = usePointerDownOutside(async (event) => {
-  const isPointerDownOnBranch = [...context.branches].some(branch =>
-    branch?.contains(event.target as HTMLElement),
-  )
-
-  if (!props.present || !isPointerEventsEnabled.value || isPointerDownOnBranch)
-    return
-  emits('pointerDownOutside', event)
-  emits('interactOutside', event)
-  await nextTick()
-  if (!event.defaultPrevented)
-    emits('dismiss')
-}, layerElement)
-
-const focusOutside = useFocusOutside((event) => {
-  const isFocusInBranch = [...context.branches].some(branch =>
-    branch?.contains(event.target as HTMLElement),
-  )
-
-  if (!props.present || isFocusInBranch)
-    return
-  emits('focusOutside', event)
-  emits('interactOutside', event)
-  if (!event.defaultPrevented)
-    emits('dismiss')
-}, layerElement)
-
 // Participation in the shared stack manager. The manager routes Escape to the
 // top *present* layer only (replacing the per-layer `window` keydown listener),
 // so `onEscapeKeyDown` here just carries the emit + dismiss. Membership is driven
@@ -157,40 +108,55 @@ const stackLayer: StackLayer = {
   },
 }
 
-// Use `watch` with explicit sources (instead of `watchEffect`) so this effect
-// only re-runs when `layerElement` or `disableOutsidePointerEvents` change.
-// Reading `context.layersWithOutsidePointerEventsDisabled.size` inside the
-// callback must NOT make it reactive: otherwise adding/removing any other
-// layer would re-run this effect and its cleanup could prematurely restore the
-// body's `pointer-events` while an ancestor layer is still open (#2674).
+// Read from the shared manager (array `indexOf`, no per-read `Array.from`).
+// `-1` when this layer is not in the stack (not present) — same as before.
+const index = computed(() => indexOfLayer(stackLayer))
+
+const isBodyPointerEventsDisabled = computed(() => highestDisabledIndex() >= 0)
+
+const isPointerEventsEnabled = computed(() => index.value >= highestDisabledIndex())
+
+const pointerDownOutside = usePointerDownOutside(async (event) => {
+  const isPointerDownOnBranch = [...branches].some(branch =>
+    branch?.contains(event.target as HTMLElement),
+  )
+
+  if (!props.present || !isPointerEventsEnabled.value || isPointerDownOnBranch)
+    return
+  emits('pointerDownOutside', event)
+  emits('interactOutside', event)
+  await nextTick()
+  if (!event.defaultPrevented)
+    emits('dismiss')
+}, layerElement)
+
+const focusOutside = useFocusOutside((event) => {
+  const isFocusInBranch = [...branches].some(branch =>
+    branch?.contains(event.target as HTMLElement),
+  )
+
+  if (!props.present || isFocusInBranch)
+    return
+  emits('focusOutside', event)
+  emits('interactOutside', event)
+  if (!event.defaultPrevented)
+    emits('dismiss')
+}, layerElement)
+
+// Body pointer-events lock (#2674). `watch` with explicit sources (not
+// `watchEffect`) so it re-runs only when this layer's `element` /
+// `disableOutsidePointerEvents` / `present` change — never on other layers'
+// membership churn. The manager reference-counts across layers (first disabling
+// layer sets `none`, last restores), so the cleanup here (prop toggle or
+// unmount) is order-independent (#2674).
 watch(
   [layerElement, () => props.disableOutsidePointerEvents, () => props.present],
   ([element, disableOutsidePointerEvents, present], _, onCleanup) => {
     if (!element || !present)
       return
     if (disableOutsidePointerEvents) {
-      if (context.layersWithOutsidePointerEventsDisabled.size === 0) {
-        context.originalBodyPointerEvents = ownerDocument.value.body.style.pointerEvents
-        ownerDocument.value.body.style.pointerEvents = 'none'
-      }
-      context.layersWithOutsidePointerEventsDisabled.add(element)
-
-      // Remove this layer from the set on cleanup (re-run via prop toggle, or
-      // unmount) and restore the body's `pointer-events` only once the last
-      // disabling layer is gone. Removing here — rather than relying solely on
-      // the unmount-only effect below — keeps the set accurate when
-      // `disableOutsidePointerEvents` toggles `true -> false` while still
-      // mounted (e.g. a modal Menu closing). Checking `size === 0` *after*
-      // deletion makes the restore independent of cleanup ordering (#2674).
-      onCleanup(() => {
-        context.layersWithOutsidePointerEventsDisabled.delete(element)
-        if (
-          context.layersWithOutsidePointerEventsDisabled.size === 0
-          && !isNullish(context.originalBodyPointerEvents)
-        ) {
-          ownerDocument.value.body.style.pointerEvents = context.originalBodyPointerEvents
-        }
-      })
+      acquireBodyPointerEventsLock(ownerDocument.value)
+      onCleanup(() => releaseBodyPointerEventsLock(ownerDocument.value))
     }
   },
   { immediate: true },
@@ -206,24 +172,13 @@ watch(
   ([element, present], _, onCleanup) => {
     if (!element || !present)
       return
-    layers.value.add(element)
-    const unregisterStackLayer = registerStackLayer(stackLayer)
-    onCleanup(() => {
-      layers.value.delete(element)
-      unregisterStackLayer()
-    })
+    // `registerStackLayer`'s unregister (fired on prop toggle or unmount) is the
+    // sole stack-membership cleanup — no separate unmount safety-net needed, as
+    // this watch already keys on `layerElement` (handles forwardRef swaps).
+    onCleanup(registerStackLayer(stackLayer))
   },
   { immediate: true },
 )
-
-watchEffect((cleanupFn) => {
-  cleanupFn(() => {
-    if (!layerElement.value)
-      return
-    layers.value.delete(layerElement.value)
-    context.layersWithOutsidePointerEventsDisabled.delete(layerElement.value)
-  })
-})
 </script>
 
 <template>

--- a/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
@@ -8,16 +8,18 @@ export interface DismissableLayerBranchProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { onMounted, onUnmounted } from 'vue'
 import { Primitive } from '@/Primitive'
-import { context } from './DismissableLayer.vue'
+import { registerBranch } from './layerStack'
 
 const props = defineProps<DismissableLayerBranchProps>()
 
 const { forwardRef, currentElement } = useForwardExpose()
+let unregisterBranch: (() => void) | undefined
 onMounted(() => {
-  context.branches.add(currentElement.value)
+  if (currentElement.value)
+    unregisterBranch = registerBranch(currentElement.value)
 })
 onUnmounted(() => {
-  context.branches.delete(currentElement.value)
+  unregisterBranch?.()
 })
 </script>
 

--- a/packages/core/src/DismissableLayer/layerStack.test.ts
+++ b/packages/core/src/DismissableLayer/layerStack.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isTopLayer, layers, registerOutsideSubscriber, registerStackLayer, resetLayerStack } from './layerStack'
+
+afterEach(() => resetLayerStack())
+
+function stackLayer(over = {}) {
+  return { element: () => document.body, isPresent: () => true, disableOutsidePointerEvents: () => false, ...over }
+}
+function subscriber(over = {}) {
+  return { armed: true, isPointerInside: false, isFocusInside: false, ...over }
+}
+
+describe('layerStack', () => {
+  it('installs one pointerdown/focusin while subscribers exist and one keydown while stack layers exist', () => {
+    const add = vi.spyOn(document, 'addEventListener')
+    const winAdd = vi.spyOn(window, 'addEventListener')
+    registerStackLayer(stackLayer())
+    registerOutsideSubscriber(subscriber())
+    registerOutsideSubscriber(subscriber())
+    expect(add.mock.calls.filter(c => c[0] === 'pointerdown')).toHaveLength(1)
+    expect(add.mock.calls.filter(c => c[0] === 'focusin')).toHaveLength(1)
+    expect(winAdd.mock.calls.filter(c => c[0] === 'keydown')).toHaveLength(1)
+    add.mockRestore()
+    winAdd.mockRestore()
+  })
+
+  it('an Editable-like subscriber (no stack layer) installs NO keydown listener', () => {
+    const winAdd = vi.spyOn(window, 'addEventListener')
+    registerOutsideSubscriber(subscriber())
+    expect(winAdd.mock.calls.filter(c => c[0] === 'keydown')).toHaveLength(0)
+    winAdd.mockRestore()
+  })
+
+  it('removes the pointerdown/focusin listeners when the last subscriber unregisters', () => {
+    const remove = vi.spyOn(document, 'removeEventListener')
+    const off1 = registerOutsideSubscriber(subscriber())
+    const off2 = registerOutsideSubscriber(subscriber())
+    off1()
+    expect(remove.mock.calls.filter(c => c[0] === 'pointerdown')).toHaveLength(0) // one left
+    off2()
+    expect(remove.mock.calls.filter(c => c[0] === 'pointerdown')).toHaveLength(1)
+    remove.mockRestore()
+  })
+
+  it('maintains stack order and isTopLayer', () => {
+    const a = stackLayer()
+    const b = stackLayer()
+    registerStackLayer(a)
+    registerStackLayer(b)
+    expect(layers[0]).toBe(a)
+    expect(isTopLayer(b)).toBe(true)
+    expect(isTopLayer(a)).toBe(false)
+  })
+
+  it('routes Escape only to the top present stack layer', () => {
+    const bottom = stackLayer({ onEscapeKeyDown: vi.fn() })
+    const top = stackLayer({ onEscapeKeyDown: vi.fn() })
+    registerStackLayer(bottom)
+    registerStackLayer(top)
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(top.onEscapeKeyDown).toHaveBeenCalledOnce()
+    expect(bottom.onEscapeKeyDown).not.toHaveBeenCalled()
+  })
+
+  it('arms a freshly-registered subscriber a macrotask later', async () => {
+    const sub = subscriber({ armed: false })
+    registerOutsideSubscriber(sub)
+    expect(sub.armed).toBe(false)
+    await new Promise(r => setTimeout(r, 0))
+    expect(sub.armed).toBe(true)
+  })
+})

--- a/packages/core/src/DismissableLayer/layerStack.ts
+++ b/packages/core/src/DismissableLayer/layerStack.ts
@@ -1,0 +1,237 @@
+import { isClient } from '@vueuse/shared'
+import { shallowReactive } from 'vue'
+
+/**
+ * Centralized DismissableLayer stack manager (transport only).
+ *
+ * Two separate registries model two populations with different lifetimes:
+ * - `layers` — the ordered participation stack, driven by each layer's
+ *   presence-based membership watch. Sole source for Escape routing, indexing,
+ *   and pointer-events accounting.
+ * - `outsideSubscribers` — pointer/focus dispatch targets, driven by each
+ *   composable's `watchEffect(enabled)` (setup lifetime for DismissableLayer,
+ *   `isEditing` lifetime for Editable). Never affect Escape/index accounting.
+ *
+ * The manager owns exactly one shared listener of each kind (installed lazily,
+ * torn down when its driving registry empties), the per-event query snapshot,
+ * arming, and the touch-click deferral. It does NOT re-implement dismissal
+ * logic — each composable ports its `handlePointerDown`/`handleFocus` body into
+ * a subscriber closure invoked here with a `DispatchContext`.
+ */
+
+export interface StackLayer {
+  element: () => HTMLElement | undefined
+  isPresent: () => boolean
+  disableOutsidePointerEvents: () => boolean
+  onEscapeKeyDown?: (event: KeyboardEvent) => void
+}
+
+export interface DispatchContext {
+  /** Composed (shadow-safe) event target, captured synchronously before any await. */
+  target: EventTarget | null
+  /** One hoisted `querySelectorAll('[data-dismissable-layer]')` per event. */
+  nodeList: Element[]
+  /** O(1) document-order index of a layer element within `nodeList` (-1 if absent). */
+  layerIndex: (el: Element) => number
+  branches: HTMLElement[]
+  /** Touch: defer this subscriber's dispatch to the next `click` (replaces = re-arm). */
+  deferTouch: (sub: OutsideSubscriber, dispatch: () => void) => void
+  /** Touch: cancel a pending deferred dispatch for this subscriber. */
+  cancelTouch: (sub: OutsideSubscriber) => void
+}
+
+export interface OutsideSubscriber {
+  /** false until a macrotask after registration (mount-via-pointerdown guard). */
+  armed: boolean
+  isPointerInside: boolean
+  isFocusInside: boolean
+  handlePointerDown?: (event: PointerEvent, ctx: DispatchContext) => void
+  handleFocus?: (event: FocusEvent, ctx: DispatchContext) => void
+}
+
+/** Ordered: [0] = bottom, last = top. `shallowReactive` so consumer computeds track membership. */
+export const layers = shallowReactive<StackLayer[]>([])
+export const outsideSubscribers = shallowReactive<OutsideSubscriber[]>([])
+export const branches = shallowReactive<HTMLElement[]>([])
+
+/**
+ * Saved `document.body.style.pointerEvents` from before the first disabling
+ * layer. Shared (not component-local) so layer B's cleanup can restore the
+ * value layer A saved after A unmounts (#2674).
+ */
+export const bodyPointerEvents = { original: undefined as string | undefined }
+
+// --- shared listener bookkeeping ---
+let outsideListenersInstalled = false
+let keydownListenerInstalled = false
+let touchClickInstalled = false
+const pendingTouch = new Map<OutsideSubscriber, () => void>()
+
+function installOutsideListeners() {
+  if (outsideListenersInstalled || !isClient)
+    return
+  outsideListenersInstalled = true
+  document.addEventListener('pointerdown', handlePointerDown)
+  document.addEventListener('focusin', handleFocusIn)
+}
+function teardownOutsideListeners() {
+  if (!outsideListenersInstalled)
+    return
+  outsideListenersInstalled = false
+  document.removeEventListener('pointerdown', handlePointerDown)
+  document.removeEventListener('focusin', handleFocusIn)
+  removeTouchClick()
+}
+function installKeydownListener() {
+  if (keydownListenerInstalled || !isClient)
+    return
+  keydownListenerInstalled = true
+  window.addEventListener('keydown', handleKeyDown)
+}
+function teardownKeydownListener() {
+  if (!keydownListenerInstalled)
+    return
+  keydownListenerInstalled = false
+  window.removeEventListener('keydown', handleKeyDown)
+}
+
+// --- touch-click deferral (one shared listener while the map is non-empty) ---
+function ensureTouchClick() {
+  if (touchClickInstalled || !isClient)
+    return
+  touchClickInstalled = true
+  document.addEventListener('click', handleTouchClick)
+}
+function removeTouchClick() {
+  if (!touchClickInstalled)
+    return
+  touchClickInstalled = false
+  document.removeEventListener('click', handleTouchClick)
+}
+function handleTouchClick() {
+  const dispatches = [...pendingTouch.values()]
+  pendingTouch.clear()
+  removeTouchClick()
+  for (const dispatch of dispatches)
+    dispatch()
+}
+function deferTouch(sub: OutsideSubscriber, dispatch: () => void) {
+  pendingTouch.set(sub, dispatch) // replace = re-arm
+  ensureTouchClick()
+}
+function cancelTouch(sub: OutsideSubscriber) {
+  pendingTouch.delete(sub)
+  if (pendingTouch.size === 0)
+    removeTouchClick()
+}
+
+// --- dispatch ---
+function buildContext(event: Event): DispatchContext {
+  const target = (event.composedPath?.()[0] ?? event.target) as EventTarget | null
+  const nodeList = isClient
+    ? Array.from(document.querySelectorAll('[data-dismissable-layer]'))
+    : []
+  const indexMap = new Map<Element, number>()
+  nodeList.forEach((el, i) => indexMap.set(el, i))
+  return {
+    target,
+    nodeList,
+    layerIndex: el => indexMap.get(el) ?? -1,
+    branches,
+    deferTouch,
+    cancelTouch,
+  }
+}
+
+function handlePointerDown(event: PointerEvent) {
+  const ctx = buildContext(event)
+  // Snapshot: a dispatch may unregister subscribers mid-iteration.
+  for (const sub of [...outsideSubscribers])
+    sub.handlePointerDown?.(event, ctx)
+}
+
+function handleFocusIn(event: FocusEvent) {
+  const ctx = buildContext(event)
+  for (const sub of [...outsideSubscribers])
+    sub.handleFocus?.(event, ctx)
+}
+
+function handleKeyDown(event: KeyboardEvent) {
+  if (event.key !== 'Escape')
+    return
+  // Top present layer only (presence order — matches today's index === size - 1).
+  const top = [...layers].reverse().find(layer => layer.isPresent())
+  top?.onEscapeKeyDown?.(event)
+}
+
+// --- registration ---
+export function registerStackLayer(layer: StackLayer): () => void {
+  layers.push(layer)
+  installKeydownListener()
+  return () => {
+    const i = layers.indexOf(layer)
+    if (i !== -1)
+      layers.splice(i, 1)
+    if (layers.length === 0)
+      teardownKeydownListener()
+  }
+}
+
+export function registerOutsideSubscriber(sub: OutsideSubscriber): () => void {
+  outsideSubscribers.push(sub)
+  // Arm a macrotask later: the shared listener is already live, so if this layer
+  // mounted *via* a pointerdown, an unarmed handle ignores that same event.
+  sub.armed = false
+  const timer = isClient ? window.setTimeout(() => { sub.armed = true }, 0) : undefined
+  installOutsideListeners()
+  return () => {
+    if (timer !== undefined)
+      window.clearTimeout(timer)
+    const i = outsideSubscribers.indexOf(sub)
+    if (i !== -1)
+      outsideSubscribers.splice(i, 1)
+    cancelTouch(sub)
+    if (outsideSubscribers.length === 0)
+      teardownOutsideListeners()
+  }
+}
+
+export function registerBranch(el: HTMLElement): () => void {
+  branches.push(el)
+  return () => {
+    const i = branches.indexOf(el)
+    if (i !== -1)
+      branches.splice(i, 1)
+  }
+}
+
+// --- queries ---
+export function indexOfLayer(layer: StackLayer): number {
+  return layers.indexOf(layer)
+}
+export function isTopLayer(layer: StackLayer): boolean {
+  return layers.length > 0 && layers.at(-1) === layer
+}
+/** Highest document-position index among layers that disable outside pointer events (-1 if none). */
+export function highestDisabledIndex(): number {
+  let index = -1
+  for (let i = 0; i < layers.length; i++) {
+    if (layers[i].disableOutsidePointerEvents())
+      index = i
+  }
+  return index
+}
+
+/** Test-only: clear ALL manager state and shared listeners. */
+export function resetLayerStack(): void {
+  layers.splice(0)
+  outsideSubscribers.splice(0)
+  branches.splice(0)
+  pendingTouch.clear()
+  teardownOutsideListeners()
+  teardownKeydownListener()
+  removeTouchClick()
+  if (isClient && bodyPointerEvents.original !== undefined)
+    document.body.style.pointerEvents = bodyPointerEvents.original
+  bodyPointerEvents.original = undefined
+}

--- a/packages/core/src/DismissableLayer/layerStack.ts
+++ b/packages/core/src/DismissableLayer/layerStack.ts
@@ -231,6 +231,27 @@ export function registerBranch(el: HTMLElement): () => void {
   }
 }
 
+// --- body pointer-events lock (#2674) ---
+// Reference-counted: the first disabling layer saves the original body
+// `pointer-events` and sets `none`; the last one to leave restores it. Counting
+// (rather than a per-component copy) is what lets layer B restore the value
+// layer A saved after A unmounts.
+let bodyLockCount = 0
+export function acquireBodyPointerEventsLock(doc: Document): void {
+  if (bodyLockCount === 0) {
+    bodyPointerEvents.original = doc.body.style.pointerEvents
+    doc.body.style.pointerEvents = 'none'
+  }
+  bodyLockCount++
+}
+export function releaseBodyPointerEventsLock(doc: Document): void {
+  bodyLockCount = Math.max(0, bodyLockCount - 1)
+  // Restore only once the last disabling layer is gone. `!== undefined` mirrors
+  // the previous `!isNullish` check ('' is a valid saved value → still restored).
+  if (bodyLockCount === 0 && bodyPointerEvents.original !== undefined)
+    doc.body.style.pointerEvents = bodyPointerEvents.original
+}
+
 // --- queries ---
 export function indexOfLayer(layer: StackLayer): number {
   return layers.indexOf(layer)
@@ -253,6 +274,7 @@ export function resetLayerStack(): void {
   for (const timer of armingTimers)
     window.clearTimeout(timer)
   armingTimers.clear()
+  bodyLockCount = 0
   layers.splice(0)
   outsideSubscribers.splice(0)
   branches.splice(0)

--- a/packages/core/src/DismissableLayer/layerStack.ts
+++ b/packages/core/src/DismissableLayer/layerStack.ts
@@ -41,7 +41,11 @@ export interface DispatchContext {
 }
 
 export interface OutsideSubscriber {
-  /** false until a macrotask after registration (mount-via-pointerdown guard). */
+  /**
+   * false until a macrotask after registration (mount-via-pointerdown guard).
+   * POINTER PATH ONLY — the focus path has no arming today (`utils.ts` attaches
+   * `focusin` synchronously at L182), so `handleFocus` must NOT check `armed`.
+   */
   armed: boolean
   isPointerInside: boolean
   isFocusInside: boolean
@@ -66,6 +70,7 @@ let outsideListenersInstalled = false
 let keydownListenerInstalled = false
 let touchClickInstalled = false
 const pendingTouch = new Map<OutsideSubscriber, () => void>()
+const armingTimers = new Set<number>()
 
 function installOutsideListeners() {
   if (outsideListenersInstalled || !isClient)
@@ -109,11 +114,14 @@ function removeTouchClick() {
   document.removeEventListener('click', handleTouchClick)
 }
 function handleTouchClick() {
-  const dispatches = [...pendingTouch.values()]
+  const entries = [...pendingTouch.entries()]
   pendingTouch.clear()
   removeTouchClick()
-  for (const dispatch of dispatches)
+  for (const [sub, dispatch] of entries) {
+    if (!outsideSubscribers.includes(sub))
+      continue
     dispatch()
+  }
 }
 function deferTouch(sub: OutsideSubscriber, dispatch: () => void) {
   pendingTouch.set(sub, dispatch) // replace = re-arm
@@ -145,15 +153,23 @@ function buildContext(event: Event): DispatchContext {
 
 function handlePointerDown(event: PointerEvent) {
   const ctx = buildContext(event)
-  // Snapshot: a dispatch may unregister subscribers mid-iteration.
-  for (const sub of [...outsideSubscribers])
+  // Snapshot: a dispatch may unregister subscribers mid-iteration. The liveness
+  // guard skips a subscriber synchronously unregistered by an earlier dispatch
+  // (matches the DOM `removed` semantics).
+  for (const sub of [...outsideSubscribers]) {
+    if (!outsideSubscribers.includes(sub))
+      continue
     sub.handlePointerDown?.(event, ctx)
+  }
 }
 
 function handleFocusIn(event: FocusEvent) {
   const ctx = buildContext(event)
-  for (const sub of [...outsideSubscribers])
+  for (const sub of [...outsideSubscribers]) {
+    if (!outsideSubscribers.includes(sub))
+      continue
     sub.handleFocus?.(event, ctx)
+  }
 }
 
 function handleKeyDown(event: KeyboardEvent) {
@@ -182,11 +198,21 @@ export function registerOutsideSubscriber(sub: OutsideSubscriber): () => void {
   // Arm a macrotask later: the shared listener is already live, so if this layer
   // mounted *via* a pointerdown, an unarmed handle ignores that same event.
   sub.armed = false
-  const timer = isClient ? window.setTimeout(() => { sub.armed = true }, 0) : undefined
+  let timer: number | undefined
+  if (isClient) {
+    timer = window.setTimeout(() => {
+      sub.armed = true
+      if (timer !== undefined)
+        armingTimers.delete(timer)
+    }, 0)
+    armingTimers.add(timer)
+  }
   installOutsideListeners()
   return () => {
-    if (timer !== undefined)
+    if (timer !== undefined) {
       window.clearTimeout(timer)
+      armingTimers.delete(timer)
+    }
     const i = outsideSubscribers.indexOf(sub)
     if (i !== -1)
       outsideSubscribers.splice(i, 1)
@@ -224,13 +250,15 @@ export function highestDisabledIndex(): number {
 
 /** Test-only: clear ALL manager state and shared listeners. */
 export function resetLayerStack(): void {
+  for (const timer of armingTimers)
+    window.clearTimeout(timer)
+  armingTimers.clear()
   layers.splice(0)
   outsideSubscribers.splice(0)
   branches.splice(0)
   pendingTouch.clear()
-  teardownOutsideListeners()
+  teardownOutsideListeners() // also removes the touch-click listener
   teardownKeydownListener()
-  removeTouchClick()
   if (isClient && bodyPointerEvents.original !== undefined)
     document.body.style.pointerEvents = bodyPointerEvents.original
   bodyPointerEvents.original = undefined

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -1,7 +1,9 @@
 import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { OutsideSubscriber } from './layerStack'
 import { isClient } from '@vueuse/shared'
 import { nextTick, ref, toValue, watchEffect } from 'vue'
 import { handleAndDispatchCustomEvent } from '@/shared'
+import { registerOutsideSubscriber } from './layerStack'
 
 export type PointerDownOutsideEvent = CustomEvent<{
   originalEvent: PointerEvent
@@ -152,36 +154,43 @@ export function useFocusOutside(
   element?: Ref<HTMLElement | undefined>,
   enabled: MaybeRefOrGetter<boolean> = true,
 ) {
-  const ownerDocument: Document
-    = element?.value?.ownerDocument ?? globalThis?.document
-
-  const isFocusInsideDOMTree = ref(false)
-  watchEffect((cleanupFn) => {
-    if (!isClient || !toValue(enabled))
-      return
-    const handleFocus = async (event: FocusEvent) => {
+  const subscriber: OutsideSubscriber = {
+    // Focus has NO arming today (the `focusin` listener attaches synchronously),
+    // so a focus subscriber is always "armed" and must never gate on it.
+    armed: true,
+    isPointerInside: false,
+    isFocusInside: false,
+    // Ported from the previous `handleFocus` body. Keeps the double `nextTick`
+    // so focus-driven DOM updates settle before the gate reads. Uses the
+    // composed `ctx.target` (captured synchronously by the manager) but a FRESH
+    // `isLayerExist` query AFTER the awaits — the DOM may have changed, and a
+    // stale snapshot would diverge from today's behavior.
+    handleFocus: async (event, ctx) => {
       if (!element?.value)
         return
 
       await nextTick()
       await nextTick()
-      const target = event.target as HTMLElement | undefined
+      const target = ctx.target as HTMLElement | null
       if (!element.value || !target || isLayerExist(element.value, target))
         return
 
-      if (event.target && !isFocusInsideDOMTree.value) {
+      if (!subscriber.isFocusInside) {
         const eventDetail = { originalEvent: event }
         handleAndDispatchCustomEvent(
           FOCUS_OUTSIDE,
           onFocusOutside,
           eventDetail,
+          target,
         )
       }
-    }
+    },
+  }
 
-    ownerDocument.addEventListener('focusin', handleFocus)
-
-    cleanupFn(() => ownerDocument.removeEventListener('focusin', handleFocus))
+  watchEffect((cleanupFn) => {
+    if (!isClient || !toValue(enabled))
+      return
+    cleanupFn(registerOutsideSubscriber(subscriber))
   })
 
   return {
@@ -189,13 +198,13 @@ export function useFocusOutside(
       if (!toValue(enabled))
         return
 
-      isFocusInsideDOMTree.value = true
+      subscriber.isFocusInside = true
     },
     onBlurCapture: () => {
       if (!toValue(enabled))
         return
 
-      isFocusInsideDOMTree.value = false
+      subscriber.isFocusInside = false
     },
   }
 }

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import type { OutsideSubscriber } from './layerStack'
 import { isClient } from '@vueuse/shared'
-import { nextTick, ref, toValue, watchEffect } from 'vue'
+import { nextTick, toValue, watchEffect } from 'vue'
 import { handleAndDispatchCustomEvent } from '@/shared'
 import { registerOutsideSubscriber } from './layerStack'
 
@@ -11,11 +11,18 @@ export type PointerDownOutsideEvent = CustomEvent<{
 export type FocusOutsideEvent = CustomEvent<{ originalEvent: FocusEvent }>
 
 export const DISMISSABLE_LAYER_NAME = 'DismissableLayer'
-export const CONTEXT_UPDATE = 'dismissableLayer.update'
 export const POINTER_DOWN_OUTSIDE = 'dismissableLayer.pointerDownOutside'
 export const FOCUS_OUTSIDE = 'dismissableLayer.focusOutside'
 
-export function isLayerExist(layerElement: HTMLElement, targetElement: HTMLElement) {
+export function isLayerExist(
+  layerElement: HTMLElement,
+  targetElement: HTMLElement,
+  // Optional pre-computed `[data-dismissable-layer]` snapshot. The manager hoists
+  // ONE snapshot per pointerdown event and passes it here so N subscribers share
+  // a single `querySelectorAll` (the synchronous pointer path — see layerStack).
+  // Omitted (focus path / direct callers) → a fresh query, matching prior behavior.
+  snapshot?: Element[],
+) {
   if (!(targetElement instanceof Element))
     return false
 
@@ -29,7 +36,7 @@ export function isLayerExist(layerElement: HTMLElement, targetElement: HTMLEleme
       '[data-dismissable-layer]',
     ) as HTMLElement
 
-  const nodeList = Array.from(
+  const nodeList = snapshot ?? Array.from(
     layerElement.ownerDocument.querySelectorAll('[data-dismissable-layer]'),
   )
 
@@ -51,27 +58,28 @@ export function usePointerDownOutside(
   element?: Ref<HTMLElement | undefined>,
   enabled: MaybeRefOrGetter<boolean> = true,
 ) {
-  const ownerDocument: Document
-    = element?.value?.ownerDocument ?? globalThis?.document
+  const subscriber: OutsideSubscriber = {
+    armed: false, // set true a macrotask after registration by the manager
+    isPointerInside: false,
+    isFocusInside: false,
+    // Ported from the previous `handlePointerDown` body, branch-for-branch.
+    handlePointerDown: (event, ctx) => {
+      // Arming guard MUST be first — before any flag write. During the arming
+      // window the whole body is skipped, so `isPointerInside` (set by the
+      // capture handler) survives until the next post-arming event.
+      if (!subscriber.armed)
+        return
 
-  const isPointerInsideDOMTree = ref(false)
-  const handleClickRef = ref(() => {})
-
-  watchEffect((cleanupFn) => {
-    if (!isClient || !toValue(enabled))
-      return
-    const handlePointerDown = async (event: PointerEvent) => {
-      const target = event.target as HTMLElement | undefined
-
+      const target = ctx.target as HTMLElement | null
       if (!element?.value || !target)
         return
 
-      if (isLayerExist(element.value, target)) {
-        isPointerInsideDOMTree.value = false
+      if (isLayerExist(element.value, target, ctx.nodeList)) {
+        subscriber.isPointerInside = false
         return
       }
 
-      if (event.target && !isPointerInsideDOMTree.value) {
+      if (!subscriber.isPointerInside) {
         const eventDetail = { originalEvent: event }
 
         function handleAndDispatchPointerDownOutsideEvent() {
@@ -79,6 +87,7 @@ export function usePointerDownOutside(
             POINTER_DOWN_OUTSIDE,
             onPointerDownOutside,
             eventDetail,
+            target,
           )
         }
 
@@ -91,56 +100,35 @@ export function usePointerDownOutside(
          * Additionally, this also lets us deal automatically with cancellations when a click event
          * isn't raised because the page was considered scrolled/drag-scrolled, long-pressed, etc.
          *
-         * This is why we also continuously remove the previous listener, because we cannot be
-         * certain that it was raised, and therefore cleaned-up.
+         * `deferTouch` replaces the previous pending dispatch (= the "continuously
+         * remove the previous listener" behavior) via the manager's shared click listener.
          */
-        if (event.pointerType === 'touch') {
-          ownerDocument.removeEventListener('click', handleClickRef.value)
-          handleClickRef.value = handleAndDispatchPointerDownOutsideEvent
-          ownerDocument.addEventListener('click', handleClickRef.value, {
-            once: true,
-          })
-        }
-        else {
+        if (event.pointerType === 'touch')
+          ctx.deferTouch(subscriber, handleAndDispatchPointerDownOutsideEvent)
+        else
           handleAndDispatchPointerDownOutsideEvent()
-        }
       }
       else {
-        // We need to remove the event listener in case the outside click has been canceled.
+        // Cancel a pending deferred dispatch when the outside click was canceled.
         // See: https://github.com/radix-ui/primitives/issues/2171
-        ownerDocument.removeEventListener('click', handleClickRef.value)
+        // NB: only here, NOT on the isLayerExist early-return above (parity).
+        ctx.cancelTouch(subscriber)
       }
-      isPointerInsideDOMTree.value = false
-    }
-    /**
-     * if this hook executes in a component that mounts via a `pointerdown` event, the event
-     * would bubble up to the document and trigger a `pointerDownOutside` event. We avoid
-     * this by delaying the event listener registration on the document.
-     * This is how the DOM works, ie:
-     * ```
-     * button.addEventListener('pointerdown', () => {
-     *   console.log('I will log');
-     *   document.addEventListener('pointerdown', () => {
-     *     console.log('I will also log');
-     *   })
-     * });
-     */
-    const timerId = window.setTimeout(() => {
-      ownerDocument.addEventListener('pointerdown', handlePointerDown)
-    }, 0)
+      subscriber.isPointerInside = false
+    },
+  }
 
-    cleanupFn(() => {
-      window.clearTimeout(timerId)
-      ownerDocument.removeEventListener('pointerdown', handlePointerDown)
-      ownerDocument.removeEventListener('click', handleClickRef.value)
-    })
+  watchEffect((cleanupFn) => {
+    if (!isClient || !toValue(enabled))
+      return
+    cleanupFn(registerOutsideSubscriber(subscriber))
   })
 
   return {
     onPointerDownCapture: () => {
       if (!toValue(enabled))
         return
-      isPointerInsideDOMTree.value = true
+      subscriber.isPointerInside = true
     },
   }
 }
@@ -207,9 +195,4 @@ export function useFocusOutside(
       subscriber.isFocusInside = false
     },
   }
-}
-
-export function dispatchUpdate() {
-  const event = new CustomEvent(CONTEXT_UPDATE)
-  document.dispatchEvent(event)
 }

--- a/packages/core/src/shared/handleAndDispatchCustomEvent.ts
+++ b/packages/core/src/shared/handleAndDispatchCustomEvent.ts
@@ -7,15 +7,19 @@ export function handleAndDispatchCustomEvent<
   detail: { originalEvent: OriginalEvent } & (E extends CustomEvent<infer D>
     ? D
     : never),
+  // The event target to dispatch on. Defaults to the original event's target,
+  // but callers should pass the synchronously-captured composed target
+  // (`composedPath()[0]`): for shadow-origin events the original target is
+  // nulled/retargeted after dispatch in real browsers, which would throw here.
+  target: EventTarget | null = detail.originalEvent.target,
 ) {
-  const target = detail.originalEvent.target
   const event = new CustomEvent(name, {
     bubbles: false,
     cancelable: true,
     detail,
   })
-  if (handler)
+  if (handler && target)
     target.addEventListener(name, handler as EventListener, { once: true })
 
-  target.dispatchEvent(event)
+  target?.dispatchEvent(event)
 }

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
     globals: true,
     exclude: ['**/node_modules/**'],
     include: ['./**/*.test.{ts,js}'],
+    benchmark: {
+      include: ['./**/*.bench.{ts,js}'],
+    },
     coverage: {
       provider: 'istanbul', // or 'v8'
     },


### PR DESCRIPTION
## Overlay & render performance overhaul (Tasks 1–7)

Implements #2724 — Phase 2 of the [reka-ui v3 roadmap #2721](https://github.com/unovue/reka-ui/issues/2721). Replaces `DismissableLayer`'s **per-layer** global listeners and per-read O(n) scans with a **single centralized stack manager**.

> **Scope:** Tasks 1–7. Task 8 (removing the `Primitive` wrapper via `useRender`) is deferred until #2722 merges into `v3` — it's a small mechanical follow-up.

### The problem
Each open `DismissableLayer` attached its **own** `pointerdown` + `focusin` (document) + `keydown` (window) listeners, and every read recomputed `Array.from(reactiveSet).indexOf(...)`. N open overlays = 3N listeners and O(n) work per interaction, plus reactive-Set churn.

### The change
- **`layerStack.ts` — a plain-module manager (transport only).** Two separate registries model two populations with different lifetimes:
  - `layers` (presence-driven ordered stack) → Escape routing, indexing, pointer-events accounting.
  - `outsideSubscribers` (setup/`enabled`-driven) → pointer/focus dispatch.
  It installs **exactly one** shared listener of each kind (torn down when its registry empties), builds **one** `querySelectorAll` snapshot per event, arms subscribers, and owns the touch-click deferral.
- **The composables become subscribers.** `usePointerDownOutside`/`useFocusOutside` keep their exact signatures (`Editable` compiles unchanged) but port their `handlePointerDown`/`handleFocus` bodies **branch-for-branch** into subscriber closures.
- **Escape** moves from a per-layer `window` keydown (`onKeyStroke`) to one shared listener routing to the top *present* layer.
- **Reactive `context` removed.** `index`/`isPointerEventsEnabled`/`isBodyPointerEventsDisabled` derive from the manager (array `indexOf`, no `Array.from`). The `disableOutsidePointerEvents` body lock is a **ref-counted** manager helper (first disabling layer sets `none`, last restores — #2674 order-independent). Branches move to the manager.
- **Shadow-ready** (baked in for #2725): target reads go through `composedPath()[0]` (captured synchronously), threaded into `handleAndDispatchCustomEvent` (which now guards a null target — the original event target is nulled post-dispatch for shadow-origin events in real browsers).

### Proof of the win
`DismissableLayer.listeners.test.ts` asserts structurally: **10 layers → exactly 1 `pointerdown` + 1 `focusin` + 1 `keydown` listener**, **1 `querySelectorAll` per outside pointerdown regardless of layer count**, and full teardown on unmount. (jsdom benchmarks in `DismissableLayer.bench.ts` are directional; render count is parity, not reduced.)

### Testing
- **Full suite green: 1972 tests / 97 files.** Type-check clean.
- Every existing `DismissableLayer.test.ts` case passes **unchanged** — including the #2674 `disableOutsidePointerEvents` suite, the `present:false` tests, and the `isLayerExist` unit tests (export kept). Consumer sweep (Dialog, Drawer, Menu, Popover, Tooltip, HoverCard, Combobox, Select, NavigationMenu, Toast, Editable) all green.
- New: manager unit tests, stacked-Escape routing, listener/query-count regressions.

### Reviewed by an advisor before building
The manager design was pressure-tested against the current `utils.ts` semantics before the migrations were ported. Findings incorporated: focus uses a **fresh** `isLayerExist` after its double `nextTick` (snapshot is pointerdown-only); the armed-guard is the literal first statement of the pointer closure (no flag writes on that path); focus never checks `armed` or writes its flag; touch deferral is a per-subscriber `Map`; arming timers are cleared on reset; a liveness guard covers synchronous mid-dispatch unregistration.

### Behavior notes (documented, not regressions)
- Escape stays on `window` (matching `onKeyStroke`'s default), so nothing that stops propagation at document level is affected.
- Two touch/interleaving micro-quirks of the old per-layer `{once}` click model are preserved bug-for-bug; one real-browser cascading-dismissal interleaving now matches what the jsdom oracle already exhibited.

Refs #2724, #2721 · Follow-up: Task 8 after #2722 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved `DismissableLayer` handling for stacked overlays by consolidating shared event processing and reducing redundant DOM queries.
  * Added performance benchmarks covering layer mounting, outside interactions, and Escape-key handling.

* **Bug Fixes**
  * Escape now consistently targets the topmost active layer.
  * Improved coordination of outside pointer and focus interactions across nested layers.
  * Preserved correct pointer-event restoration for nested overlays.

* **Tests**
  * Added coverage for shared listener lifecycle, event routing, query efficiency, and stack cleanup.

* **Documentation**
  * Added an implementation plan for the overlay rendering and interaction performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->