### PR TITLE
fix: process Android soft-keyboard composition live for filters

### DIFF
--- a/packages/core/src/Autocomplete/Autocomplete.test.ts
+++ b/packages/core/src/Autocomplete/Autocomplete.test.ts
@@ -1,6 +1,6 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
 import { handleSubmit, sleep } from '@/test'
@@ -173,6 +173,60 @@ describe('given default Autocomplete', () => {
         const emitted = wrapper.emitted('update:modelValue')
         const lastEmit = emitted.at(-1)?.[0]
         expect(lastEmit).toBe('香')
+      })
+
+      it('should not filter during plain-text composition off Android (desktop Pinyin preedit)', async () => {
+        await input.trigger('compositionstart')
+        input.element.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'xiang', bubbles: true }))
+        input.element.value = 'xiang'
+        await input.trigger('input')
+        await nextTick()
+        const content = wrapper.find('[role=listbox]')
+        expect(content.attributes('data-empty')).toBeUndefined()
+      })
+
+      describe('on Android soft keyboard', () => {
+        beforeEach(() => {
+          Object.defineProperty(window.navigator, 'userAgent', {
+            value: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+            configurable: true,
+          })
+        })
+
+        afterEach(() => {
+          delete (window.navigator as { userAgent?: string }).userAgent
+        })
+
+        it('should filter and update modelValue live during plain-text (autocorrect) composition', async () => {
+          await input.trigger('compositionstart')
+          input.element.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'zzzzz', bubbles: true }))
+          input.element.value = 'zzzzz'
+          await input.trigger('input')
+          await nextTick()
+
+          const content = wrapper.find('[role=listbox]')
+          expect(content.attributes('data-empty')).toBeDefined()
+          expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toBe('zzzzz')
+        })
+
+        it('should not filter during CJK IME composition until compositionend', async () => {
+          const emittedBefore = wrapper.emitted('update:modelValue')?.length ?? 0
+          await input.trigger('compositionstart')
+          input.element.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'かんじ', bubbles: true }))
+          input.element.value = 'かんじ'
+          await input.trigger('input')
+          await nextTick()
+
+          expect(wrapper.find('[role=listbox]').attributes('data-empty')).toBeUndefined()
+          expect(wrapper.emitted('update:modelValue')?.length ?? 0).toBe(emittedBefore)
+
+          await input.trigger('compositionend')
+          await nextTick()
+          await nextTick()
+
+          expect(wrapper.find('[role=listbox]').attributes('data-empty')).toBeDefined()
+          expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toBe('かんじ')
+        })
       })
     })
 

--- a/packages/core/src/Autocomplete/AutocompleteInput.vue
+++ b/packages/core/src/Autocomplete/AutocompleteInput.vue
@@ -38,7 +38,7 @@ onMounted(() => {
     rootContext.onInputElementChange(currentElement.value as HTMLInputElement)
 })
 
