### PR TITLE
fix(DateField): advance segment focus in DOM order in RTL

### DIFF
--- a/packages/core/src/DateField/DateField.test.ts
+++ b/packages/core/src/DateField/DateField.test.ts
@@ -443,6 +443,23 @@ describe('dateField', async () => {
     }
   })
 
+  it('advances focus through segments in DOM order when typing in RTL', async () => {
+    const { user, month, day, year } = setup({
+      dateFieldProps: {
+        dir: 'rtl',
+      },
+    })
+
+    await user.click(month)
+    expect(month).toHaveFocus()
+    await user.keyboard('{2}')
+    expect(day).toHaveFocus()
+    await user.keyboard('{19}')
+    expect(year).toHaveFocus()
+    await user.keyboard('{1980}')
+    expect(year).toHaveTextContent('1980')
+  })
+
   it('adjusts the hour cycle with the `hourCycle` prop', async () => {
     const { getByTestId, queryByTestId, user } = setup({
       dateFieldProps: {

--- a/packages/core/src/DateField/DateFieldRoot.vue
+++ b/packages/core/src/DateField/DateFieldRoot.vue
@@ -287,7 +287,10 @@ provideDateFieldRootContext({
   elements: segmentElements,
   setFocusedElement,
   focusNext() {
-    nextFocusableSegment.value?.focus()
+    // Auto-advance follows the segments' DOM order (the locale's format
+    // order) regardless of writing direction; only arrow-key navigation is
+    // direction-aware via nextFocusableSegment/prevFocusableSegment.
+    Array.from(segmentElements.value)[currentSegmentIndex.value + 1]?.focus()
   },
 })
 

--- a/packages/core/src/DateRangeField/DateRangeField.test.ts
+++ b/packages/core/src/DateRangeField/DateRangeField.test.ts
@@ -53,6 +53,21 @@ it('should pass axe accessibility tests', async () => {
 })
 
 describe('dateField', async () => {
+  it('advances focus through segments in DOM order when typing in RTL', async () => {
+    const { user, start } = setup({
+      dateFieldProps: {
+        dir: 'rtl',
+      },
+    })
+
+    await user.click(start.month)
+    expect(start.month).toHaveFocus()
+    await user.keyboard('{2}')
+    expect(start.day).toHaveFocus()
+    await user.keyboard('{19}')
+    expect(start.year).toHaveFocus()
+  })
+
   it('populates segment with value - `CalendarDate`', async () => {
     const { start, end } = setup({
       dateFieldProps: { modelValue: calendarDate },

--- a/packages/core/src/DateRangeField/DateRangeField.test.ts
+++ b/packages/core/src/DateRangeField/DateRangeField.test.ts
@@ -54,7 +54,7 @@ it('should pass axe accessibility tests', async () => {
 
 describe('dateField', async () => {
   it('advances focus through segments in DOM order when typing in RTL', async () => {
-    const { user, start } = setup({
+    const { user, start, end } = setup({
       dateFieldProps: {
         dir: 'rtl',
       },
@@ -66,6 +66,8 @@ describe('dateField', async () => {
     expect(start.day).toHaveFocus()
     await user.keyboard('{19}')
     expect(start.year).toHaveFocus()
+    await user.keyboard('1980')
+    expect(end.month).toHaveFocus()
   })
 
   it('populates segment with value - `CalendarDate`', async () => {

--- a/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
+++ b/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
@@ -369,7 +369,10 @@ provideDateRangeFieldRootContext({
   elements: segmentElements,
   setFocusedElement,
   focusNext() {
-    nextFocusableSegment.value?.focus()
+    // Auto-advance follows the segments' DOM order (the locale's format
+    // order) regardless of writing direction; only arrow-key navigation is
+    // direction-aware via nextFocusableSegment/prevFocusableSegment.
+    Array.from(segmentElements.value)[currentSegmentIndex.value + 1]?.focus()
   },
 })
 

--- a/packages/core/src/TimeField/TimeField.test.ts
+++ b/packages/core/src/TimeField/TimeField.test.ts
@@ -57,6 +57,19 @@ it('should pass axe accessibility tests', async () => {
 })
 
 describe('timeField', async () => {
+  it('advances focus through segments in DOM order when typing in RTL', async () => {
+    const { user, hour, getByTestId } = setup({
+      timeFieldProps: {
+        dir: 'rtl',
+      },
+    })
+
+    await user.click(hour)
+    expect(hour).toHaveFocus()
+    await user.keyboard('{11}')
+    expect(getByTestId('minute')).toHaveFocus()
+  })
+
   it('populates segment with value - `Time`', async () => {
     const { hour } = setup({
       timeFieldProps: { modelValue: time },

--- a/packages/core/src/TimeField/TimeFieldRoot.vue
+++ b/packages/core/src/TimeField/TimeFieldRoot.vue
@@ -328,7 +328,10 @@ provideTimeFieldRootContext({
   elements: segmentElements,
   setFocusedElement,
   focusNext() {
-    nextFocusableSegment.value?.focus()
+    // Auto-advance follows the segments' DOM order (the locale's format
+    // order) regardless of writing direction; only arrow-key navigation is
+    // direction-aware via nextFocusableSegment/prevFocusableSegment.
+    Array.from(segmentElements.value)[currentSegmentIndex.value + 1]?.focus()
   },
 })
 

--- a/packages/core/src/TimeRangeField/TimeRangeField.test.ts
+++ b/packages/core/src/TimeRangeField/TimeRangeField.test.ts
@@ -47,6 +47,22 @@ it('should pass axe accessibility tests', async () => {
 })
 
 describe('timeField', () => {
+  it('advances focus through segments in DOM order when typing in RTL', async () => {
+    const { user, start, end } = setup({
+      timeRangeFieldProps: {
+        dir: 'rtl',
+        locale: 'en-GB',
+      },
+    })
+
+    await user.click(start.hour)
+    expect(start.hour).toHaveFocus()
+    await user.keyboard('{11}')
+    expect(start.minute).toHaveFocus()
+    await user.keyboard('{45}')
+    expect(end.hour).toHaveFocus()
+  })
+
   it('populates segment with value - `Time`', async () => {
     const { start, end } = setup({
       timeRangeFieldProps: { modelValue: time, locale: 'en-GB' },

--- a/packages/core/src/TimeRangeField/TimeRangeFieldRoot.vue
+++ b/packages/core/src/TimeRangeField/TimeRangeFieldRoot.vue
@@ -433,7 +433,10 @@ provideTimeRangeFieldRootContext({
   elements: segmentElements,
   setFocusedElement,
   focusNext() {
-    nextFocusableSegment.value?.focus()
+    // Auto-advance follows the segments' DOM order (the locale's format
+    // order) regardless of writing direction; only arrow-key navigation is
+    // direction-aware via nextFocusableSegment/prevFocusableSegment.
+    Array.from(segmentElements.value)[currentSegmentIndex.value + 1]?.focus()
   },
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2812

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`focusNext()` — the auto-advance that runs after a segment is completed — reused `nextFocusableSegment`, whose index sign flips for RTL (`const sign = dir.value === 'rtl' ? -1 : 1`). The flip is correct for `ArrowLeft`/`ArrowRight` spatial navigation, but auto-advance is *logical* navigation: the next segment to type is always the next one in DOM order (the locale's format order), exactly like Tab. In RTL this made completing the first segment move focus nowhere (index `-1`), and completing a middle segment move focus backwards.

`focusNext()` now advances `currentSegmentIndex + 1` in DOM order directly, in `DateFieldRoot`, `DateRangeFieldRoot` and `TimeFieldRoot` (all three duplicated the pattern). Arrow-key navigation is untouched and stays direction-aware.

Each component gets a regression test (default `en-US` locale with `dir="rtl"`, mirroring the existing typing tests); all three fail on `main` and pass with the fix. Full `DateField`/`DateRangeField`/`TimeField` suites pass (142 tests).

Downstream context: nuxt/ui#6414 (fa-IR `UInputDate`, report with video).

### 📸 Screenshots (if appropriate)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic focus advancement for date, date-range, and time fields in right-to-left layouts.
  * Auto-advance now follows the locale/format DOM segment order, while arrow-key navigation remains direction-aware.
* **Tests**
  * Added RTL keyboard focus traversal coverage for DateField, DateRangeField, TimeField, and TimeRangeField, including year/month/day and hour/minute progression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->