### PR TITLE
fix(PinInput): reflect undefined values in numeric v-model type

### DIFF
--- a/packages/core/src/PinInput/PinInput.test.ts
+++ b/packages/core/src/PinInput/PinInput.test.ts
@@ -334,6 +334,22 @@ describe('give PinInput type=number', async () => {
     })
   })
 
+  describe('after clearing a middle input', () => {
+    beforeEach(async () => {
+      await userEvent.keyboard('12345')
+      inputs[2].element.focus()
+      await inputs[2].trigger('keydown', { key: 'Backspace' })
+    })
+
+    it('should clear only the targeted box', () => {
+      expect(inputs.map(i => i.element.value)).toStrictEqual(['1', '2', '', '4', '5'])
+    })
+
+    it('should emit \'update:modelValue\' with an explicit undefined at the gap', () => {
+      expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toStrictEqual([1, 2, undefined, 4, 5])
+    })
+  })
+
   describe('after user input numeric word consisting only of zeros', () => {
     beforeEach(async () => {
       await userEvent.keyboard('00000')

--- a/packages/core/src/PinInput/PinInputInput.vue
+++ b/packages/core/src/PinInput/PinInputInput.vue
@@ -218,7 +218,7 @@ function updateModelValueAt(index: number, value: string) {
     const num = +value
 
     if (value === '' || isNaN(num)) {
-      delete tempModelValue[index]
+      tempModelValue[index] = undefined
     }
     else {
       tempModelValue[index] = num

--- a/packages/core/src/PinInput/PinInputRoot.vue
+++ b/packages/core/src/PinInput/PinInputRoot.vue
@@ -9,15 +9,16 @@ import VisuallyHiddenInput from '@/VisuallyHidden/VisuallyHiddenInput.vue'
 export type PinInputType = 'text' | 'number'
 
 // Using this type to avoid mixed arrays (string | number)[].
-// The value type can be number[] only when the type is explicitly set to 'number'
-export type PinInputValue<Type extends PinInputType> = [Type] extends ['number'] ? number[] : string[]
+// The value type can be (number | undefined)[] only when the type is explicitly set to 'number'.
+// Cleared inputs leave gaps, so numeric values may be `undefined`.
+export type PinInputValue<Type extends PinInputType> = [Type] extends ['number'] ? (number | undefined)[] : string[]
 
 // provide the mixed arrays because the `type` is dynamic in the context
 export type PinInputContextValue<Type extends PinInputType = 'text'>
   = Type extends 'number'
     ? Type extends 'string'
-      ? string[] | number[]
-      : number[]
+      ? string[] | (number | undefined)[]
+      : (number | undefined)[]
     : string[]
 
 export type PinInputRootEmits<Type extends PinInputType = 'text'> = {


### PR DESCRIPTION
Clearing a numeric PinInput uses `delete` on the model array, which leaves a gap, so a v-model like `[1, 2, 3]` comes back as `[1, undefined, 3]`. The `PinInputValue` type for `'number'` was `number[]`, so those `undefined` entries weren't reflected. This widens the numeric case to `(number | undefined)[]` to match what the component actually emits.

Fixes #2811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated numeric PIN handling so cleared or empty positions are represented as explicit gaps, keeping other digits intact.
  * Empty or invalid numeric input now results in that slot becoming empty (instead of being removed), improving `modelValue`/completion accuracy and contextual state.
* **Tests**
  * Added coverage for clearing a middle slot via Backspace, verifying the emitted `update:modelValue` includes an explicit empty gap at the cleared index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->