### PR TITLE
fix(Toast): remove viewport listeners when a toast is dismissed

### DIFF
--- a/packages/core/src/Toast/Toast.test.ts
+++ b/packages/core/src/Toast/Toast.test.ts
@@ -1,10 +1,11 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { findByText, fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
 import Toast from './story/_Toast.vue'
+import { VIEWPORT_PAUSE, VIEWPORT_RESUME } from './utils'
 
 const CLOSE_TEXT = 'Close'
 
@@ -64,6 +65,24 @@ describe('given a default Toast', () => {
     // The toast title and description must both be part of the announced
     // text so screen-reader users actually hear the toast.
     expect(text).toContain('Scheduled: Catch up')
+  })
+
+  it('should remove viewport event listeners when the toast is dismissed', async () => {
+    await fireEvent.click(trigger.element)
+    await findByText(document.body, 'Scheduled: Catch up')
+
+    // The toast registers pause/resume listeners on the shared viewport while
+    // it is mounted; dismissing it must tear them down so the detached toast
+    // (and its listeners) can be garbage collected.
+    const viewport = document.querySelector('ol')!
+    const removeEventListener = vi.spyOn(viewport, 'removeEventListener')
+
+    const closeButton = await findByText(document.body, CLOSE_TEXT)
+    await fireEvent.click(closeButton)
+    await nextTick()
+
+    expect(removeEventListener).toHaveBeenCalledWith(VIEWPORT_PAUSE, expect.any(Function))
+    expect(removeEventListener).toHaveBeenCalledWith(VIEWPORT_RESUME, expect.any(Function))
   })
 
   describe('after clicking the trigger', () => {

--- a/packages/core/src/Toast/ToastRootImpl.vue
+++ b/packages/core/src/Toast/ToastRootImpl.vue
@@ -141,10 +141,10 @@ watchEffect((cleanupFn) => {
     }
     viewport.addEventListener(VIEWPORT_PAUSE, handlePause)
     viewport.addEventListener(VIEWPORT_RESUME, handleResume)
-    return () => {
+    cleanupFn(() => {
       viewport.removeEventListener(VIEWPORT_PAUSE, handlePause)
       viewport.removeEventListener(VIEWPORT_RESUME, handleResume)
-    }
+    })
   }
 })
 


### PR DESCRIPTION
Each toast registers pause and resume listeners on the shared viewport inside a `watchEffect`, but the teardown was returned from the effect callback instead of being registered through its cleanup argument, so `watchEffect` silently discarded it. Every dismissed toast therefore left its listeners and detached `<li>` subtree attached to the viewport, leaking on each open/close cycle. This registers the cleanup through the `watchEffect` cleanup callback so the listeners are removed when the toast unmounts.

Fixes #2782


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications now properly remove viewport event listeners when dismissed.
  * Improved cleanup of pause and resume behavior to prevent lingering event handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->