-const { isComposing, handleCompositionStart, handleCompositionEnd } = useComposing((event) => {
+const { isComposing, shouldDeferInput, handleCompositionStart, handleCompositionUpdate, handleCompositionEnd } = useComposing((event) => {
   const el = event.target as HTMLInputElement
   if (el)
     processInputValue(el.value)
@@ -71,7 +71,7 @@ function processInputValue(value: string) {
 }
 
 function handleInput(event: InputEvent) {
-  if (isComposing.value)
+  if (shouldDeferInput.value)
     return
   processInputValue((event.target as HTMLInputElement).value)
 }
@@ -123,6 +123,7 @@ watch(rootContext.filterState, (_newValue, oldValue) => {
     @keydown.down.up="handleKeyDown"
     @focus="handleFocus"
     @compositionstart="handleCompositionStart"
+    @compositionupdate="handleCompositionUpdate"
     @compositionend="handleCompositionEnd"
   >
     <slot />

--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -1,6 +1,6 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { handleSubmit, sleep } from '@/test'
@@ -684,6 +684,60 @@ describe('handle IME composition', () => {
     const content = wrapper.find('[role=listbox]')
     expect(content.exists()).toBe(true)
     expect(content.attributes('data-empty')).toBeDefined()
+  })
+
+  it('should not update filter during plain-text composition off Android (desktop Pinyin preedit)', async () => {
+    await input.trigger('compositionstart')
+    input.element.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'xiang', bubbles: true }))
+    input.element.value = 'xiang'
+    await input.trigger('input')
+    await nextTick()
+
+    expect(wrapper.find('[role=listbox]').exists()).toBe(false)
+  })
+
+  describe('on Android soft keyboard', () => {
+    beforeEach(() => {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+        configurable: true,
+      })
+    })
+
+    afterEach(() => {
+      delete (window.navigator as { userAgent?: string }).userAgent
+    })
+
+    it('should update filter live during plain-text (autocorrect) composition', async () => {
+      await input.trigger('compositionstart')
+      input.element.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'zzzzz', bubbles: true }))
+      input.element.value = 'zzzzz'
+      await input.trigger('input')
+      await nextTick()
+      await nextTick()
+
+      const content = wrapper.find('[role=listbox]')
+      expect(content.exists()).toBe(true)
+      expect(content.attributes('data-empty')).toBeDefined()
+    })
+
+    it('should not update filter during CJK IME composition until compositionend', async () => {
+      await input.trigger('compositionstart')
+      input.element.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'かんじ', bubbles: true }))
+      input.element.value = 'かんじ'
+      await input.trigger('input')
+      await nextTick()
+
+      expect(wrapper.find('[role=listbox]').exists()).toBe(false)
+
+      await input.trigger('compositionend')
+      await nextTick()
+      await nextTick()
+
+      const content = wrapper.find('[role=listbox]')
+      expect(content.exists()).toBe(true)
+      expect(content.attributes('data-empty')).toBeDefined()
+    })
   })
 })
 

--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -35,7 +35,7 @@ onMounted(() => {
     rootContext.onInputElementChange(currentElement.value as HTMLInputElement)
 })
 
