### PR TITLE
feat(Menu): headless composables for the Menu overlay family (#2723)

### DIFF
--- a/docs/superpowers/pocs/2723-menu-overlay-composable.md
+++ b/docs/superpowers/pocs/2723-menu-overlay-composable.md
@@ -1,9 +1,11 @@
-# POC: headless composables for an OVERLAY family (Menu) — #2723
+# Headless composables for an OVERLAY family (Menu) — #2723
 
-> **Status: proof-of-concept, throwaway branch `poc-2723-menu-composable`.** Not a
-> parity-gated production PR. Purpose: test whether the `useX()` pattern (validated
-> on Switch + Tabs) extends to an overlay family, and produce the findings that
-> should shape the deferred overlay contract (**joint with #2724**).
+> **Status: overlay archetype validated + core Menu parts converted** (parity-gated,
+> 51 consumer tests green). Began as a spike; graduated to a real conversion. This
+> establishes the overlay contract that the deferred overlay work (**joint with
+> #2724**) should build on. Scope: `MenuRoot`/`MenuItem`/`MenuItemImpl`/
+> `MenuContentImpl`; `MenuSubTrigger`/`Checkbox`/`Radio`/`Sub` reuse the same builders
+> as follow-ups (see "Scope NOT covered").
 
 ## TL;DR
 
@@ -20,7 +22,7 @@ input to #2724.
 
 ## What was built
 
-All on branch `poc-2723-menu-composable` (off `v3`). `packages/core/src/Menu/useMenu.ts`:
+In `packages/core/src/Menu/useMenu.ts`:
 
 1. **`useMenuRoot()`** — the state-only overlay root. Renders no attrs, so **no
    `PartSurface`**; returns `{ open, onOpenChange, onClose, menuContext, menuRootContext }`
@@ -140,8 +142,7 @@ named seam. That is exactly the boundary #2724 should build the overlay contract
 - Fold `useFocusGuards`/`useBodyScrollLock` into `useMenuContent` behind a flag, so a
   standalone consumer opts into the mount side-effects (kept in the SFC here so the
   brain stays side-effect-free).
-- Move `PartSurface` to `@/shared` (this POC imports it from `@/Switch` on `v3`; the
-  Tabs PR #2795 relocates it — rebase onto that).
+- `PartSurface` is imported from `@/shared` (relocated there by #2795).
 
 ## Bottom line
 `useX()` works for overlays. It costs two axiom amendments (state-only root;

--- a/docs/superpowers/pocs/2723-menu-overlay-composable.md
+++ b/docs/superpowers/pocs/2723-menu-overlay-composable.md
@@ -1,0 +1,153 @@
+# POC: headless composables for an OVERLAY family (Menu) — #2723
+
+> **Status: proof-of-concept, throwaway branch `poc-2723-menu-composable`.** Not a
+> parity-gated production PR. Purpose: test whether the `useX()` pattern (validated
+> on Switch + Tabs) extends to an overlay family, and produce the findings that
+> should shape the deferred overlay contract (**joint with #2724**).
+
+## TL;DR
+
+The pattern extends — but overlays **bend two axioms** from the Switch/Tabs recipe,
+and the recipe's stated reason for deferring overlays ("overlay logic lives in
+Content-part wrappers") is **wrong by half**. The wrappers are a thin shell; the
+overlay *brain* (typeahead, arrow-nav, the pointer-grace machine, highlight
+ownership) is plain state+handlers and extracts cleanly — **now demonstrated, not
+just argued**: `useMenuContent()` pulls ~215 lines out of `MenuContentImpl.vue`
+(**405 → 191 lines**), leaving the SFC as the four wrappers + positioning props.
+The single thing that couldn't move is `RovingFocusGroup.getItems()` (a template-
+instance ref), injected as one `getItems` option. That reframe is the most useful
+input to #2724.
+
+## What was built
+
+All on branch `poc-2723-menu-composable` (off `v3`). `packages/core/src/Menu/useMenu.ts`:
+
+1. **`useMenuRoot()`** — the state-only overlay root. Renders no attrs, so **no
+   `PartSurface`**; returns `{ open, onOpenChange, onClose, menuContext, menuRootContext }`
+   — the two context objects the SFC provides verbatim. `MenuRoot.vue` now composes it.
+2. **`getMenuItemBaseSurface(contentContext, { disabled, currentElement })`** — the
+   attr-bearing item render surface (role/tabindex/aria-disabled + the
+   pointermove/leave/focus/blur hover-highlight). `MenuItemImpl.vue` composes it.
+3. **`getMenuItemSelectSurface(rootContext, { disabled, currentElement, onSelect, searchRef })`**
+   — the select protocol (click/pointerdown/pointerup/keydown + close-on-select).
+   `MenuItem.vue` composes it.
+4. **`useMenuContent(options)`** — the overlay **brain**: typeahead, arrow-nav
+   (`handleKeyDown`/`onKeydownNavigation`), the pointer-grace/direction machine, and
+   `highlightedElement` ownership. Returns the `role=menu` `PartSurface` + the
+   `MenuContentContext` value. `MenuContentImpl.vue` composes it, keeping the four
+   wrappers + the two mount side-effects. **Extracted ~215 lines (405 → 191).**
+
+**Verification:** `Menu` + `DropdownMenu` + `ContextMenu` + `Menubar` suites (the
+compatibility oracle for these SFCs) **51/51 green**; full suite **2042 green**;
+`type-check` clean; **19** POC unit tests across the four shapes.
+
+## Findings — the questions overlays force
+
+### 1. Overlay-root contract: `{ state, context }`, no surface
+`useMenuRoot()` returns state + the context objects, no `PartSurface`. **The family
+is not surface-free — only the root is.** `DropdownMenuTrigger`/`Content` have real
+surfaces; the surfaces just begin one level below the root. Recipe addition (one line):
+
+> *Overlay roots are state-only (`{ state, context }`, no surface); positioning
+> (`PopperRoot`) and portal stay wrappers, so a standalone overlay `useX()` yields
+> the state machine and the trigger/item surfaces but not placement.*
+
+The two-context shape (`MenuContext` keyed `['MenuRoot','MenuSub']` + `MenuRootContext`)
+is reused by `MenuSub` — a future `useMenuSub()` returns a `MenuContext`-shaped
+object, so the contract is symmetric.
+
+### 2. HEADLINE: the item builder is a context-SCOPED FACTORY, not a pure builder
+Tabs' per-item builders are **pure, idempotent derivations** of `(context, value)` —
+safe to call many times. `getMenuItemBaseSurface` **cannot** be: it creates
+per-instance state (`isFocused`) and closes over the item's own `currentElement`
+(the highlight identity check + pointer handlers compare against it). So it must be
+called **exactly once per item instance**, and callers pass an element ref they
+populate after mount.
+
+> **The "context-pure builder" axiom does not survive contact with overlays.**
+> Overlay item builders are *context-scoped factories*: `state`/`props` computeds
+> stay pure derivations, but the factory itself instantiates state. If both the
+> standalone `useMenu().getItemSurface` path and the SFC inject-and-call path
+> instantiated it, you'd get two divergent `isFocused` states — so memoize one
+> factory call per instance.
+
+### 3. The select protocol moves — as a callback channel
+`MenuItem`'s close-on-select is **not** a DOM dispatch — it builds
+`new CustomEvent(ITEM_SELECT, { cancelable: true })` as a cancelable **token**, emits
+it, `await nextTick()`, and closes unless `defaultPrevented`. That whole flow lives
+in the composable behind an **`onSelect: (event) => void`** option; the SFC passes
+`e => emits('select', e)`. `onSelect` stays a callback — it is never a merged DOM
+listener. The async `defaultPrevented`-after-`nextTick` veto survives `mergeProps`
+binding as long as surface handlers come first in the merge.
+
+### 4. base + variant layering (so SubTrigger can reuse)
+The SFC split (`MenuItemImpl` = render/highlight; `MenuItem` = select) maps to two
+builders. **Base** (`getMenuItemBaseSurface`) is what every item variant renders
+through, so `MenuSubTrigger`/`MenuCheckboxItem`/`MenuRadioItem` can reuse it and add
+their own layer. Not layering the base would strand SubTrigger.
+
+### 5. What CANNOT move (stays wrapper/SFC)
+- **`CollectionItem` registration** — vnode-bound provide/inject; the `<CollectionItem>`
+  wrapper stays in the SFC. The composable documents it as a required host.
+- **`RovingFocusGroup.getItems()`** — a template-instance-ref call (typeahead
+  candidates); a standalone `useMenuContent()` must **accept an injected `getItems`**.
+- **The pointer-grace machine** — CAN move, but only into a **content** composable,
+  never the item's. Items already consume it purely via the `onItemEnter`/`onItemLeave`/
+  `onTriggerLeave` closure trio on `MenuContentContext` — that trio IS the contract,
+  keep it verbatim. It's pinned near the DOM only by lazy `getBoundingClientRect()`/
+  `dataset.side` reads (SSR-safe as-is).
+- **`highlightedElement` is an `HTMLElement`** — the stale-leave guard, `isHighlighted`,
+  and arrow-nav all depend on **element identity**. Do NOT normalize it to an id/index
+  in a refactor — that's a behavior rewrite.
+- **Mount-lifecycle composables** (`useBodyScrollLock`, `useFocusGuards`,
+  `useIsUsingKeyboard`) — must run inside the mounted content/root, so an overlay
+  `useX()` is **not callable outside `setup()`** (unlike Switch/Tabs). Expected for
+  overlays; test in a mount harness.
+
+### 6. Two recipe amendments overlays require
+- **Functional `data-*` selectors are exempt from the no-`data-*` rule.**
+  `data-reka-menu-content` (submenu-scoping `closest()` check), `data-reka-collection-item`,
+  and `[data-disabled]` (read by `useArrowNavigation`'s selector) are *functional
+  selectors*, not semantic state — they belong in `props`, not routed through
+  `stateToDataAttrs`. Silently dropping one degrades UX with no test failure.
+- **Overlay item builders are context-scoped factories** (finding #2) — the recipe's
+  "pure builder" wording needs the factory caveat for overlays.
+
+## The reframe for #2724 (most valuable output) — now PROVEN
+
+The deferral said "overlay logic lives in Content-part component wrappers." Reality
+for Menu: `MenuContentImpl` composes **4** wrappers (FocusScope/DismissableLayer/
+RovingFocusGroup/PopperContent), but the **majority** of its logic — typeahead,
+`onKeydownNavigation`, `handleKeyDown`, `handleBlur`, the pointer-direction tracker,
+the grace machine (`isPointerMovingToSubmenu`, `pointerGraceIntentRef`,
+`pointerDirRef`, `lastPointerXRef`), and `highlightedElement` ownership — is
+**wrapper-independent**. `useMenuContent()` extracts it: it returns the `role=menu`
+surface and the `MenuContentContext` value, and **`MenuContentImpl.vue` drops from
+405 to 191 lines** — the residue is the 4 wrappers, the positioning props, and the
+two mount side-effects (`useFocusGuards`/`useBodyScrollLock`).
+
+**The wrappers are the shell; the overlay brain is the composable.** The only piece
+that resisted extraction is `RovingFocusGroup.getItems()` (a template-instance ref
+for typeahead candidates), injected as a single `getItems` option — a clean,
+named seam. That is exactly the boundary #2724 should build the overlay contract on.
+
+## Scope NOT covered (recommended next depth)
+- Reuse `getMenuItemBaseSurface` in **`MenuSubTrigger`/`MenuCheckboxItem`/`MenuRadioItem`**
+  (proves the base+variant layering end-to-end; SubTrigger adds the open-timer +
+  grace-polygon layer).
+- **`useMenuSub()`** — the `MenuContext` symmetry (`MenuSub` re-provides a
+  `MenuContext`-shaped object).
+- Fold `useFocusGuards`/`useBodyScrollLock` into `useMenuContent` behind a flag, so a
+  standalone consumer opts into the mount side-effects (kept in the SFC here so the
+  brain stays side-effect-free).
+- Move `PartSurface` to `@/shared` (this POC imports it from `@/Switch` on `v3`; the
+  Tabs PR #2795 relocates it — rebase onto that).
+
+## Bottom line
+`useX()` works for overlays. It costs two axiom amendments (state-only root;
+context-scoped factories) and one exemption (functional `data-*`). The real prize
+isn't the item surface — it's that the overlay brain in the Content part extracts,
+and this POC **proves it**: `useMenuContent()` takes 405→191 lines out of the SFC
+with one named seam (`getItems`), all 51 consumer tests still green. That is the
+concrete evidence #2724 needs before it rewrites overlay internals — the overlay
+contract can be "state-only root + brain composable + wrappers stay wrappers."

--- a/docs/superpowers/recipes/2723-headless-composable-recipe.md
+++ b/docs/superpowers/recipes/2723-headless-composable-recipe.md
@@ -103,21 +103,56 @@ computed from `(context, itemValue)`. What converting Tabs settled:
   to a literal so it stays callable outside `setup()` (Tabs is computed-only — no
   watchers/lifecycle in the composable). Never call `useId` inside the composable.
 
+## Overlay families (validated on Menu)
+
+Overlays (Menu/DropdownMenu, Dialog, Popover, Select, Combobox) differ again: the
+ROOT renders no attrs, and the behavior lives in a Content part wrapped by component
+families (FocusScope/DismissableLayer/Presence/Popper/RovingFocus). Converting the
+core Menu parts settled the overlay contract:
+
+- **The root is state-only: `{ state, context }`, no `PartSurface`.** `useMenuRoot()`
+  returns `open`/`onOpenChange`/`onClose` + the context object(s) the SFC provides.
+  The family is not surface-free — surfaces begin at Trigger/Content. Positioning
+  (`PopperRoot`) and portal stay wrappers.
+- **Per-item overlay builders are context-SCOPED FACTORIES, not pure builders.**
+  Unlike Tabs' idempotent `(context, value)` derivations, `getMenuItemBaseSurface`
+  creates per-instance state (`isFocused`) and closes over the item's `currentElement`
+  — call it EXACTLY ONCE per instance. `state`/`props` computeds stay pure; the
+  factory instantiates. **This is the Tabs axiom that does NOT survive overlays.**
+- **Functional `data-*` selectors are exempt from the no-`data-*` rule.**
+  `data-reka-menu-content` (submenu `closest()` scoping), `data-reka-collection-item`,
+  and `[data-disabled]` (read by `useArrowNavigation`) are selectors, not semantic
+  state — put them in `props`, not through `stateToDataAttrs`. Dropping one degrades
+  UX with no test failure.
+- **Close-on-select is a callback channel, not a merged listener.** The item's
+  `CustomEvent(ITEM_SELECT, { cancelable })` is a token: emit it, `await nextTick()`,
+  close unless `defaultPrevented`. Expose it as an `onSelect(event)` option; the SFC
+  passes `e => emits('select', e)`. Never bind it as a DOM listener.
+- **The Content "brain" extracts; the wrappers are the shell.** Typeahead, arrow-nav,
+  the pointer-grace machine, and `highlightedElement` ownership are wrapper-independent
+  — `useMenuContent()` took `MenuContentImpl` from 405→191 lines, returning the
+  `role=menu` surface + the content context; FocusScope/DismissableLayer/
+  RovingFocusGroup/PopperContent + `useFocusGuards`/`useBodyScrollLock` stay in the
+  SFC. The one seam that can't move is `RovingFocusGroup.getItems()` (a template-
+  instance ref) — inject it as a `getItems` option.
+- **Overlay composables are mount-lifecycle-bound** (`useIsUsingKeyboard`, the content
+  watchers/`onUnmounted`) — NOT callable outside `setup()`; test in a mount harness.
+
 ## Dependency- and structure-ordered migration (not size)
 
-- **Overlays are deferred.** Dialog/Popover/Tooltip/HoverCard/DropdownMenu/Select/
-  Combobox render **no root attrs** (`PopoverRoot` is `<PopperRoot><slot/></PopperRoot>`);
-  their logic lives in Content-part component wrappers. Define the overlay contract
-  **jointly with #2724** (which rewrites overlay internals) — converting them here
-  first is double churn.
+- **Overlays: contract validated on Menu (see above).** The remaining overlays
+  (Dialog/Popover/Tooltip/HoverCard/Select/Combobox) render **no root attrs**
+  (`PopoverRoot` is `<PopperRoot><slot/></PopperRoot>`) and share Menu's shape. Convert
+  them **jointly with #2724** (which rewrites overlay internals) so the state-only-root
+  + brain-composable + wrappers-stay-wrappers contract lands once, not twice.
 - **Convert dependencies first.** Families that snapshot a child's `exposed`
   (`ComboboxRoot` reads `ListboxRoot`'s exposed methods) require the dependency
   converted first: **Listbox → Combobox → Select**.
 - **Tiers:** (1) form/toggle: Checkbox, RadioGroup, ToggleGroup, Toggle; (2)
   collection/disclosure: Tabs ✓(gate), Accordion, Collapsible; (3) delegation
-  chains: Listbox → Combobox → Select; (4) overlays — deferred (joint with #2724);
-  (5) date/calendar family last (heavy generics; `useDateField` is already
-  composable-shaped — the house prior art for this whole effort).
+  chains: Listbox → Combobox → Select; (4) overlays — Menu ✓(contract), rest joint
+  with #2724; (5) date/calendar family last (heavy generics; `useDateField` is
+  already composable-shaped — the house prior art for this whole effort).
 
 ## Footguns
 

--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -2,7 +2,6 @@
 import type { Ref } from 'vue'
 import type {
   GraceIntent,
-  Side,
 } from './utils'
 import type {
   DismissableLayerEmits,
@@ -14,11 +13,9 @@ import type { RovingFocusGroupEmits } from '@/RovingFocus'
 
 import {
   createContext,
-  getActiveElement,
-  useArrowNavigation,
+  stateToDataAttrs,
   useFocusGuards,
   useForwardExpose,
-  useTypeahead,
 } from '@/shared'
 import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 
@@ -92,10 +89,9 @@ export interface MenuRootContentTypeProps
 
 <script setup lang="ts">
 import {
-  onUnmounted,
+  mergeProps,
   ref,
   toRefs,
-  watch,
 } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { FocusScope } from '@/FocusScope'
@@ -105,14 +101,7 @@ import {
 } from '@/Popper'
 import { RovingFocusGroup } from '@/RovingFocus'
 import { injectMenuContext, injectMenuRootContext } from './MenuRoot.vue'
-import {
-  FIRST_LAST_KEYS,
-  focusFirst,
-  getOpenState,
-  isMouseEvent,
-  isPointerInGraceArea,
-  LAST_KEYS,
-} from './utils'
+import { useMenuContent } from './useMenu'
 
 const props = withDefaults(defineProps<MenuContentImplProps>(), {
   ...PopperContentPropsDefaultValue,
@@ -123,223 +112,28 @@ const rootContext = injectMenuRootContext()
 
 const { trapFocus, disableOutsidePointerEvents, loop } = toRefs(props)
 
+// Mount side-effects + the four component wrappers (FocusScope/DismissableLayer/
+// RovingFocusGroup/PopperContent) stay in the SFC; the keyboard/pointer/highlight
+// brain moves into useMenuContent(). `getItems` bridges the one seam the composable
+// can't reach — RovingFocusGroup's template-instance-ref.
 useBodyScrollLock(disableOutsidePointerEvents.value)
-
-const searchRef = ref('')
-const timerRef = ref(0)
-const pointerGraceTimerRef = ref(0)
-const pointerGraceIntentRef = ref<GraceIntent | null>(null)
-const pointerDirRef = ref<Side>('right')
-const lastPointerXRef = ref(0)
-const currentItemId = ref<string | null>(null)
 
 const rovingFocusGroupRef = ref<InstanceType<typeof RovingFocusGroup>>()
 const { forwardRef, currentElement: contentElement } = useForwardExpose()
-// Scope focus guards to the content's root (shadow-safe); anchored on the
-// content element, so it's set up after `contentElement` is resolved.
+
+// Shadow-safe focus guards scoped to the content's root (#2794).
 useFocusGuards(contentElement)
-const { handleTypeaheadSearch } = useTypeahead()
 
-const highlightedElement = ref<HTMLElement>()
-
-function onKeydownNavigation(event: KeyboardEvent) {
-  const el = useArrowNavigation(
-    event,
-    (highlightedElement.value || getActiveElement()) as HTMLElement,
-    contentElement.value,
-    {
-      loop: loop.value,
-      arrowKeyOptions: 'vertical',
-      dir: rootContext?.dir.value,
-      focus: false,
-      attributeName: '[data-reka-collection-item]:not([data-disabled])',
-    },
-  )
-  if (el) {
-    highlightedElement.value = el
-    el.scrollIntoView({ block: 'nearest' })
-  }
-}
-
-function onKeydownEnter() {
-  if (highlightedElement.value) {
-    highlightedElement.value.click()
-  }
-}
-
-const filterElement = ref<HTMLElement>()
-const activeSubmenuContext = ref<{ onOpenChange: (open: boolean) => void, trigger: Ref<HTMLElement | undefined> }>()
-
-watch(highlightedElement, (el) => {
-  if (activeSubmenuContext.value && (el === undefined || el !== activeSubmenuContext.value.trigger.value)) {
-    // Don't close the submenu when the highlight disappears (pointer left
-    // all parent items, likely because the submenu opened on top of the
-    // trigger in a constrained viewport). Only close when highlight moves
-    // to a different parent item.
-    if (el === undefined)
-      return
-    activeSubmenuContext.value.onOpenChange(false)
-    activeSubmenuContext.value = undefined
-  }
+const { content, contentContext, handleMountAutoFocus, currentItemId } = useMenuContent({
+  menuContext: menuContext!,
+  rootContext,
+  contentElement,
+  getItems: () => rovingFocusGroupRef.value?.getItems() ?? [],
+  loop,
+  onOpenAutoFocus: event => emits('openAutoFocus', event),
 })
 
-watch(contentElement, (el) => {
-  menuContext!.onContentChange(el)
-})
-
-onUnmounted(() => {
-  window.clearTimeout(timerRef.value)
-})
-
-function isPointerMovingToSubmenu(event: PointerEvent) {
-  const isMovingTowards
-    = pointerDirRef.value === pointerGraceIntentRef.value?.side
-
-  return (
-    isMovingTowards
-    && isPointerInGraceArea(event, pointerGraceIntentRef.value?.area)
-  )
-}
-
-async function handleMountAutoFocus(event: Event) {
-  emits('openAutoFocus', event)
-  if (event.defaultPrevented)
-    return
-  // when opening, explicitly focus the content area only and leave
-  // `onEntryFocus` in  control of focusing first item
-  event.preventDefault()
-  contentElement.value?.focus({
-    preventScroll: true,
-  })
-}
-
-function handleKeyDown(event: KeyboardEvent) {
-  if (event.defaultPrevented)
-    return
-  // submenu key events bubble through portals. We only care about keys in this menu.
-  const target = event.target as HTMLElement
-  const isKeyDownInside
-    = target.closest('[data-reka-menu-content]') === event.currentTarget
-  const isKeyDownInTextField = ['input', 'textarea'].includes(target.tagName.toLowerCase())
-  const isModifierKey = event.ctrlKey || event.altKey || event.metaKey
-  const isCharacterKey = event.key.length === 1
-
-  const el = useArrowNavigation(
-    event,
-    getActiveElement() as HTMLElement,
-    contentElement.value,
-    {
-      loop: loop.value,
-      arrowKeyOptions: 'vertical',
-      dir: rootContext?.dir.value,
-      focus: true,
-      attributeName: '[data-reka-collection-item]:not([data-disabled])',
-    },
-  )
-  if (el)
-    return el?.focus()
-
-  // prevent "Space" taken account into handleTypeahead
-  if (event.code === 'Space')
-    return
-
-  const collectionItems = rovingFocusGroupRef.value?.getItems() ?? []
-
-  if (isKeyDownInside) {
-    if (event.key === 'Tab' && rootContext.modal.value)
-      event.preventDefault()
-    if (!isModifierKey && isCharacterKey && !isKeyDownInTextField)
-      handleTypeaheadSearch(event.key, collectionItems)
-  }
-
-  // focus first/last item based on key pressed
-  if (event.target !== contentElement.value)
-    return
-  if (!FIRST_LAST_KEYS.includes(event.key))
-    return
-  event.preventDefault()
-  const candidateNodes = [...collectionItems.map(item => item.ref)]
-  if (LAST_KEYS.includes(event.key))
-    candidateNodes.reverse()
-  focusFirst(candidateNodes)
-}
-
-function handleBlur(event: FocusEvent) {
-  // clear search buffer when leaving the menu
-  // @ts-expect-error the provided currentTarget and target should be HTMLElement
-  if (!event?.currentTarget?.contains?.(event.target)) {
-    window.clearTimeout(timerRef.value)
-    searchRef.value = ''
-  }
-}
-
-function handlePointerMove(event: PointerEvent) {
-  if (!isMouseEvent(event))
-    return
-  const target = event.target as HTMLElement
-  const pointerXHasChanged = lastPointerXRef.value !== event.clientX
-
-  // We don't use `event.movementX` for this check because Safari will
-  // always return `0` on a pointer event.
-  if (
-    (event?.currentTarget as HTMLElement)?.contains(target)
-    && pointerXHasChanged
-  ) {
-    const newDir = event.clientX > lastPointerXRef.value ? 'right' : 'left'
-    pointerDirRef.value = newDir
-    lastPointerXRef.value = event.clientX
-  }
-}
-
-function handlePointerEnter(event: PointerEvent) {
-  if (!isMouseEvent(event))
-    return
-  // When hovering over a menu content (main or sub), focus its filter element if it exists
-  if (filterElement.value) {
-    filterElement.value.focus()
-  }
-}
-
-provideMenuContentContext({
-  onItemEnter: (event) => {
-    // event.preventDefault() we can't prevent pointerMove event
-    if (isPointerMovingToSubmenu(event))
-      return true
-    else
-      return false
-  },
-  onItemLeave: (event) => {
-    if (isPointerMovingToSubmenu(event))
-      return true
-
-    const isInputFocused = ['INPUT', 'TEXTAREA'].includes(getActiveElement()?.tagName || '')
-    if (!isInputFocused)
-      contentElement.value?.focus()
-
-    currentItemId.value = null
-    return false
-  },
-  onTriggerLeave: (event) => {
-    // event.preventDefault() we can't prevent pointerLeave event
-    if (isPointerMovingToSubmenu(event))
-      return true
-    else
-      return false
-  },
-  searchRef,
-  highlightedElement,
-  onKeydownNavigation,
-  onKeydownEnter,
-  filterElement,
-  onFilterElementChange: (el) => {
-    filterElement.value = el
-  },
-  activeSubmenuContext,
-  pointerGraceTimerRef,
-  onPointerGraceIntentChange: (intent) => {
-    pointerGraceIntentRef.value = intent
-  },
-})
+provideMenuContentContext(contentContext)
 </script>
 
 <template>
@@ -373,13 +167,8 @@ provideMenuContentContext({
       >
         <PopperContent
           :ref="forwardRef"
-          role="menu"
           :as="as"
           :as-child="asChild"
-          aria-orientation="vertical"
-          data-reka-menu-content
-          :data-state="getOpenState(menuContext.open.value)"
-          :dir="rootContext.dir.value"
           :side="side"
           :side-offset="sideOffset"
           :align="align"
@@ -394,10 +183,7 @@ provideMenuContentContext({
           :sticky="sticky"
           :hide-when-detached="hideWhenDetached"
           :reference="reference"
-          @keydown="handleKeyDown"
-          @blur="handleBlur"
-          @pointermove="handlePointerMove"
-          @pointerenter="handlePointerEnter"
+          v-bind="mergeProps(content.props.value, stateToDataAttrs(content.state.value))"
         >
           <slot />
         </PopperContent>

--- a/packages/core/src/Menu/MenuItem.vue
+++ b/packages/core/src/Menu/MenuItem.vue
@@ -14,11 +14,11 @@ export interface MenuItemProps extends MenuItemImplProps {}
 </script>
 
 <script setup lang="ts">
-import { nextTick, ref } from 'vue'
+import { mergeProps } from 'vue'
 import { injectMenuContentContext } from './MenuContentImpl.vue'
 import MenuItemImpl from './MenuItemImpl.vue'
 import { injectMenuRootContext } from './MenuRoot.vue'
-import { ITEM_SELECT, SELECTION_KEYS } from './utils'
+import { getMenuItemSelectSurface } from './useMenu'
 
 const props = defineProps<MenuItemProps>()
 const emits = defineEmits<MenuItemEmits>()
@@ -27,61 +27,21 @@ const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectMenuRootContext()
 const contentContext = injectMenuContentContext()
 
-const isPointerDownRef = ref(false)
-
-async function handleSelect() {
-  const menuItem = currentElement.value
-  if (!props.disabled && menuItem) {
-    const itemSelectEvent = new CustomEvent(ITEM_SELECT, {
-      bubbles: true,
-      cancelable: true,
-    })
-    emits('select', itemSelectEvent)
-    // let select event finish
-    await nextTick()
-    if (itemSelectEvent.defaultPrevented)
-      isPointerDownRef.value = false
-    else rootContext.onClose()
-  }
-}
+// The select layer (click/pointer/keydown + the close-on-select protocol). Merged
+// onto MenuItemImpl so its handlers chain with the base surface's. `onSelect` is a
+// callback channel — the cancelable CustomEvent token, not a merged DOM listener.
+const select = getMenuItemSelectSurface(rootContext, {
+  disabled: () => props.disabled,
+  currentElement,
+  onSelect: event => emits('select', event),
+  searchRef: contentContext.searchRef,
+})
 </script>
 
 <template>
   <MenuItemImpl
-    v-bind="props"
+    v-bind="mergeProps(props, select.props.value)"
     :ref="forwardRef"
-    @click="handleSelect"
-    @pointerdown="
-      () => {
-        isPointerDownRef = true;
-      }
-    "
-    @pointerup="
-      async (event: PointerEvent) => {
-        await nextTick();
-        if (event.defaultPrevented) return;
-        // Pointer down can move to a different menu item which should activate it on pointer up.
-        // We dispatch a click for selection to allow composition with click based triggers and to
-        // prevent Firefox from getting stuck in text selection mode when the menu closes.
-        if (!isPointerDownRef) (event.currentTarget as HTMLElement)?.click();
-      }
-    "
-    @keydown="
-      async (event: KeyboardEvent) => {
-        const isTypingAhead = contentContext.searchRef.value !== '';
-        if (disabled || (isTypingAhead && event.key === ' ')) return;
-        if (SELECTION_KEYS.includes(event.key)) {
-          (event.currentTarget as HTMLElement)?.click();
-          /**
-           * We prevent default browser behaviour for selection keys as they should trigger
-           * a selection only:
-           * - prevents space from scrolling the page.
-           * - if keydown causes focus to move, prevents keydown from firing on the new target.
-           */
-          event.preventDefault();
-        }
-      }
-    "
   >
     <slot />
   </MenuItemImpl>

--- a/packages/core/src/Menu/MenuItemImpl.vue
+++ b/packages/core/src/Menu/MenuItemImpl.vue
@@ -13,14 +13,12 @@ export interface MenuItemImplProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, nextTick, ref } from 'vue'
+import { mergeProps } from 'vue'
 import { useCollection } from '@/Collection'
-import {
-  Primitive,
-} from '@/Primitive'
-import { getActiveElement, useForwardExpose } from '@/shared'
+import { Primitive } from '@/Primitive'
+import { stateToDataAttrs, useForwardExpose } from '@/shared'
 import { injectMenuContentContext } from './MenuContentImpl.vue'
-import { isMouseEvent } from './utils'
+import { getMenuItemBaseSurface } from './useMenu'
 
 defineOptions({
   inheritAttrs: false,
@@ -32,75 +30,22 @@ const contentContext = injectMenuContentContext()
 const { forwardRef, currentElement } = useForwardExpose()
 const { CollectionItem } = useCollection()
 
-const isFocused = ref(false)
-const isHighlighted = computed(() => isFocused.value || (currentElement.value != null && contentContext.highlightedElement.value === currentElement.value))
-
-async function handlePointerMove(event: PointerEvent) {
-  if (event.defaultPrevented || !isMouseEvent(event))
-    return
-  if (props.disabled) {
-    contentContext.onItemLeave(event)
-  }
-  else {
-    const defaultPrevented = contentContext.onItemEnter(event)
-    if (!defaultPrevented) {
-      const item = event.currentTarget as HTMLElement
-      contentContext.highlightedElement.value = item
-      const isInputFocused = ['INPUT', 'TEXTAREA'].includes(getActiveElement()?.tagName || '')
-      if (!isInputFocused)
-        item.focus({ preventScroll: true })
-    }
-  }
-}
-
-async function handlePointerLeave(event: PointerEvent) {
-  await nextTick()
-  if (event.defaultPrevented)
-    return
-  if (!isMouseEvent(event))
-    return
-
-  // If the highlight was already claimed by another element (e.g. the pointer moved
-  // directly onto another item, whose synchronous `pointermove` ran before this
-  // `nextTick` resolved), this leave is stale and must not reset focus/roving state.
-  if (contentContext.highlightedElement.value !== currentElement.value)
-    return
-
-  const isMovingToSubmenu = contentContext.onItemLeave(event)
-  if (!isMovingToSubmenu && contentContext.highlightedElement.value === currentElement.value)
-    contentContext.highlightedElement.value = undefined
-}
+// role/aria/data-* + the hover-highlight (pointermove/leave/focus/blur) come from
+// the shared item surface. The `<CollectionItem>` registration wrapper stays in
+// the SFC — it is vnode-bound provide/inject a composable can't absorb.
+const surface = getMenuItemBaseSurface(contentContext, {
+  disabled: () => props.disabled,
+  currentElement,
+})
 </script>
 
 <template>
   <CollectionItem :value="{ textValue }">
     <Primitive
       :ref="forwardRef"
-      role="menuitem"
-      tabindex="-1"
-      v-bind="$attrs"
       :as="as"
       :as-child="asChild"
-      :aria-disabled="disabled || undefined"
-      :data-disabled="disabled ? '' : undefined"
-      :data-highlighted="isHighlighted ? '' : undefined"
-      @pointermove="handlePointerMove"
-      @pointerleave="handlePointerLeave"
-      @focus="
-        async (event: FocusEvent) => {
-          await nextTick();
-          if (event.defaultPrevented || disabled) return;
-          isFocused = true;
-          contentContext.highlightedElement.value = event.currentTarget as HTMLElement
-        }
-      "
-      @blur="
-        async (event: FocusEvent) => {
-          await nextTick();
-          if (event.defaultPrevented) return;
-          isFocused = false;
-        }
-      "
+      v-bind="mergeProps(surface.props.value, stateToDataAttrs(surface.state.value), $attrs)"
     >
       <slot />
     </Primitive>

--- a/packages/core/src/Menu/MenuRoot.vue
+++ b/packages/core/src/Menu/MenuRoot.vue
@@ -2,7 +2,6 @@
 import type { Ref } from 'vue'
 import type { Direction } from './utils'
 import { createContext, useDirection } from '@/shared'
-import { useIsUsingKeyboard } from '@/shared/useIsUsingKeyboard'
 
 export interface MenuContext {
   open: Ref<boolean>
@@ -48,44 +47,25 @@ export const [injectMenuRootContext, provideMenuRootContext]
 
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
-import {
-  ref,
-  toRefs,
-} from 'vue'
+import { toRefs } from 'vue'
 import { PopperRoot } from '@/Popper'
+import { useMenuRoot } from './useMenu'
 
 const props = withDefaults(defineProps<MenuProps>(), {
   open: false,
   modal: true,
 })
 const emits = defineEmits<MenuEmits>()
+// `useVModel` + `useDirection` (ConfigProvider-aware) stay in the shell; the
+// composable receives the resolved refs and builds the two context objects.
 const { modal, dir: propDir } = toRefs(props)
 const dir = useDirection(propDir)
-
 const open = useVModel(props, 'open', emits)
 
-const content = ref<HTMLElement>()
-const isUsingKeyboardRef = useIsUsingKeyboard()
+const { menuContext, menuRootContext } = useMenuRoot({ open, dir, modal })
 
-provideMenuContext({
-  open,
-  onOpenChange: (value) => {
-    open.value = value
-  },
-  content,
-  onContentChange: (element) => {
-    content.value = element
-  },
-})
-
-provideMenuRootContext({
-  onClose: () => {
-    open.value = false
-  },
-  isUsingKeyboardRef,
-  dir,
-  modal,
-})
+provideMenuContext(menuContext)
+provideMenuRootContext(menuRootContext)
 </script>
 
 <template>

--- a/packages/core/src/Menu/useMenu.test.ts
+++ b/packages/core/src/Menu/useMenu.test.ts
@@ -1,0 +1,291 @@
+import type { MenuContentContext } from './MenuContentImpl.vue'
+import type { MenuContext, MenuRootContext } from './MenuRoot.vue'
+import type { UseMenuContentReturn, UseMenuRootReturn } from './useMenu'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, ref } from 'vue'
+import { getMenuItemBaseSurface, getMenuItemSelectSurface, useMenuContent, useMenuRoot } from './useMenu'
+
+// Minimal fakes — the builders only touch a handful of context fields.
+function mockContentContext(overrides: Partial<MenuContentContext> = {}): MenuContentContext {
+  return {
+    highlightedElement: ref<HTMLElement | undefined>(undefined),
+    searchRef: ref(''),
+    onItemEnter: vi.fn(() => false),
+    onItemLeave: vi.fn(() => false),
+    onTriggerLeave: vi.fn(() => false),
+    ...overrides,
+  } as unknown as MenuContentContext
+}
+
+function mockRootContext(overrides: Partial<MenuRootContext> = {}): MenuRootContext {
+  return {
+    onClose: vi.fn(),
+    dir: ref('ltr'),
+    isUsingKeyboardRef: ref(false),
+    modal: ref(true),
+    ...overrides,
+  } as unknown as MenuRootContext
+}
+
+function mockMenuContext(open = true): MenuContext {
+  return {
+    open: ref(open),
+    onOpenChange: vi.fn(),
+    content: ref<HTMLElement | undefined>(undefined),
+    onContentChange: vi.fn(),
+  } as unknown as MenuContext
+}
+
+describe('useMenuRoot — state-only overlay root', () => {
+  function harness() {
+    let api!: UseMenuRootReturn
+    mount(defineComponent({
+      setup() {
+        api = useMenuRoot()
+        return () => null
+      },
+    }))
+    return api
+  }
+
+  it('returns the two context objects, no PartSurface', () => {
+    const api = harness()
+    expect(api.menuContext).toBeDefined()
+    expect(api.menuRootContext).toBeDefined()
+    expect('root' in api).toBe(false)
+    expect('props' in api).toBe(false)
+  })
+
+  it('defaults: closed, modal, ltr', () => {
+    const api = harness()
+    expect(api.open.value).toBe(false)
+    expect(api.menuRootContext.modal.value).toBe(true)
+    expect(api.menuRootContext.dir.value).toBe('ltr')
+  })
+
+  it('onOpenChange/onClose drive the shared open ref (context sees it)', () => {
+    const api = harness()
+    api.onOpenChange(true)
+    expect(api.open.value).toBe(true)
+    expect(api.menuContext.open.value).toBe(true)
+    api.onClose()
+    expect(api.open.value).toBe(false)
+  })
+
+  it('onContentChange writes the content ref', () => {
+    const api = harness()
+    const el = document.createElement('div')
+    api.menuContext.onContentChange(el)
+    expect(api.menuContext.content.value).toBe(el)
+  })
+})
+
+describe('getMenuItemBaseSurface — the item render surface', () => {
+  it('props expose role/tabindex/aria-disabled and NO data-*; state is semantic', () => {
+    const surface = getMenuItemBaseSurface(mockContentContext(), { currentElement: ref(), disabled: true })
+    expect(surface.props.value).toMatchObject({ 'role': 'menuitem', 'tabindex': -1, 'aria-disabled': true })
+    expect(Object.keys(surface.props.value).some(k => k.startsWith('data-'))).toBe(false)
+    expect(surface.state.value).toEqual({ disabled: true, highlighted: false })
+  })
+
+  it('isHighlighted tracks the content highlightedElement by element identity', () => {
+    const ctx = mockContentContext()
+    const el = document.createElement('div')
+    const surface = getMenuItemBaseSurface(ctx, { currentElement: ref(el), disabled: false })
+    expect(surface.isHighlighted.value).toBe(false)
+    ctx.highlightedElement.value = el
+    expect(surface.isHighlighted.value).toBe(true)
+    expect(surface.state.value.highlighted).toBe(true)
+  })
+
+  it('pointermove enters + claims the highlight for an enabled item', async () => {
+    const ctx = mockContentContext()
+    const el = document.createElement('div')
+    const surface = getMenuItemBaseSurface(ctx, { currentElement: ref(el), disabled: false })
+    const evt = { defaultPrevented: false, pointerType: 'mouse', currentTarget: el } as unknown as PointerEvent
+    await surface.props.value.onPointermove(evt)
+    expect(ctx.onItemEnter).toHaveBeenCalled()
+    expect(ctx.highlightedElement.value).toBe(el)
+  })
+
+  it('pointermove on a disabled item leaves instead of highlighting', async () => {
+    const ctx = mockContentContext()
+    const surface = getMenuItemBaseSurface(ctx, { currentElement: ref(), disabled: true })
+    const evt = { defaultPrevented: false, pointerType: 'mouse', currentTarget: document.createElement('div') } as unknown as PointerEvent
+    await surface.props.value.onPointermove(evt)
+    expect(ctx.onItemLeave).toHaveBeenCalled()
+    expect(ctx.highlightedElement.value).toBeUndefined()
+  })
+})
+
+describe('getMenuItemSelectSurface — the select protocol', () => {
+  it('click emits a cancelable select token and closes when not prevented', async () => {
+    const rootContext = mockRootContext()
+    const onSelect = vi.fn()
+    const select = getMenuItemSelectSurface(rootContext, {
+      currentElement: ref(document.createElement('div')),
+      onSelect,
+      searchRef: ref(''),
+      disabled: false,
+    })
+    await select.props.value.onClick()
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect((onSelect.mock.calls[0][0] as Event).cancelable).toBe(true)
+    expect(rootContext.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close when the consumer prevents the select token', async () => {
+    const rootContext = mockRootContext()
+    const select = getMenuItemSelectSurface(rootContext, {
+      currentElement: ref(document.createElement('div')),
+      onSelect: (e: Event) => e.preventDefault(),
+      searchRef: ref(''),
+      disabled: false,
+    })
+    await select.props.value.onClick()
+    expect(rootContext.onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not select a disabled item', async () => {
+    const rootContext = mockRootContext()
+    const onSelect = vi.fn()
+    const select = getMenuItemSelectSurface(rootContext, {
+      currentElement: ref(document.createElement('div')),
+      onSelect,
+      searchRef: ref(''),
+      disabled: true,
+    })
+    await select.props.value.onClick()
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(rootContext.onClose).not.toHaveBeenCalled()
+  })
+
+  it('keydown on a selection key clicks the item and preventsDefault', async () => {
+    const el = document.createElement('div')
+    const clickSpy = vi.fn()
+    el.click = clickSpy
+    const select = getMenuItemSelectSurface(mockRootContext(), {
+      currentElement: ref(el),
+      onSelect: vi.fn(),
+      searchRef: ref(''),
+      disabled: false,
+    })
+    const evt = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+    Object.defineProperty(evt, 'currentTarget', { value: el })
+    await select.props.value.onKeydown(evt)
+    expect(clickSpy).toHaveBeenCalled()
+    expect(evt.defaultPrevented).toBe(true)
+  })
+
+  it('keydown Space is ignored while typing ahead', async () => {
+    const el = document.createElement('div')
+    const clickSpy = vi.fn()
+    el.click = clickSpy
+    const select = getMenuItemSelectSurface(mockRootContext(), {
+      currentElement: ref(el),
+      onSelect: vi.fn(),
+      searchRef: ref('foo'),
+      disabled: false,
+    })
+    const evt = new KeyboardEvent('keydown', { key: ' ', cancelable: true })
+    Object.defineProperty(evt, 'currentTarget', { value: el })
+    await select.props.value.onKeydown(evt)
+    expect(clickSpy).not.toHaveBeenCalled()
+  })
+
+  it('pointerup dispatches a click only when pointer moved between items', async () => {
+    const el = document.createElement('div')
+    const clickSpy = vi.fn()
+    el.click = clickSpy
+    const select = getMenuItemSelectSurface(mockRootContext(), {
+      currentElement: ref(el),
+      onSelect: vi.fn(),
+      searchRef: ref(''),
+      disabled: false,
+    })
+    // No preceding pointerdown on THIS item (pointer moved from another) → click.
+    const evt = { defaultPrevented: false, currentTarget: el } as unknown as PointerEvent
+    await select.props.value.onPointerup(evt)
+    await nextTick()
+    expect(clickSpy).toHaveBeenCalled()
+
+    // pointerdown on this item first → no synthetic click on pointerup.
+    clickSpy.mockClear()
+    select.props.value.onPointerdown()
+    await select.props.value.onPointerup(evt)
+    await nextTick()
+    expect(clickSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('useMenuContent — the overlay brain', () => {
+  function harness(overrides: Partial<Parameters<typeof useMenuContent>[0]> = {}) {
+    let api!: UseMenuContentReturn
+    const contentEl = document.createElement('div')
+    const contentElement = ref<HTMLElement | undefined>(contentEl)
+    mount(defineComponent({
+      setup() {
+        api = useMenuContent({
+          menuContext: mockMenuContext(true),
+          rootContext: mockRootContext(),
+          contentElement,
+          getItems: () => [],
+          ...overrides,
+        })
+        return () => null
+      },
+    }))
+    return { api, contentEl }
+  }
+
+  it('content.props is the role=menu surface incl. the functional data-reka-menu-content selector', () => {
+    const { api } = harness()
+    expect(api.content.props.value).toMatchObject({
+      'role': 'menu',
+      'aria-orientation': 'vertical',
+      'data-reka-menu-content': '',
+      'dir': 'ltr',
+    })
+    expect(typeof api.content.props.value.onKeydown).toBe('function')
+    expect(typeof api.content.props.value.onPointermove).toBe('function')
+  })
+
+  it('content.state maps the open state to data-state', () => {
+    expect(harness().api.content.state.value.state).toBe('open')
+  })
+
+  it('provides the pointer-grace closure trio + the shared highlight/search refs', () => {
+    const { api } = harness()
+    expect(typeof api.contentContext.onItemEnter).toBe('function')
+    expect(typeof api.contentContext.onItemLeave).toBe('function')
+    expect(typeof api.contentContext.onTriggerLeave).toBe('function')
+    expect(api.contentContext.searchRef).toBe(api.searchRef)
+    expect(api.contentContext.highlightedElement).toBe(api.highlightedElement)
+  })
+
+  it('onItemLeave (not moving to a submenu) refocuses content and clears currentItemId', () => {
+    const { api, contentEl } = harness()
+    const focusSpy = vi.spyOn(contentEl, 'focus')
+    api.currentItemId.value = 'x'
+    const movingToSubmenu = api.contentContext.onItemLeave({} as PointerEvent)
+    expect(movingToSubmenu).toBe(false)
+    expect(focusSpy).toHaveBeenCalled()
+    expect(api.currentItemId.value).toBe(null)
+  })
+
+  it('handleMountAutoFocus focuses content, and the openAutoFocus veto suppresses it', () => {
+    const onOpenAutoFocus = vi.fn()
+    const open = harness({ onOpenAutoFocus })
+    const openFocus = vi.spyOn(open.contentEl, 'focus')
+    const evt = new Event('focus', { cancelable: true })
+    open.api.handleMountAutoFocus(evt)
+    expect(onOpenAutoFocus).toHaveBeenCalledWith(evt)
+    expect(openFocus).toHaveBeenCalled()
+
+    const vetoed = harness({ onOpenAutoFocus: (e: Event) => e.preventDefault() })
+    const vetoedFocus = vi.spyOn(vetoed.contentEl, 'focus')
+    vetoed.api.handleMountAutoFocus(new Event('focus', { cancelable: true }))
+    expect(vetoedFocus).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/Menu/useMenu.ts
+++ b/packages/core/src/Menu/useMenu.ts
@@ -1,0 +1,523 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
+import type { MenuContentContext } from './MenuContentImpl.vue'
+import type { MenuContext, MenuRootContext } from './MenuRoot.vue'
+import type { Direction, GraceIntent, Side } from './utils'
+import type { PartSurface } from '@/shared'
+import { computed, nextTick, onUnmounted, ref, toValue, watch } from 'vue'
+import { getActiveElement, useArrowNavigation, useTypeahead } from '@/shared'
+import { useIsUsingKeyboard } from '@/shared/useIsUsingKeyboard'
+import { FIRST_LAST_KEYS, focusFirst, getOpenState, isMouseEvent, isPointerInGraceArea, ITEM_SELECT, LAST_KEYS, SELECTION_KEYS } from './utils'
+
+// =============================================================================
+// Headless composables for the Menu (overlay) family — issue #2723.
+//
+// Validates that the useX() pattern extends to an OVERLAY family, and documents
+// where it bends. Findings: docs/superpowers/pocs/2723-menu-overlay-composable.md.
+//
+// Four shapes are exercised:
+//  1. useMenuRoot()            — state-only root (NO surface); returns the two
+//                                context objects the SFC provides. This is the
+//                                overlay-root contract: `{ state, context }`.
+//  2. getMenuItemBaseSurface() — the attr-bearing item render surface (role/
+//                                aria/data-* + hover-highlight handlers). A
+//                                context-SCOPED FACTORY: it creates per-instance
+//                                refs (isFocused) and needs the item's element,
+//                                so unlike Tabs' builders it is NOT pure and must
+//                                be called exactly once per item instance.
+//  3. getMenuItemSelectSurface() — the select protocol (click/pointer/keydown +
+//                                the CustomEvent-token close-on-select). Pure
+//                                handlers, no data-*. `onSelect` is a callback
+//                                channel (never a merged DOM listener).
+//  4. useMenuContent()         — the overlay BRAIN (typeahead/arrow-nav/pointer-
+//                                grace/highlight). Returns the role=menu surface +
+//                                MenuContentContext; the 4 wrappers stay in the SFC.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// 1. useMenuRoot — state-only overlay root
+// -----------------------------------------------------------------------------
+
+export interface UseMenuRootProps {
+  /** Externally-owned open state (the SFC hands its `useVModel` ref). */
+  open?: Ref<boolean>
+  /** Resolved reading direction (the SFC hands its `useDirection` ref). @defaultValue `'ltr'` */
+  dir?: MaybeRefOrGetter<Direction | undefined>
+  /** @defaultValue `true` */
+  modal?: MaybeRefOrGetter<boolean | undefined>
+}
+
+export interface UseMenuRootReturn {
+  open: Ref<boolean>
+  onOpenChange: (value: boolean) => void
+  onClose: () => void
+  /** The `MenuContext` value — the SFC provides this verbatim. */
+  menuContext: MenuContext
+  /** The `MenuRootContext` value — the SFC provides this verbatim. */
+  menuRootContext: MenuRootContext
+}
+
+/**
+ * Headless Menu root. Renders NO element attributes (the SFC keeps `<PopperRoot>`
+ * as a wrapper), so there is NO `PartSurface` — the return is pure state plus the
+ * two context objects. This is the overlay-root contract: `{ state, context }`.
+ *
+ * NOT callable outside `setup()` — `useIsUsingKeyboard` binds a mount lifecycle.
+ * (Overlay roots are inherently lifecycle-bound; test in a mount harness.)
+ */
+export function useMenuRoot(props: UseMenuRootProps = {}): UseMenuRootReturn {
+  const open = props.open ?? ref(false)
+  const dir = computed<Direction>(() => toValue(props.dir) ?? 'ltr')
+  const modal = computed<boolean>(() => toValue(props.modal) ?? true)
+  const content = ref<HTMLElement>()
+  const isUsingKeyboardRef = useIsUsingKeyboard()
+
+  function onOpenChange(value: boolean) {
+    open.value = value
+  }
+  function onClose() {
+    open.value = false
+  }
+
+  const menuContext: MenuContext = {
+    open,
+    onOpenChange,
+    content,
+    onContentChange: (element) => {
+      content.value = element
+    },
+  }
+  const menuRootContext: MenuRootContext = {
+    onClose,
+    dir: dir as Ref<Direction>,
+    isUsingKeyboardRef,
+    modal: modal as Ref<boolean>,
+  }
+
+  return { open, onOpenChange, onClose, menuContext, menuRootContext }
+}
+
+// -----------------------------------------------------------------------------
+// 2. getMenuItemBaseSurface — the item render surface (MenuItemImpl)
+// -----------------------------------------------------------------------------
+
+export type MenuItemState = { disabled: boolean, highlighted: boolean }
+
+export interface MenuItemBaseSurface extends PartSurface<MenuItemState> {
+  /** Focus-driven half of the highlight (item also reads content's shared ref). */
+  isFocused: Ref<boolean>
+  isHighlighted: ComputedRef<boolean>
+}
+
+export interface MenuItemBaseOptions {
+  disabled?: MaybeRefOrGetter<boolean | undefined>
+  /**
+   * The item's own element ref (populated by the SFC after mount). REQUIRED: the
+   * highlight identity check and pointer handlers compare against this element,
+   * so a standalone caller must pass a ref it will populate.
+   */
+  currentElement: Ref<HTMLElement | undefined>
+}
+
+/**
+ * The attr-bearing item surface shared by every item variant (they all render
+ * through `MenuItemImpl`). A context-SCOPED FACTORY: it creates `isFocused` and
+ * closes over `currentElement`, so call it EXACTLY ONCE per item instance (never
+ * re-derive) — this is the axiom Tabs' pure builders don't need.
+ *
+ * `highlightedElement` is content-owned shared state; the item both reads it (for
+ * `isHighlighted`) and writes it (on pointer-enter/focus) through the context.
+ */
+export function getMenuItemBaseSurface(
+  contentContext: MenuContentContext,
+  options: MenuItemBaseOptions,
+): MenuItemBaseSurface {
+  const { currentElement } = options
+  const isDisabled = computed(() => toValue(options.disabled) ?? false)
+  const isFocused = ref(false)
+  const isHighlighted = computed(() =>
+    isFocused.value || (currentElement.value != null && contentContext.highlightedElement.value === currentElement.value))
+
+  async function handlePointerMove(event: PointerEvent) {
+    if (event.defaultPrevented || !isMouseEvent(event))
+      return
+    if (isDisabled.value) {
+      contentContext.onItemLeave(event)
+    }
+    else {
+      const defaultPrevented = contentContext.onItemEnter(event)
+      if (!defaultPrevented) {
+        const item = event.currentTarget as HTMLElement
+        contentContext.highlightedElement.value = item
+        const isInputFocused = ['INPUT', 'TEXTAREA'].includes(getActiveElement()?.tagName || '')
+        if (!isInputFocused)
+          item.focus({ preventScroll: true })
+      }
+    }
+  }
+
+  async function handlePointerLeave(event: PointerEvent) {
+    await nextTick()
+    if (event.defaultPrevented)
+      return
+    if (!isMouseEvent(event))
+      return
+    // Stale-leave guard: if another item already claimed the highlight (its
+    // synchronous pointermove ran before this nextTick), don't reset state.
+    if (contentContext.highlightedElement.value !== currentElement.value)
+      return
+    const isMovingToSubmenu = contentContext.onItemLeave(event)
+    if (!isMovingToSubmenu && contentContext.highlightedElement.value === currentElement.value)
+      contentContext.highlightedElement.value = undefined
+  }
+
+  async function handleFocus(event: FocusEvent) {
+    await nextTick()
+    if (event.defaultPrevented || isDisabled.value)
+      return
+    isFocused.value = true
+    contentContext.highlightedElement.value = event.currentTarget as HTMLElement
+  }
+
+  async function handleBlur(event: FocusEvent) {
+    await nextTick()
+    if (event.defaultPrevented)
+      return
+    isFocused.value = false
+  }
+
+  return {
+    props: computed(() => ({
+      'role': 'menuitem',
+      'tabindex': -1,
+      'aria-disabled': isDisabled.value || undefined,
+      'onPointermove': handlePointerMove,
+      'onPointerleave': handlePointerLeave,
+      'onFocus': handleFocus,
+      'onBlur': handleBlur,
+    })),
+    state: computed(() => ({ disabled: isDisabled.value, highlighted: isHighlighted.value })),
+    isFocused,
+    isHighlighted,
+  }
+}
+
+// -----------------------------------------------------------------------------
+// 3. getMenuItemSelectSurface — the select protocol (MenuItem)
+// -----------------------------------------------------------------------------
+
+export interface MenuItemSelectOptions {
+  disabled?: MaybeRefOrGetter<boolean | undefined>
+  currentElement: Ref<HTMLElement | undefined>
+  /**
+   * Select callback channel. The SFC passes `e => emits('select', e)`. NOT a DOM
+   * event — `e` is a cancelable CustomEvent token; calling `preventDefault()` on
+   * it keeps the menu open. This stays a callback (never a merged listener).
+   */
+  onSelect: (event: Event) => void
+  /** Content search buffer, to suppress Space selection while typing ahead. */
+  searchRef: Ref<string>
+}
+
+export interface MenuItemSelectSurface {
+  /** Handlers only — no `state` (select semantics render no `data-*`). */
+  props: ComputedRef<Record<string, any>>
+  isPointerDownRef: Ref<boolean>
+}
+
+/**
+ * The select layer added on top of the base surface. Ported verbatim from
+ * `MenuItem.vue`: the CustomEvent-token protocol (emit → `await nextTick()` →
+ * close unless `defaultPrevented`), and the pointerdown/pointerup/keydown wiring.
+ * Handlers stay async so the `defaultPrevented`-after-`nextTick` consumer veto
+ * keeps working once bound via `mergeProps` (surface handlers first).
+ */
+export function getMenuItemSelectSurface(
+  rootContext: MenuRootContext,
+  options: MenuItemSelectOptions,
+): MenuItemSelectSurface {
+  const isDisabled = computed(() => toValue(options.disabled) ?? false)
+  const isPointerDownRef = ref(false)
+
+  async function handleSelect() {
+    const menuItem = options.currentElement.value
+    if (!isDisabled.value && menuItem) {
+      const itemSelectEvent = new CustomEvent(ITEM_SELECT, { bubbles: true, cancelable: true })
+      options.onSelect(itemSelectEvent)
+      await nextTick()
+      if (itemSelectEvent.defaultPrevented)
+        isPointerDownRef.value = false
+      else
+        rootContext.onClose()
+    }
+  }
+
+  return {
+    props: computed(() => ({
+      onClick: handleSelect,
+      onPointerdown: () => {
+        isPointerDownRef.value = true
+      },
+      onPointerup: async (event: PointerEvent) => {
+        await nextTick()
+        if (event.defaultPrevented)
+          return
+        // Pointer down can move to a different item which should activate on
+        // pointer up; dispatch a click so click-based triggers compose and
+        // Firefox doesn't get stuck in text-selection mode when the menu closes.
+        if (!isPointerDownRef.value)
+          (event.currentTarget as HTMLElement)?.click()
+      },
+      onKeydown: async (event: KeyboardEvent) => {
+        const isTypingAhead = options.searchRef.value !== ''
+        if (isDisabled.value || (isTypingAhead && event.key === ' '))
+          return
+        if (SELECTION_KEYS.includes(event.key)) {
+          (event.currentTarget as HTMLElement)?.click()
+          // Selection keys should only select: prevent Space from scrolling and
+          // prevent keydown re-firing on a new target if focus moved.
+          event.preventDefault()
+        }
+      },
+    })),
+    isPointerDownRef,
+  }
+}
+
+// -----------------------------------------------------------------------------
+// 4. useMenuContent — the overlay BRAIN (MenuContentImpl)
+//
+// The finding this proves: the recipe deferred overlays because "their logic
+// lives in content-part wrappers", but the MAJORITY of MenuContentImpl's logic —
+// typeahead, arrow-nav, the pointer-grace/direction machine, and highlight
+// ownership — is wrapper-INDEPENDENT and extracts here. FocusScope/DismissableLayer/
+// RovingFocusGroup/PopperContent (+ the two mount side-effects useFocusGuards /
+// useBodyScrollLock) stay in the SFC. The wrappers are the shell; this is the brain.
+//
+// The one genuine seam: `RovingFocusGroup.getItems()` is a template-instance-ref
+// call the composable cannot make — the SFC injects it as `getItems`.
+// -----------------------------------------------------------------------------
+
+export interface MenuContentItem { ref: HTMLElement, value?: any }
+
+export interface UseMenuContentOptions {
+  menuContext: MenuContext
+  rootContext: MenuRootContext
+  /** The content element ref (the SFC's `useForwardExpose` currentElement). */
+  contentElement: Ref<HTMLElement | undefined>
+  /**
+   * Roving-focus/collection items. `rovingFocusGroupRef.getItems()` is a
+   * template-instance-ref call the composable can't make — the SFC injects it.
+   * This is the wrapper seam.
+   */
+  getItems: () => MenuContentItem[]
+  /** @defaultValue `false` */
+  loop?: MaybeRefOrGetter<boolean | undefined>
+  /** `openAutoFocus` passthrough (SFC: `e => emits('openAutoFocus', e)`). */
+  onOpenAutoFocus?: (event: Event) => void
+}
+
+export type MenuContentState = { state: 'open' | 'closed' }
+
+export interface UseMenuContentReturn {
+  /** The `role=menu` surface for `PopperContent`; positioning props stay in the SFC. */
+  content: PartSurface<MenuContentState>
+  /** The context the SFC provides via `provideMenuContentContext`. */
+  contentContext: MenuContentContext
+  /** `FocusScope` `@mount-auto-focus` — focuses content, honors the openAutoFocus veto. */
+  handleMountAutoFocus: (event: Event) => void
+  /** `RovingFocusGroup` `v-model:current-tab-stop-id`. */
+  currentItemId: Ref<string | null>
+  highlightedElement: Ref<HTMLElement | undefined>
+  searchRef: Ref<string>
+}
+
+/**
+ * Headless Menu content — the keyboard/pointer/highlight brain. Returns the
+ * `role=menu` surface + the `MenuContentContext` value; the SFC keeps the four
+ * component wrappers and the two mount side-effects. Owns watchers + `onUnmounted`,
+ * so it runs inside the mounted content's `setup()` (not standalone-callable).
+ */
+export function useMenuContent(options: UseMenuContentOptions): UseMenuContentReturn {
+  const { menuContext, rootContext, contentElement, getItems } = options
+  const loop = () => toValue(options.loop) ?? false
+
+  const searchRef = ref('')
+  const timerRef = ref(0)
+  const pointerGraceTimerRef = ref(0)
+  const pointerGraceIntentRef = ref<GraceIntent | null>(null)
+  const pointerDirRef = ref<Side>('right')
+  const lastPointerXRef = ref(0)
+  const currentItemId = ref<string | null>(null)
+  const highlightedElement = ref<HTMLElement>()
+  const filterElement = ref<HTMLElement>()
+  const activeSubmenuContext = ref<{ onOpenChange: (open: boolean) => void, trigger: Ref<HTMLElement | undefined> }>()
+
+  const { handleTypeaheadSearch } = useTypeahead()
+
+  function onKeydownNavigation(event: KeyboardEvent) {
+    const el = useArrowNavigation(
+      event,
+      (highlightedElement.value || getActiveElement()) as HTMLElement,
+      contentElement.value,
+      { loop: loop(), arrowKeyOptions: 'vertical', dir: rootContext?.dir.value, focus: false, attributeName: '[data-reka-collection-item]:not([data-disabled])' },
+    )
+    if (el) {
+      highlightedElement.value = el
+      el.scrollIntoView({ block: 'nearest' })
+    }
+  }
+
+  function onKeydownEnter() {
+    if (highlightedElement.value)
+      highlightedElement.value.click()
+  }
+
+  function isPointerMovingToSubmenu(event: PointerEvent) {
+    const isMovingTowards = pointerDirRef.value === pointerGraceIntentRef.value?.side
+    return isMovingTowards && isPointerInGraceArea(event, pointerGraceIntentRef.value?.area)
+  }
+
+  function handleMountAutoFocus(event: Event) {
+    options.onOpenAutoFocus?.(event)
+    if (event.defaultPrevented)
+      return
+    // focus the content area only; onEntryFocus controls focusing the first item
+    event.preventDefault()
+    contentElement.value?.focus({ preventScroll: true })
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.defaultPrevented)
+      return
+    // submenu key events bubble through portals; only handle keys in this menu.
+    const target = event.target as HTMLElement
+    const isKeyDownInside = target.closest('[data-reka-menu-content]') === event.currentTarget
+    const isKeyDownInTextField = ['input', 'textarea'].includes(target.tagName.toLowerCase())
+    const isModifierKey = event.ctrlKey || event.altKey || event.metaKey
+    const isCharacterKey = event.key.length === 1
+
+    const el = useArrowNavigation(
+      event,
+      getActiveElement() as HTMLElement,
+      contentElement.value,
+      { loop: loop(), arrowKeyOptions: 'vertical', dir: rootContext?.dir.value, focus: true, attributeName: '[data-reka-collection-item]:not([data-disabled])' },
+    )
+    if (el)
+      return el?.focus()
+
+    // prevent "Space" being taken into typeahead
+    if (event.code === 'Space')
+      return
+
+    const collectionItems = getItems() ?? []
+    if (isKeyDownInside) {
+      if (event.key === 'Tab' && rootContext.modal.value)
+        event.preventDefault()
+      if (!isModifierKey && isCharacterKey && !isKeyDownInTextField)
+        handleTypeaheadSearch(event.key, collectionItems)
+    }
+
+    if (event.target !== contentElement.value)
+      return
+    if (!FIRST_LAST_KEYS.includes(event.key))
+      return
+    event.preventDefault()
+    const candidateNodes = [...collectionItems.map(item => item.ref)]
+    if (LAST_KEYS.includes(event.key))
+      candidateNodes.reverse()
+    focusFirst(candidateNodes)
+  }
+
+  function handleBlur(event: FocusEvent) {
+    // clear the search buffer when focus leaves the menu
+    // @ts-expect-error the provided currentTarget and target should be HTMLElement
+    if (!event?.currentTarget?.contains?.(event.target)) {
+      window.clearTimeout(timerRef.value)
+      searchRef.value = ''
+    }
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (!isMouseEvent(event))
+      return
+    const target = event.target as HTMLElement
+    const pointerXHasChanged = lastPointerXRef.value !== event.clientX
+    // not `event.movementX` — Safari always returns 0 on a pointer event.
+    if ((event?.currentTarget as HTMLElement)?.contains(target) && pointerXHasChanged) {
+      pointerDirRef.value = event.clientX > lastPointerXRef.value ? 'right' : 'left'
+      lastPointerXRef.value = event.clientX
+    }
+  }
+
+  function handlePointerEnter(event: PointerEvent) {
+    if (!isMouseEvent(event))
+      return
+    // hovering a menu content (main or sub) focuses its filter element if present
+    if (filterElement.value)
+      filterElement.value.focus()
+  }
+
+  watch(highlightedElement, (el) => {
+    if (activeSubmenuContext.value && (el === undefined || el !== activeSubmenuContext.value.trigger.value)) {
+      // Only close when the highlight moves to a DIFFERENT parent item; a
+      // disappearing highlight (pointer left all items) must not close it.
+      if (el === undefined)
+        return
+      activeSubmenuContext.value.onOpenChange(false)
+      activeSubmenuContext.value = undefined
+    }
+  })
+
+  watch(contentElement, (el) => {
+    menuContext.onContentChange(el)
+  })
+
+  onUnmounted(() => {
+    window.clearTimeout(timerRef.value)
+  })
+
+  const contentContext: MenuContentContext = {
+    onItemEnter: event => isPointerMovingToSubmenu(event),
+    onItemLeave: (event) => {
+      if (isPointerMovingToSubmenu(event))
+        return true
+      const isInputFocused = ['INPUT', 'TEXTAREA'].includes(getActiveElement()?.tagName || '')
+      if (!isInputFocused)
+        contentElement.value?.focus()
+      currentItemId.value = null
+      return false
+    },
+    onTriggerLeave: event => isPointerMovingToSubmenu(event),
+    searchRef,
+    highlightedElement,
+    onKeydownNavigation,
+    onKeydownEnter,
+    filterElement,
+    onFilterElementChange: (el) => {
+      filterElement.value = el
+    },
+    activeSubmenuContext,
+    pointerGraceTimerRef,
+    onPointerGraceIntentChange: (intent) => {
+      pointerGraceIntentRef.value = intent
+    },
+  }
+
+  const content: PartSurface<MenuContentState> = {
+    props: computed(() => ({
+      'role': 'menu',
+      'aria-orientation': 'vertical',
+      // Functional selector (submenu `closest()` scoping) — lives in `props`,
+      // exempt from the no-`data-*` rule; NOT routed through stateToDataAttrs.
+      'data-reka-menu-content': '',
+      'dir': rootContext.dir.value,
+      'onKeydown': handleKeyDown,
+      'onBlur': handleBlur,
+      'onPointermove': handlePointerMove,
+      'onPointerenter': handlePointerEnter,
+    })),
+    state: computed(() => ({ state: getOpenState(menuContext.open.value) })),
+  }
+
+  return { content, contentContext, handleMountAutoFocus, currentItemId, highlightedElement, searchRef }
+}


### PR DESCRIPTION
## Summary

Converts the core **Menu** parts to headless composables (`Refs #2723`), validating the **overlay archetype** after Switch (form-control) and Tabs (collection). Menu is the base for DropdownMenu / ContextMenu / Menubar. Public API is unchanged — an internal re-architecture that additively exposes the logic.

Menu is what the recipe had **deferred** as "overlays"; this PR settles the overlay contract with a working conversion rather than leaving it abstract. It converts `MenuRoot` / `MenuItem` / `MenuItemImpl` / `MenuContentImpl`; the remaining item variants (`MenuSubTrigger` / `Checkbox` / `Radio`) and `MenuSub` reuse the same builders as follow-ups.

## What changed — `Menu/useMenu.ts`

- **`useMenuRoot()`** — the **state-only** overlay root. Returns `{ open, onOpenChange, onClose }` + the `MenuContext` / `MenuRootContext` objects the SFC provides. **No `PartSurface`** — the root renders no attrs. `MenuRoot.vue` composes it.
- **`getMenuItemBaseSurface()`** — the attr-bearing item render surface (role/aria + hover-highlight). A **context-scoped factory** (creates per-instance `isFocused`, needs the item element) — the Tabs "pure builder" axiom does **not** hold for overlays. `MenuItemImpl.vue` composes it.
- **`getMenuItemSelectSurface()`** — the close-on-select protocol as an **`onSelect` callback channel** (the cancelable `CustomEvent` token, never a merged DOM listener). `MenuItem.vue` composes it.
- **`useMenuContent()`** — the overlay **brain**: typeahead, arrow-nav, the pointer-grace machine, and `highlightedElement` ownership. Returns the `role=menu` surface + the content context. Cuts **`MenuContentImpl.vue` from 405 → 191 lines**; the four component wrappers (FocusScope/DismissableLayer/RovingFocusGroup/PopperContent) and the two mount side-effects stay in the SFC. The one un-extractable seam is `RovingFocusGroup.getItems()` (a template-instance ref), injected as a `getItems` option.

Surfaces bind via `mergeProps` so consumer listeners chain. Functional `data-*` selectors (`data-reka-menu-content`) live in `props`, not `stateToDataAttrs`. `useFocusGuards` stays scoped to the content root (#2794).

## The overlay contract (now in the recipe)

`docs/superpowers/recipes/2723-headless-composable-recipe.md` gains an **"Overlay families (validated on Menu)"** section: state-only root; context-scoped factories (not pure builders); functional `data-*` exemption; select-as-callback; **the wrappers are the shell, the content brain is the composable**; overlay composables are mount-bound. Full findings in `docs/superpowers/pocs/2723-menu-overlay-composable.md`.

## Testing

- **19** `useMenu` unit tests across the four shapes (state, item surfaces + handler bodies, pointer-grace closures, `openAutoFocus` veto).
- Compatibility oracle green: **Menu + DropdownMenu + ContextMenu + Menubar 56/56**; full suite **2075 / 107 files**; `type-check` clean; `typos` clean.

## Follow-ups (noted in the doc)
- Reuse `getMenuItemBaseSurface` in `MenuSubTrigger` / `MenuCheckboxItem` / `MenuRadioItem` (base + variant layering).
- `useMenuSub()` (the `MenuContext` symmetry).
- Convert the remaining overlays jointly with #2724, on this contract.

Refs #2723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headless composables for building menu roots, content, and item interactions.
  * Improved menu keyboard navigation, typeahead search, pointer hover behavior, submenu handling, and focus management.
  * Added cancelable menu item selection behavior, allowing applications to prevent automatic menu closing.
  * Preserved menu accessibility semantics and state indicators.

* **Documentation**
  * Added validated guidance and design documentation for overlay composables and menu migrations.

* **Tests**
  * Added comprehensive coverage for menu state, interactions, accessibility, focus, and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->