### PR TITLE
docs: add CSS demos for color components

### DIFF
--- a/docs/components/demo/ColorArea/css/index.vue
+++ b/docs/components/demo/ColorArea/css/index.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import {
+  ColorAreaArea,
+  ColorAreaRoot,
+  ColorAreaThumb,
+} from 'reka-ui'
+import { ref } from 'vue'
+import './styles.css'
+
+const color = ref('#56d799')
+</script>
+
+<template>
+  <div class="color-area-demo">
+    <div class="color-area-demo__value">
+      Current: {{ color }}
+    </div>
+
+    <ColorAreaRoot
+      v-slot="{ style }"
+      v-model="color"
+      class="color-area-demo__root"
+    >
+      <ColorAreaArea
+        class="color-area-demo__area"
+        :style="style"
+      >
+        <ColorAreaThumb class="color-area-demo__thumb" />
+      </ColorAreaArea>
+    </ColorAreaRoot>
+  </div>
+</template>

--- a/docs/components/demo/ColorArea/css/index.vue
+++ b/docs/components/demo/ColorArea/css/index.vue
@@ -11,21 +11,21 @@ const color = ref('#56d799')
 </script>
 
 <template>
-  <div class="color-area-demo">
-    <div class="color-area-demo__value">
+  <div class="ColorAreaDemo">
+    <div class="ColorAreaValue">
       Current: {{ color }}
     </div>
 
     <ColorAreaRoot
       v-slot="{ style }"
       v-model="color"
-      class="color-area-demo__root"
+      class="ColorAreaRoot"
     >
       <ColorAreaArea
-        class="color-area-demo__area"
+        class="ColorAreaArea"
         :style="style"
       >
-        <ColorAreaThumb class="color-area-demo__thumb" />
+        <ColorAreaThumb class="ColorAreaThumb" />
       </ColorAreaArea>
     </ColorAreaRoot>
   </div>

--- a/docs/components/demo/ColorArea/css/styles.css
+++ b/docs/components/demo/ColorArea/css/styles.css
@@ -2,22 +2,22 @@
 @import '@radix-ui/colors/grass.css';
 @import '@radix-ui/colors/mauve.css';
 