-const { isComposing, handleCompositionStart, handleCompositionEnd } = useComposing((event) => {
+const { isComposing, shouldDeferInput, handleCompositionStart, handleCompositionUpdate, handleCompositionEnd } = useComposing((event) => {
   const el = event.target as HTMLInputElement
   if (el)
     processInputValue(el.value)
@@ -66,7 +66,7 @@ function processInputValue(value: string) {
 }
 
 function handleInput(event: InputEvent) {
-  if (isComposing.value)
+  if (shouldDeferInput.value)
     return
   processInputValue((event.target as HTMLInputElement).value)
 }
@@ -170,6 +170,7 @@ watch(rootContext.filterState, (_newValue, oldValue) => {
     @focus="handleFocus"
     @blur="handleBlur"
     @compositionstart="handleCompositionStart"
+    @compositionupdate="handleCompositionUpdate"
     @compositionend="handleCompositionEnd"
   >
     <slot />

--- a/packages/core/src/DropdownMenu/DropdownMenuFilter.test.ts
+++ b/packages/core/src/DropdownMenu/DropdownMenuFilter.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
 import DropdownMenuWithFilter from './story/_DropdownMenuWithFilter.vue'
 
@@ -177,6 +177,68 @@ describe('given DropdownMenu with Filter', () => {
 
       const items = document.querySelectorAll('[role="menuitem"]')
       expect(items.length).toBe(0)
+    })
+
+    it('should not update search during plain-text composition off Android (desktop Pinyin preedit)', async () => {
+      const filterInput = document.querySelector('[role="searchbox"]') as HTMLInputElement
+      const baseline = document.querySelectorAll('[role="menuitem"]').length
+
+      filterInput.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+      filterInput.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'xiang', bubbles: true }))
+      filterInput.value = 'xiang'
+      filterInput.dispatchEvent(new Event('input', { bubbles: true }))
+      await nextTick()
+
+      expect(wrapper.vm.filterText).toBe('')
+      expect(document.querySelectorAll('[role="menuitem"]').length).toBe(baseline)
+    })
+
+    describe('on Android soft keyboard', () => {
+      beforeEach(() => {
+        Object.defineProperty(window.navigator, 'userAgent', {
+          value: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+          configurable: true,
+        })
+      })
+
+      afterEach(() => {
+        delete (window.navigator as { userAgent?: string }).userAgent
+      })
+
+      it('should update search live during plain-text (autocorrect) composition', async () => {
+        const filterInput = document.querySelector('[role="searchbox"]') as HTMLInputElement
+
+        filterInput.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+        filterInput.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'New', bubbles: true }))
+        filterInput.value = 'New'
+        filterInput.dispatchEvent(new Event('input', { bubbles: true }))
+        await nextTick()
+
+        expect(wrapper.vm.filterText).toBe('New')
+        const items = document.querySelectorAll('[role="menuitem"]')
+        expect(items.length).toBe(2)
+      })
+
+      it('should not update search during CJK IME composition until compositionend', async () => {
+        const filterInput = document.querySelector('[role="searchbox"]') as HTMLInputElement
+        const baseline = document.querySelectorAll('[role="menuitem"]').length
+
+        filterInput.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+        filterInput.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'かんじ', bubbles: true }))
+        filterInput.value = 'かんじ'
+        filterInput.dispatchEvent(new Event('input', { bubbles: true }))
+        await nextTick()
+
+        expect(wrapper.vm.filterText).toBe('')
+        expect(document.querySelectorAll('[role="menuitem"]').length).toBe(baseline)
+
+        filterInput.dispatchEvent(new CompositionEvent('compositionend', { data: 'かんじ', bubbles: true }))
+        await nextTick()
+        await nextTick()
+
+        expect(wrapper.vm.filterText).toBe('かんじ')
+        expect(document.querySelectorAll('[role="menuitem"]').length).toBe(0)
+      })
     })
 
     it('should not navigate items during IME composition (arrow keys are IME candidate navigation)', async () => {

--- a/packages/core/src/DropdownMenu/DropdownMenuFilter.vue
+++ b/packages/core/src/DropdownMenu/DropdownMenuFilter.vue
@@ -71,7 +71,7 @@ onUnmounted(() => {
   contentContext.searchRef.value = ''
 })
 
-const { isComposing, handleCompositionStart, handleCompositionEnd } = useComposing((event) => {
+const { isComposing, shouldDeferInput, handleCompositionStart, handleCompositionUpdate, handleCompositionEnd } = useComposing((event) => {
   const el = event.target as HTMLInputElement
   if (el) {
     modelValue.value = el.value
@@ -82,7 +82,7 @@ const { isComposing, handleCompositionStart, handleCompositionEnd } = useComposi
 function handleInput(event: InputEvent) {
   if (disabled.value)
     return
-  if (isComposing.value)
+  if (shouldDeferInput.value)
     return
   const target = event.target as HTMLInputElement
   modelValue.value = target.value
@@ -131,6 +131,7 @@ function handleKeyDown(event: KeyboardEvent) {
     @input="handleInput"
     @keydown="handleKeyDown"
     @compositionstart="handleCompositionStart"
+    @compositionupdate="handleCompositionUpdate"
     @compositionend="handleCompositionEnd"
   >
     <slot :model-value="modelValue" />

--- a/packages/core/src/Listbox/Listbox.test.ts
+++ b/packages/core/src/Listbox/Listbox.test.ts
@@ -1,11 +1,11 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { useKbd } from '@/shared'
 import { handleSubmit } from '@/test'
-import { ListboxContent, ListboxItem, ListboxRoot, ListboxVirtualizer } from '.'
+import { ListboxContent, ListboxFilter, ListboxItem, ListboxRoot, ListboxVirtualizer } from '.'
 import Listbox from './story/_Listbox.vue'
 
 describe('given default Listbox', () => {
@@ -536,5 +536,80 @@ describe('given Listbox in a form', async () => {
       expect(handleSubmit).toHaveBeenCalledTimes(2)
       expect(handleSubmit.mock.results[1].value).toStrictEqual({ test: items[4].text() })
     })
+  })
+})
+
+describe('given Listbox with ListboxFilter handling IME composition', () => {
+  let wrapper: VueWrapper
+  let input: DOMWrapper<HTMLInputElement>
+  let updates: string[]
+
+  window.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+  const ANDROID_UA = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36'
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    updates = []
+    const search = ref('')
+    wrapper = mount(defineComponent({
+      setup() {
+        return () => h(ListboxRoot, {}, {
+          default: () => [
+            h(ListboxFilter, {
+              'modelValue': search.value,
+              'onUpdate:modelValue': (v: string) => {
+                updates.push(v)
+                search.value = v
+              },
+            }),
+            h(ListboxContent, {}, {
+              default: () => ['Apple', 'Banana'].map(i => h(ListboxItem, { value: i }, { default: () => i })),
+            }),
+          ],
+        })
+      },
+    }), { attachTo: document.body })
+    input = wrapper.find('input')
+  })
+
+  afterEach(() => {
+    delete (window.navigator as { userAgent?: string }).userAgent
+  })
+
+  it('should not update modelValue during plain-text composition off Android (desktop Pinyin preedit)', async () => {
+    await input.trigger('compositionstart')
+    input.element.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'xiang', bubbles: true }))
+    input.element.value = 'xiang'
+    await input.trigger('input')
+
+    expect(updates).toEqual([])
+  })
+
+  it('should update modelValue live during plain-text (autocorrect) composition on Android', async () => {
+    Object.defineProperty(window.navigator, 'userAgent', { value: ANDROID_UA, configurable: true })
+
+    await input.trigger('compositionstart')
+    input.element.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'Br', bubbles: true }))
+    input.element.value = 'Br'
+    await input.trigger('input')
+
+    expect(updates).toEqual(['Br'])
+  })
+
+  it('should not update modelValue during CJK IME composition on Android until compositionend', async () => {
+    Object.defineProperty(window.navigator, 'userAgent', { value: ANDROID_UA, configurable: true })
+
+    await input.trigger('compositionstart')
+    input.element.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'かんじ', bubbles: true }))
+    input.element.value = 'かんじ'
+    await input.trigger('input')
+
+    expect(updates).toEqual([])
+
+    await input.trigger('compositionend')
+    await nextTick()
+
+    expect(updates).toEqual(['かんじ'])
   })
 })

