### PR TITLE
fix(rating): reset hover state on mouse leave in case of hoverable

### DIFF
--- a/packages/core/src/Rating/Rating.test.ts
+++ b/packages/core/src/Rating/Rating.test.ts
@@ -56,6 +56,34 @@ describe('given a default Rating', () => {
   })
 })
 
+describe('given a hoverable Rating', () => {
+  let wrapper: VueWrapper<InstanceType<typeof Rating>>
+  let root: DOMWrapper<HTMLElement>
+  let radios: DOMWrapper<HTMLElement>[]
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(Rating, { attachTo: document.body, props: { defaultValue: 1, hoverable: true, length: 3 } })
+    root = wrapper.find('[role=radiogroup]')
+    radios = wrapper.findAll('[role=radio]')
+  })
+
+  it('should preview the hovered rating', async () => {
+    await fireEvent.mouseEnter(radios[2].element)
+    expect(radios[1].attributes('data-state')).toBe('active')
+    expect(radios[2].attributes('data-state')).toBe('active')
+  })
+
+  it('should reset the preview to the model value on mouse leave', async () => {
+    await fireEvent.mouseEnter(radios[2].element)
+    await fireEvent.mouseLeave(root.element)
+
+    expect(radios[0].attributes('data-state')).toBe('active')
+    expect(radios[1].attributes('data-state')).toBeUndefined()
+    expect(radios[2].attributes('data-state')).toBeUndefined()
+  })
+})
+
 describe('given disabled Rating', () => {
   let wrapper: VueWrapper<InstanceType<typeof Rating>>
   let radios: DOMWrapper<HTMLElement>[]

--- a/packages/core/src/Rating/RatingRoot.vue
+++ b/packages/core/src/Rating/RatingRoot.vue
@@ -10,10 +10,8 @@ export interface RatingRootContext {
   hoveredRating: Ref<number>
   disabled: Ref<boolean>
   step: Ref<number>
-  hoverable: Ref<boolean>
   changeModelValue: (rating: number) => void
   changeHoveredRating: (rating: number) => void
-  resetHoveredRating: () => void
 }
 
 export interface RatingRootProps extends Omit<RadioGroupRootProps, 'modelValue' | 'defaultValue'> {
@@ -93,10 +91,10 @@ function changeHoveredRating(rating: number) {
 
   hoveredRating.value = rating
 }
-function resetHoveredRating() {
-  if (disabled.value || !hoverable.value)
-    return
 
+// Unconditional, so a preview left over from a `hoverable`/`disabled` toggle
+// mid-hover still clears once the pointer leaves.
+function resetHoveredRating() {
   hoveredRating.value = 0
 }
 
@@ -106,10 +104,8 @@ provideRatingRootContext({
   hoveredRating,
   disabled,
   step,
-  hoverable,
   changeModelValue,
   changeHoveredRating,
-  resetHoveredRating,
 })
 </script>
 

--- a/packages/core/src/Rating/RatingRoot.vue
+++ b/packages/core/src/Rating/RatingRoot.vue
@@ -10,8 +10,10 @@ export interface RatingRootContext {
   hoveredRating: Ref<number>
   disabled: Ref<boolean>
   step: Ref<number>
+  hoverable: Ref<boolean>
   changeModelValue: (rating: number) => void
   changeHoveredRating: (rating: number) => void
+  resetHoveredRating: () => void
 }
 
 export interface RatingRootProps extends Omit<RadioGroupRootProps, 'modelValue' | 'defaultValue'> {
@@ -91,6 +93,12 @@ function changeHoveredRating(rating: number) {
 
   hoveredRating.value = rating
 }
+function resetHoveredRating() {
+  if (disabled.value || !hoverable.value)
+    return
+
+  hoveredRating.value = 0
+}
 
 provideRatingRootContext({
   modelValue,
@@ -98,8 +106,10 @@ provideRatingRootContext({
   hoveredRating,
   disabled,
   step,
+  hoverable,
   changeModelValue,
   changeHoveredRating,
+  resetHoveredRating,
 })
 </script>
 
@@ -107,6 +117,7 @@ provideRatingRootContext({
   <RadioGroupRoot
     v-bind="reactiveOmit(props, 'length', 'clearable', 'hoverable', 'step')"
     :disabled="disabled"
+    @mouseleave="resetHoveredRating"
   >
     <slot
       :items="items"


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
https://github.com/nuxt/ui/issues/6746
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hover previews now clear automatically when the pointer leaves the rating control.
  * Hovering a rating restores the selected value when the pointer leaves.
  * Disabled ratings remain unaffected by hover reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->