-.color-area-demo {
+.ColorAreaDemo {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.color-area-demo__value {
+.ColorAreaValue {
   color: var(--mauve-11);
   font-size: 14px;
 }
 
-.color-area-demo__root {
+.ColorAreaRoot {
   position: relative;
 }
 
-.color-area-demo__area {
+.ColorAreaArea {
   position: relative;
   width: 200px;
   height: 200px;
@@ -25,12 +25,12 @@
   border-radius: 8px;
 }
 
-.color-area-demo__area:focus {
+.ColorAreaArea:focus {
   outline: none;
   box-shadow: 0 0 0 2px var(--grass-7);
 }
 
-.color-area-demo__thumb {
+.ColorAreaThumb {
   display: block;
   width: 16px;
   height: 16px;

--- a/docs/components/demo/ColorArea/css/styles.css
+++ b/docs/components/demo/ColorArea/css/styles.css
@@ -1,0 +1,42 @@
+@import '@radix-ui/colors/black-alpha.css';
+@import '@radix-ui/colors/grass.css';
+@import '@radix-ui/colors/mauve.css';
+
+.color-area-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.color-area-demo__value {
+  color: var(--mauve-11);
+  font-size: 14px;
+}
+
+.color-area-demo__root {
+  position: relative;
+}
+
+.color-area-demo__area {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.color-area-demo__area:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--grass-7);
+}
+
+.color-area-demo__thumb {
+  display: block;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  background-color: white;
+  border: 2px solid var(--mauve-8);
+  border-radius: 9999px;
+  box-shadow: 0 2px 10px var(--black-a7);
+}

--- a/docs/components/demo/ColorField/css/index.vue
+++ b/docs/components/demo/ColorField/css/index.vue
@@ -10,20 +10,20 @@ const color = ref('#56d799')
 </script>
 
 <template>
-  <div class="color-field-demo">
+  <div class="ColorFieldDemo">
     <ColorFieldRoot
       v-model="color"
-      class="color-field-demo__root"
+      class="ColorFieldRoot"
     >
-      <label class="color-field-demo__label">
+      <label class="ColorFieldLabel">
         Color
       </label>
-      <div class="color-field-demo__control">
+      <div class="ColorFieldControl">
         <div
-          class="color-field-demo__swatch"
+          class="ColorFieldSwatch"
           :style="{ background: color }"
         />
-        <ColorFieldInput class="color-field-demo__input" />
+        <ColorFieldInput class="ColorFieldInput" />
       </div>
     </ColorFieldRoot>
   </div>

--- a/docs/components/demo/ColorField/css/index.vue
+++ b/docs/components/demo/ColorField/css/index.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import {
+  ColorFieldInput,
+  ColorFieldRoot,
+} from 'reka-ui'
+import { ref } from 'vue'
+import './styles.css'
+
+const color = ref('#56d799')
+</script>
+
+<template>
+  <div class="color-field-demo">
+    <ColorFieldRoot
+      v-model="color"
+      class="color-field-demo__root"
+    >
+      <label class="color-field-demo__label">
+        Color
+      </label>
+      <div class="color-field-demo__control">
+        <div
+          class="color-field-demo__swatch"
+          :style="{ background: color }"
+        />
+        <ColorFieldInput class="color-field-demo__input" />
+      </div>
+    </ColorFieldRoot>
+  </div>
+</template>

--- a/docs/components/demo/ColorField/css/styles.css
+++ b/docs/components/demo/ColorField/css/styles.css
@@ -1,0 +1,56 @@
+@import '@radix-ui/colors/black-alpha.css';
+@import '@radix-ui/colors/grass.css';
+@import '@radix-ui/colors/mauve.css';
+
+.color-field-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.color-field-demo__root {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.color-field-demo__label {
+  color: var(--mauve-12);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.color-field-demo__control {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.color-field-demo__swatch {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 1px var(--black-a7);
+}
+
+.color-field-demo__input {
+  width: 128px;
+  padding: 8px 12px;
+  color: var(--mauve-12);
+  font-size: 14px;
+  background-color: var(--black-a5);
+  border: none;
+  border-radius: 6px;
+  box-shadow: 0 0 0 1px var(--black-a9);
+}
+
+.color-field-demo__input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--grass-7);
+}
+
+.color-field-demo__input:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/docs/components/demo/ColorField/css/styles.css
+++ b/docs/components/demo/ColorField/css/styles.css
@@ -2,31 +2,31 @@
 @import '@radix-ui/colors/grass.css';
 @import '@radix-ui/colors/mauve.css';
 
-.color-field-demo {
+.ColorFieldDemo {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.color-field-demo__root {
+.ColorFieldRoot {
   display: inline-flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.color-field-demo__label {
+.ColorFieldLabel {
   color: var(--mauve-12);
   font-size: 14px;
   font-weight: 500;
 }
 
-.color-field-demo__control {
+.ColorFieldControl {
   display: flex;
   gap: 8px;
   align-items: center;
 }
 
-.color-field-demo__swatch {
+.ColorFieldSwatch {
   flex-shrink: 0;
   width: 32px;
   height: 32px;
@@ -34,7 +34,7 @@
   box-shadow: inset 0 0 0 1px var(--black-a7);
 }
 
-.color-field-demo__input {
+.ColorFieldInput {
   width: 128px;
   padding: 8px 12px;
   color: var(--mauve-12);
@@ -45,12 +45,12 @@
   box-shadow: 0 0 0 1px var(--black-a9);
 }
 
-.color-field-demo__input:focus {
+.ColorFieldInput:focus {
   outline: none;
   box-shadow: 0 0 0 2px var(--grass-7);
 }
 
-.color-field-demo__input:disabled {
+.ColorFieldInput:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }

--- a/docs/components/demo/ColorSlider/css/index.vue
+++ b/docs/components/demo/ColorSlider/css/index.vue
@@ -11,24 +11,24 @@ const color = ref('#56d799')
 </script>
 
 <template>
-  <div class="color-slider-demo">
+  <div class="ColorSliderDemo">
     <ColorSliderRoot
       v-model="color"
       channel="hue"
-      class="color-slider-demo__root"
+      class="ColorSliderRoot"
     >
-      <ColorSliderTrack class="color-slider-demo__track">
-        <div class="color-slider-demo__track-fill" />
+      <ColorSliderTrack class="ColorSliderTrack">
+        <div class="ColorSliderTrackFill" />
       </ColorSliderTrack>
-      <ColorSliderThumb class="color-slider-demo__thumb" />
+      <ColorSliderThumb class="ColorSliderThumb" />
     </ColorSliderRoot>
 
-    <div class="color-slider-demo__value">
+    <div class="ColorSliderValue">
       <div
-        class="color-slider-demo__swatch"
+        class="ColorSliderSwatch"
         :style="{ background: color }"
       />
-      <span class="color-slider-demo__code">{{ color }}</span>
+      <span class="ColorSliderCode">{{ color }}</span>
     </div>
   </div>
 </template>

--- a/docs/components/demo/ColorSlider/css/index.vue
+++ b/docs/components/demo/ColorSlider/css/index.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import {
+  ColorSliderRoot,
+  ColorSliderThumb,
+  ColorSliderTrack,
+} from 'reka-ui'
+import { ref } from 'vue'
+import './styles.css'
+
+const color = ref('#56d799')
+</script>
+
+<template>
+  <div class="color-slider-demo">
+    <ColorSliderRoot
+      v-model="color"
+      channel="hue"
+      class="color-slider-demo__root"
+    >
+      <ColorSliderTrack class="color-slider-demo__track">
+        <div class="color-slider-demo__track-fill" />
+      </ColorSliderTrack>
+      <ColorSliderThumb class="color-slider-demo__thumb" />
+    </ColorSliderRoot>
+
+    <div class="color-slider-demo__value">
+      <div
+        class="color-slider-demo__swatch"
+        :style="{ background: color }"
+      />
+      <span class="color-slider-demo__code">{{ color }}</span>
+    </div>
+  </div>
+</template>

--- a/docs/components/demo/ColorSlider/css/styles.css
+++ b/docs/components/demo/ColorSlider/css/styles.css
@@ -1,0 +1,73 @@
+@import '@radix-ui/colors/black-alpha.css';
+@import '@radix-ui/colors/grass.css';
+@import '@radix-ui/colors/mauve.css';
+
+.color-slider-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.color-slider-demo__root {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 200px;
+  height: 20px;
+  touch-action: none;
+  user-select: none;
+}
+
+.color-slider-demo__track {
+  position: relative;
+  flex: 1;
+  height: 12px;
+  border-radius: 9999px;
+}
+
+.color-slider-demo__track-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+}
+
+.color-slider-demo__thumb {
+  display: block;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  background-color: white;
+  border: 2px solid var(--mauve-8);
+  border-radius: 9999px;
+  box-shadow: 0 2px 10px var(--black-a7);
+  transition: transform 150ms;
+}
+
+.color-slider-demo__thumb:hover {
+  transform: scale(1.1);
+}
+
+.color-slider-demo__thumb:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--grass-7);
+}
+
+.color-slider-demo__value {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  color: var(--mauve-11);
+  font-size: 12px;
+}
+
+.color-slider-demo__swatch {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--mauve-6);
+  border-radius: 4px;
+}
+
+.color-slider-demo__code {
+  font-family: monospace;
+}

--- a/docs/components/demo/ColorSlider/css/styles.css
+++ b/docs/components/demo/ColorSlider/css/styles.css
@@ -2,13 +2,13 @@
 @import '@radix-ui/colors/grass.css';
 @import '@radix-ui/colors/mauve.css';
 
-.color-slider-demo {
+.ColorSliderDemo {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.color-slider-demo__root {
+.ColorSliderRoot {
   position: relative;
   display: flex;
   align-items: center;
@@ -18,20 +18,20 @@
   user-select: none;
 }
 
-.color-slider-demo__track {
+.ColorSliderTrack {
   position: relative;
   flex: 1;
   height: 12px;
   border-radius: 9999px;
 }
 
-.color-slider-demo__track-fill {
+.ColorSliderTrackFill {
   position: absolute;
   inset: 0;
   border-radius: 9999px;
 }
 
-.color-slider-demo__thumb {
+.ColorSliderThumb {
   display: block;
   width: 20px;
   height: 20px;
@@ -43,16 +43,16 @@
   transition: transform 150ms;
 }
 
-.color-slider-demo__thumb:hover {
+.ColorSliderThumb:hover {
   transform: scale(1.1);
 }
 
-.color-slider-demo__thumb:focus {
+.ColorSliderThumb:focus {
   outline: none;
   box-shadow: 0 0 0 2px var(--grass-7);
 }
 
-.color-slider-demo__value {
+.ColorSliderValue {
   display: flex;
   gap: 8px;
   align-items: center;
@@ -60,7 +60,7 @@
   font-size: 12px;
 }
 
-.color-slider-demo__swatch {
+.ColorSliderSwatch {
   flex-shrink: 0;
   width: 20px;
   height: 20px;
@@ -68,6 +68,6 @@
   border-radius: 4px;
 }
 
-.color-slider-demo__code {
+.ColorSliderCode {
   font-family: monospace;
 }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #2787

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds plain CSS demos for ColorArea, ColorField, and ColorSlider. The demos mirror their Tailwind counterparts and use the Radix color tokens and styling conventions found in the existing CSS demos.

### 📸 Screenshots (if appropriate)

<img width="795" height="1036" alt="Screenshot 2026-07-13 at 10 37 10" src="https://github.com/user-attachments/assets/cf192532-8f73-4bb3-9338-5134910078a9" />
<img width="799" height="991" alt="Screenshot 2026-07-13 at 10 37 00" src="https://github.com/user-attachments/assets/0c45069a-4817-413b-ad1b-2f1806d548d1" />
<img width="792" height="1025" alt="Screenshot 2026-07-13 at 10 36 48" src="https://github.com/user-attachments/assets/713263b1-78e6-44c1-9338-a3b0f7aa0e7b" />


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added interactive Vue demos for **ColorArea**, **ColorField**, and **ColorSlider** with live swatches.
  * Demos support two-way binding so color updates are reflected immediately in the UI.
  * ColorField includes editable input; ColorSlider includes hue-channel adjustment.

* **Documentation**
  * Added dedicated demo stylesheets for **ColorArea**, **ColorField**, and **ColorSlider**.
  * Improved demo visuals with consistent layout plus focus, hover, and disabled state styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->