--- a/packages/core/src/Listbox/ListboxFilter.vue
+++ b/packages/core/src/Listbox/ListboxFilter.vue
@@ -61,7 +61,7 @@ onUnmounted(() => {
   rootContext.focusable.value = true
 })
 
-const { isComposing, handleCompositionStart, handleCompositionEnd } = useComposing((event) => {
+const { isComposing, shouldDeferInput, handleCompositionStart, handleCompositionUpdate, handleCompositionEnd } = useComposing((event) => {
   modelValue.value = (event.target as HTMLInputElement).value
   rootContext.onCompositionEnd()
   rootContext.highlightFirstItem()
@@ -73,7 +73,7 @@ function onCompositionStart() {
 }
 
 function handleInput(event: InputEvent) {
-  if (isComposing.value)
+  if (shouldDeferInput.value)
     return
   modelValue.value = (event.target as HTMLInputElement).value
   rootContext.highlightFirstItem()
@@ -110,6 +110,7 @@ function handleKeydownEnter(event: KeyboardEvent) {
     @keydown.enter="handleKeydownEnter"
     @input="handleInput"
     @compositionstart="onCompositionStart"
+    @compositionupdate="handleCompositionUpdate"
     @compositionend="handleCompositionEnd"
   >
     <slot :model-value="modelValue" />

--- a/packages/core/src/shared/useComposing.test.ts
+++ b/packages/core/src/shared/useComposing.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useComposing } from './useComposing'
+
+const ANDROID_UA = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36'
+
+function stubUserAgent(ua: string) {
+  Object.defineProperty(window.navigator, 'userAgent', { value: ua, configurable: true })
+}
+
+function restoreUserAgent() {
+  // remove the own property so the jsdom prototype getter takes over again
+  delete (window.navigator as { userAgent?: string }).userAgent
+}
+
+function compositionUpdate(data: string) {
+  return new CompositionEvent('compositionupdate', { data })
+}
+
+describe('useComposing', () => {
+  afterEach(() => {
+    restoreUserAgent()
+  })
+
+  it('should defer input while composing before any compositionupdate', () => {
+    const { shouldDeferInput, handleCompositionStart } = useComposing()
+    expect(shouldDeferInput.value).toBe(false)
+    handleCompositionStart()
+    expect(shouldDeferInput.value).toBe(true)
+  })
+
+  it('should process plain-text composition live on Android (soft-keyboard autocorrect)', () => {
+    stubUserAgent(ANDROID_UA)
+    const { shouldDeferInput, handleCompositionStart, handleCompositionUpdate } = useComposing()
+    handleCompositionStart()
+    handleCompositionUpdate(compositionUpdate('Br'))
+    expect(shouldDeferInput.value).toBe(false)
+  })
+
+  it('should keep deferring plain-text composition off Android (e.g. desktop Pinyin preedit)', () => {
+    const { shouldDeferInput, handleCompositionStart, handleCompositionUpdate } = useComposing()
+    handleCompositionStart()
+    handleCompositionUpdate(compositionUpdate('xiang'))
+    expect(shouldDeferInput.value).toBe(true)
+  })
+
+  it.each([
+    ['Han', '香'],
+    ['Hiragana', 'かん'],
+    ['Katakana', 'カナ'],
+    ['Hangul syllable', '한'],
+    ['Hangul jamo', 'ㅂ'],
+    ['Bopomofo', 'ㄅㄆ'],
+  ])('should defer IME-script composition even on Android (%s)', (_, data) => {
+    stubUserAgent(ANDROID_UA)
+    const { shouldDeferInput, handleCompositionStart, handleCompositionUpdate } = useComposing()
+    handleCompositionStart()
+    handleCompositionUpdate(compositionUpdate(data))
+    expect(shouldDeferInput.value).toBe(true)
+  })
+
+  it('should keep the previous classification on empty compositionupdate data', () => {
+    stubUserAgent(ANDROID_UA)
+    const { shouldDeferInput, handleCompositionStart, handleCompositionUpdate } = useComposing()
+    handleCompositionStart()
+
+    handleCompositionUpdate(compositionUpdate('Br'))
+    handleCompositionUpdate(compositionUpdate(''))
+    expect(shouldDeferInput.value).toBe(false)
+
+    handleCompositionUpdate(compositionUpdate('香'))
+    handleCompositionUpdate(compositionUpdate(''))
+    expect(shouldDeferInput.value).toBe(true)
+  })
+
+  it('should reset composing state and call onEnd after compositionend', async () => {
+    stubUserAgent(ANDROID_UA)
+    const onEnd = vi.fn()
+    const { isComposing, shouldDeferInput, handleCompositionStart, handleCompositionUpdate, handleCompositionEnd } = useComposing(onEnd)
+    handleCompositionStart()
+    handleCompositionUpdate(compositionUpdate('Br'))
+
+    const endEvent = new CompositionEvent('compositionend', { data: 'Br' })
+    handleCompositionEnd(endEvent)
+    await nextTick()
+    expect(isComposing.value).toBe(false)
+    expect(shouldDeferInput.value).toBe(false)
+    expect(onEnd).toHaveBeenCalledWith(endEvent)
+
+    // a new composition session starts deferred again
+    handleCompositionStart()
+    expect(shouldDeferInput.value).toBe(true)
+  })
+})

--- a/packages/core/src/shared/useComposing.test.ts
+++ b/packages/core/src/shared/useComposing.test.ts
@@ -59,6 +59,44 @@ describe('useComposing', () => {
     expect(shouldDeferInput.value).toBe(true)
   })
 
+  it('should stay deferred once IME script appears mid-session (Android romaji → kana)', () => {
+    stubUserAgent(ANDROID_UA)
+    const { shouldDeferInput, handleCompositionStart, handleCompositionUpdate } = useComposing()
+    handleCompositionStart()
+
+    // romaji-mode Japanese IMEs compose Latin first, then convert within the
+    // same session — indistinguishable from autocorrect until kana shows up
+    handleCompositionUpdate(compositionUpdate('k'))
+    expect(shouldDeferInput.value).toBe(false)
+    handleCompositionUpdate(compositionUpdate('ka'))
+    expect(shouldDeferInput.value).toBe(false)
+
+    handleCompositionUpdate(compositionUpdate('か'))
+    expect(shouldDeferInput.value).toBe(true)
+    handleCompositionUpdate(compositionUpdate('かん'))
+    expect(shouldDeferInput.value).toBe(true)
+
+    // backspacing out of kana back into romaji must not flip back to live
+    handleCompositionUpdate(compositionUpdate('kan'))
+    expect(shouldDeferInput.value).toBe(true)
+  })
+
+  it('should not carry the IME verdict into the next composition session', async () => {
+    stubUserAgent(ANDROID_UA)
+    const { shouldDeferInput, handleCompositionStart, handleCompositionUpdate, handleCompositionEnd } = useComposing()
+    handleCompositionStart()
+    handleCompositionUpdate(compositionUpdate('か'))
+    expect(shouldDeferInput.value).toBe(true)
+
+    handleCompositionEnd(new CompositionEvent('compositionend', { data: '感' }))
+    await nextTick()
+
+    // a fresh Latin session on Android filters live again
+    handleCompositionStart()
+    handleCompositionUpdate(compositionUpdate('Br'))
+    expect(shouldDeferInput.value).toBe(false)
+  })
+
   it('should keep the previous classification on empty compositionupdate data', () => {
     stubUserAgent(ANDROID_UA)
     const { shouldDeferInput, handleCompositionStart, handleCompositionUpdate } = useComposing()

--- a/packages/core/src/shared/useComposing.ts
+++ b/packages/core/src/shared/useComposing.ts
@@ -13,18 +13,30 @@ function isAndroid() {
 export function useComposing(onEnd?: (event: CompositionEvent) => void) {
   const isComposing = ref(false)
   const isImeComposition = ref(true)
+  // Sticky for the whole composition session: once IME script has been seen, a
+  // later plain-text update cannot downgrade the session back to live.
+  const sawImeScript = ref(false)
 
   // Whether `input` events should wait for `compositionend` before being
   // processed. Android soft keyboards (Gboard, Samsung Keyboard, …) keep the
   // current Latin word in composition for autocorrect and only commit it on
   // space/Enter/suggestion tap, so deferring there would freeze live filtering
-  // until the word is committed (nuxt/ui#6717). Genuine IME composition still
-  // defers so incomplete values never leak (#2540).
+  // until the word is committed (nuxt/ui#6717). IME composition still defers so
+  // incomplete values never leak (#2540).
+  //
+  // Known limitation: on Android, the *leading* plain-text updates of a
+  // transliterating IME are indistinguishable from soft-keyboard autocorrect —
+  // romaji-mode Japanese ("ka" → "か"), Vietnamese Telex, Thai and Indic
+  // transliteration all emit Latin before any IME script appears — so those
+  // first keystrokes do filter live. Once IME script shows up the session
+  // becomes deferred and stays deferred, and the committed value is always
+  // correct; only the transient popup state is wrong.
   const shouldDeferInput = computed(() => isComposing.value && isImeComposition.value)
 
   function handleCompositionStart() {
     isComposing.value = true
     isImeComposition.value = true
+    sawImeScript.value = false
   }
 
   function handleCompositionUpdate(event: CompositionEvent) {
@@ -34,8 +46,9 @@ export function useComposing(onEnd?: (event: CompositionEvent) => void) {
       return
     if (imeScriptRE.test(event.data)) {
       isImeComposition.value = true
+      sawImeScript.value = true
     }
-    else if (isAndroid()) {
+    else if (isAndroid() && !sawImeScript.value) {
       // Plain-text composition on Android is the soft keyboard buffering a
       // word for autocorrect — process input live. Desktop IMEs also compose
       // plain Latin before conversion (e.g. Pinyin preedit "xiang" for 香,

--- a/packages/core/src/shared/useComposing.ts
+++ b/packages/core/src/shared/useComposing.ts
@@ -1,10 +1,48 @@
-import { nextTick, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
+
+// Scripts typed through an IME with a candidate/conversion step (Chinese,
+// Japanese, Korean, Bopomofo). When the composing text contains any of these,
+// the value is incomplete until `compositionend` and must not be processed early.
+const imeScriptRE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Bopomofo}]/u
+const androidRE = /android/i
+
+function isAndroid() {
+  return typeof navigator !== 'undefined' && androidRE.test(navigator.userAgent)
+}
 
 export function useComposing(onEnd?: (event: CompositionEvent) => void) {
   const isComposing = ref(false)
+  const isImeComposition = ref(true)
+
+  // Whether `input` events should wait for `compositionend` before being
+  // processed. Android soft keyboards (Gboard, Samsung Keyboard, …) keep the
+  // current Latin word in composition for autocorrect and only commit it on
+  // space/Enter/suggestion tap, so deferring there would freeze live filtering
+  // until the word is committed (nuxt/ui#6717). Genuine IME composition still
+  // defers so incomplete values never leak (#2540).
+  const shouldDeferInput = computed(() => isComposing.value && isImeComposition.value)
 
   function handleCompositionStart() {
     isComposing.value = true
+    isImeComposition.value = true
+  }
+
+  function handleCompositionUpdate(event: CompositionEvent) {
+    // Empty data (e.g. backspacing the whole composed word) keeps the previous
+    // classification.
+    if (!event.data)
+      return
+    if (imeScriptRE.test(event.data)) {
+      isImeComposition.value = true
+    }
+    else if (isAndroid()) {
+      // Plain-text composition on Android is the soft keyboard buffering a
+      // word for autocorrect — process input live. Desktop IMEs also compose
+      // plain Latin before conversion (e.g. Pinyin preedit "xiang" for 香,
+      // the exact repro of #2540), so everywhere else deferring stays the
+      // safe default.
+      isImeComposition.value = false
+    }
   }
 
   function handleCompositionEnd(event: CompositionEvent) {
@@ -14,5 +52,5 @@ export function useComposing(onEnd?: (event: CompositionEvent) => void) {
     })
   }
 
-  return { isComposing, handleCompositionStart, handleCompositionEnd }
+  return { isComposing, shouldDeferInput, handleCompositionStart, handleCompositionUpdate, handleCompositionEnd }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #2665: Android soft keyboards (Gboard, Samsung, …) keep the current Latin word in composition for autocorrect, so deferring all `input` until `compositionend` froze live filtering in Autocomplete, Combobox, ListboxFilter, and DropdownMenuFilter ([nuxt/ui#6717](https://github.com/nuxt/ui/issues/6717)).
- `useComposing` now exposes `shouldDeferInput`: on Android, plain-text composition updates filter live; IME-script composition (Han/Hiragana/Katakana/Hangul/Bopomofo) and desktop Pinyin preedit still wait for commit.
- The verdict is **sticky per composition session**: romaji-mode Japanese IMEs compose Latin before converting to kana in a single session, so classifying each `compositionupdate` independently would let the session flip back to live mid-conversion.
- Keydown still gates on `isComposing` so IME candidate navigation is unchanged.

## Scope
- `shouldDeferInput` is applied to the four filter inputs only (Autocomplete, Combobox, ListboxFilter, DropdownMenuFilter) — those are the ones that filter on every `input`. TagsInput, NumberField, ColorField and PinInput keep gating on raw `isComposing`: they act on keydown, not on live input, so the Android autocorrect freeze doesn't apply to them. Deliberately out of scope.

## Known limitation
- On Android, the *leading* plain-text updates of a transliterating IME are indistinguishable from soft-keyboard autocorrect — romaji-mode Japanese (`ka` → `か`), Vietnamese Telex, Thai and Indic transliteration all emit Latin before any IME script appears — so those first keystrokes filter live. No content-based heuristic can separate them. Once IME script appears the session defers and stays deferred; the committed value is always correct, only transient popup state is wrong.

## Test plan
- [x] Unit tests for `useComposing` (Android Latin live, desktop Latin defer, CJK defer, empty update)
- [x] Mid-session `romaji → kana → romaji` transition stays deferred once IME script is seen, and the verdict does not leak into the next session
- [x] Autocomplete / Combobox / Listbox / DropdownMenuFilter coverage for the same matrix
- [ ] Smoke on Android (Chrome/Firefox/Samsung): type `Br` in a Combobox/InputMenu and confirm Broccoli appears before Return
- [ ] Smoke CJK IME on Android: confirm filtering still waits until composition commit
- [ ] Smoke desktop Pinyin: confirm Latin preedit still does not filter early

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autocomplete, combobox, dropdown filter, and listbox filtering behavior during IME composition.
  * Android plain-text autocorrect (e.g., desktop Pinyin preedit) now updates suggestions/results live when appropriate.
  * CJK/“real IME” composition is deferred until `compositionend`, preventing premature filtering and value updates.
* **Tests**
  * Expanded IME composition regression coverage for Android vs non-Android across autocomplete, combobox, dropdown filtering, and listbox filtering.
  * Added dedicated tests for `useComposing`’s new defer/update composition behavior and updated test lifecycle imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
