### PR TITLE
perf(DismissableLayer): render via useRender, drop the Primitive wrapper (#2724 Task 8)

### DIFF
--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -10,7 +10,6 @@ import {
   nextTick,
   watch,
 } from 'vue'
-import { useForwardExpose } from '@/shared'
 
 export interface DismissableLayerProps extends PrimitiveProps {
   /**
@@ -56,7 +55,7 @@ export type DismissableLayerPrivateEmits = DismissableLayerEmits & {
 <script setup lang="ts">
 import type { StackLayer } from './layerStack'
 import {
-  Primitive,
+  useRender,
 } from '@/Primitive'
 import {
   acquireBodyPointerEventsLock,
@@ -88,7 +87,12 @@ const props = withDefaults(defineProps<DismissableLayerProps & {
 
 const emits = defineEmits<DismissableLayerPrivateEmits>()
 
-const { forwardRef, currentElement: layerElement } = useForwardExpose()
+// Render via `useRender` (no `Primitive` wrapper instance). `elementRef` is the
+// forwarded callback ref; `layerElement` the resolved root element.
+const { tag, currentElement: layerElement, elementRef } = useRender({
+  as: () => props.as,
+  asChild: () => props.asChild,
+})
 const ownerDocument = computed(
   () => layerElement.value?.ownerDocument ?? globalThis.document,
 )
@@ -182,10 +186,9 @@ watch(
 </script>
 
 <template>
-  <Primitive
-    :ref="forwardRef"
-    :as-child="asChild"
-    :as="as"
+  <component
+    :is="tag"
+    :ref="elementRef"
     data-dismissable-layer
     :style="{
       pointerEvents: isBodyPointerEventsDisabled
@@ -199,5 +202,5 @@ watch(
     @pointerdown.capture="pointerDownOutside.onPointerDownCapture"
   >
     <slot />
-  </Primitive>
+  </component>
 </template>

--- a/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
@@ -1,18 +1,20 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
 
 export interface DismissableLayerBranchProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
 import { onMounted, onUnmounted } from 'vue'
-import { Primitive } from '@/Primitive'
+import { useRender } from '@/Primitive'
 import { registerBranch } from './layerStack'
 
 const props = defineProps<DismissableLayerBranchProps>()
 
-const { forwardRef, currentElement } = useForwardExpose()
+const { tag, currentElement, elementRef } = useRender({
+  as: () => props.as,
+  asChild: () => props.asChild,
+})
 let unregisterBranch: (() => void) | undefined
 onMounted(() => {
   if (currentElement.value)
@@ -24,10 +26,10 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <Primitive
-    :ref="forwardRef"
-    v-bind="props"
+  <component
+    :is="tag"
+    :ref="elementRef"
   >
     <slot />
-  </Primitive>
+  </component>
 </template>


### PR DESCRIPTION
## DismissableLayer: render via `useRender` (drop the `Primitive` wrapper)

Completes **#2724 Task 8** — deferred until #2722 (`useRender`) and #2724 Tasks 1–7 landed on `v3`, both now merged.

`DismissableLayer.vue` and `DismissableLayerBranch.vue` now render `<component :is="tag">` directly through `useRender` instead of wrapping a `<Primitive>`. This **removes one component instance per overlay part** — every Dialog/Popover/Menu/Tooltip/Select/Combobox/Drawer content sits behind a DismissableLayer, so this is one fewer instance in each of those chains.

### What changed
- Swap `useForwardExpose()` + `<Primitive :ref="forwardRef">` for `useRender({ as, asChild })` + `<component :is="tag" :ref="elementRef">`. `useRender` already wires `useForwardExpose` internally, so there's no double-call (the migration landmine from #2722).
- `data-dismissable-layer`, the `pointer-events` style, and the capture-phase focus/blur/pointerdown handlers stay as direct template bindings on the rendered element (they don't need the merge core, and this avoids a setup-ordering cycle).

### Perf
Measured for #2722: dropping the wrapper is **~1.6× faster mount** on the common path. Here it applies to the DismissableLayer link in every overlay chain.

### Testing
- **Full suite green: 1997 tests / 99 files.** Type-check clean.
- The entire `DismissableLayer.test.ts` suite (incl. #2674 body-lock, stacking, present:false) and every overlay consumer (Dialog, Popover, Menu, Select, Combobox, Tooltip, HoverCard, Drawer, Toast, Editable) pass **unchanged**.

Refs #2724, #2721

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dismissible layers and layer branches to use a more flexible rendering approach.
  * Preserved existing support for custom element rendering, nested branches, dismissal behavior, outside-interaction handling, and pointer-event styling.
  * Maintained existing public component behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->