### PR TITLE
feat(types): enable exactOptionalPropertyTypes

### DIFF
--- a/eslint-rules/add-undef-to-optional.mjs
+++ b/eslint-rules/add-undef-to-optional.mjs
@@ -34,16 +34,19 @@ const NEEDS_PARENS = new Set([
  *
  * @param {import('@typescript-eslint/types').TSESTree.TSTypeAnnotation['typeAnnotation'] | undefined} typeNode
  * @param {Map<string, any>} typeDefinitions
+ * @param {Set<string>} resolving Aliases on the current resolution path, so a
+ * recursive alias (`type A = B; type B = A`) terminates instead of overflowing
+ * the stack.
  * @returns {boolean} Whether the type already accepts `undefined`.
  */
-function acceptsUndefined(typeNode, typeDefinitions) {
+function acceptsUndefined(typeNode, typeDefinitions, resolving = new Set()) {
   if (!typeNode) {
     return false
   }
 
   switch (typeNode.type) {
     case AST_NODE_TYPES.TSUnionType: {
-      return typeNode.types.some(t => acceptsUndefined(t, typeDefinitions))
+      return typeNode.types.some(t => acceptsUndefined(t, typeDefinitions, resolving))
     }
     case AST_NODE_TYPES.TSUndefinedKeyword:
     case AST_NODE_TYPES.TSAnyKeyword:
@@ -51,13 +54,18 @@ function acceptsUndefined(typeNode, typeDefinitions) {
       return true
     case AST_NODE_TYPES.TSTypeReference: {
       if (typeNode.typeName?.type === AST_NODE_TYPES.Identifier) {
+        const { name } = typeNode.typeName
         // Check if it's a reference to 'undefined' itself
-        if (typeNode.typeName.name === 'undefined') {
+        if (name === 'undefined') {
           return true
         }
-        // If we have a local definition, check it
-        if (typeDefinitions.has(typeNode.typeName.name)) {
-          return acceptsUndefined(typeDefinitions.get(typeNode.typeName.name), typeDefinitions)
+        // If we have a local definition, check it — unless we are already
+        // resolving it further up the path
+        if (typeDefinitions.has(name) && !resolving.has(name)) {
+          resolving.add(name)
+          const result = acceptsUndefined(typeDefinitions.get(name), typeDefinitions, resolving)
+          resolving.delete(name)
+          return result
         }
       }
       break
@@ -85,6 +93,8 @@ export default createRule({
   defaultOptions: [],
   create(context) {
     const typeDefinitions = new Map()
+    /** @type {import('@typescript-eslint/types').TSESTree.TSPropertySignature[]} */
+    const optionalProperties = []
 
     return {
       // Collect type alias definitions, ie, type Foo = ...
@@ -95,28 +105,36 @@ export default createRule({
       },
       // only checks optional properties in types/interfaces
       TSPropertySignature(node) {
-        if (!node.optional || !node.typeAnnotation) {
-          return
+        if (node.optional && node.typeAnnotation) {
+          optionalProperties.push(node)
         }
-        const typeNode = node.typeAnnotation.typeAnnotation
-        if (!typeNode || acceptsUndefined(typeNode, typeDefinitions)) {
-          return
-        }
+      },
+      // Deferred: nodes are visited in source order, so an alias declared below
+      // the property that references it is not in `typeDefinitions` yet while
+      // the property is being visited.
+      'Program:exit': function () {
         const source = context.sourceCode
-        context.report({
-          node: node.key ?? node,
-          messageId: 'addUndefined',
-          data: {
-            propName: source.getText(node.key),
-          },
-          fix(fixer) {
-            const text = source.getText(typeNode)
-            return fixer.replaceText(
-              typeNode,
-              NEEDS_PARENS.has(typeNode.type) ? `(${text}) | undefined` : `${text} | undefined`,
-            )
-          },
-        })
+
+        for (const node of optionalProperties) {
+          const typeNode = node.typeAnnotation.typeAnnotation
+          if (!typeNode || acceptsUndefined(typeNode, typeDefinitions)) {
+            continue
+          }
+          context.report({
+            node: node.key ?? node,
+            messageId: 'addUndefined',
+            data: {
+              propName: source.getText(node.key),
+            },
+            fix(fixer) {
+              const text = source.getText(typeNode)
+              return fixer.replaceText(
+                typeNode,
+                NEEDS_PARENS.has(typeNode.type) ? `(${text}) | undefined` : `${text} | undefined`,
+              )
+            },
+          })
+        }
       },
     }
   },

--- a/eslint-rules/add-undef-to-optional.mjs
+++ b/eslint-rules/add-undef-to-optional.mjs
@@ -1,0 +1,123 @@
+/**
+ * Adapted from MUI's `add-undef-to-optional` rule.
+ * @see https://github.com/mui/mui-public/blob/master/packages/code-infra/src/eslint/mui/rules/add-undef-to-optional.mjs
+ *
+ * Optional properties whose type does not include `undefined` are unusable by
+ * consumers compiling with `exactOptionalPropertyTypes`, since they cannot pass
+ * `undefined` explicitly (e.g. `:disabled="maybeUndefined"`).
+ */
+
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils'
+
+const createRule = ESLintUtils.RuleCreator(
+  () =>
+    'https://github.com/unovue/reka-ui/blob/v2/eslint-rules/add-undef-to-optional.mjs',
+)
+
+const RULE_NAME = 'add-undef-to-optional'
+
+/**
+ * Type nodes that bind loosely enough that appending `| undefined` would change
+ * their meaning, so the original type has to be wrapped in parentheses.
+ */
+const NEEDS_PARENS = new Set([
+  AST_NODE_TYPES.TSFunctionType,
+  AST_NODE_TYPES.TSConstructorType,
+  AST_NODE_TYPES.TSConditionalType,
+  AST_NODE_TYPES.TSInferType,
+])
+
+/**
+ * Checks whether the given type node includes 'undefined' either directly,
+ * via union, or via type references that eventually include 'undefined'.
+ * Treats 'any' and 'unknown' as including 'undefined'.
+ *
+ * @param {import('@typescript-eslint/types').TSESTree.TSTypeAnnotation['typeAnnotation'] | undefined} typeNode
+ * @param {Map<string, any>} typeDefinitions
+ * @returns {boolean} Whether the type already accepts `undefined`.
+ */
+function acceptsUndefined(typeNode, typeDefinitions) {
+  if (!typeNode) {
+    return false
+  }
+
+  switch (typeNode.type) {
+    case AST_NODE_TYPES.TSUnionType: {
+      return typeNode.types.some(t => acceptsUndefined(t, typeDefinitions))
+    }
+    case AST_NODE_TYPES.TSUndefinedKeyword:
+    case AST_NODE_TYPES.TSAnyKeyword:
+    case AST_NODE_TYPES.TSUnknownKeyword:
+      return true
+    case AST_NODE_TYPES.TSTypeReference: {
+      if (typeNode.typeName?.type === AST_NODE_TYPES.Identifier) {
+        // Check if it's a reference to 'undefined' itself
+        if (typeNode.typeName.name === 'undefined') {
+          return true
+        }
+        // If we have a local definition, check it
+        if (typeDefinitions.has(typeNode.typeName.name)) {
+          return acceptsUndefined(typeDefinitions.get(typeNode.typeName.name), typeDefinitions)
+        }
+      }
+      break
+    }
+    default:
+      break
+  }
+  return false
+}
+
+export default createRule({
+  meta: {
+    docs: {
+      description: 'Ensures that optional properties include undefined in their type.',
+    },
+    messages: {
+      addUndefined:
+        'Optional property "{{ propName }}" type does not explicitly include undefined. Add "| undefined".',
+    },
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+  },
+  name: RULE_NAME,
+  defaultOptions: [],
+  create(context) {
+    const typeDefinitions = new Map()
+
+    return {
+      // Collect type alias definitions, ie, type Foo = ...
+      TSTypeAliasDeclaration(node) {
+        if (node.id && node.typeAnnotation) {
+          typeDefinitions.set(node.id.name, node.typeAnnotation)
+        }
+      },
+      // only checks optional properties in types/interfaces
+      TSPropertySignature(node) {
+        if (!node.optional || !node.typeAnnotation) {
+          return
+        }
+        const typeNode = node.typeAnnotation.typeAnnotation
+        if (!typeNode || acceptsUndefined(typeNode, typeDefinitions)) {
+          return
+        }
+        const source = context.sourceCode
+        context.report({
+          node: node.key ?? node,
+          messageId: 'addUndefined',
+          data: {
+            propName: source.getText(node.key),
+          },
+          fix(fixer) {
+            const text = source.getText(typeNode)
+            return fixer.replaceText(
+              typeNode,
+              NEEDS_PARENS.has(typeNode.type) ? `(${text}) | undefined` : `${text} | undefined`,
+            )
+          },
+        })
+      },
+    }
+  },
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import antfu from '@antfu/eslint-config'
+import addUndefToOptional from './eslint-rules/add-undef-to-optional.mjs'
 
 export default antfu(
   {
@@ -19,6 +20,31 @@ export default antfu(
   },
   {
     ignores: ['*.js'],
+  },
+  {
+    // Shipped library source only. The rule exists so that consumers compiling
+    // with `exactOptionalPropertyTypes` can pass an explicit `undefined` into
+    // any optional property we export; tests and stories are not part of that
+    // contract.
+    files: ['packages/*/src/**/*.ts', 'packages/*/src/**/*.vue'],
+    ignores: [
+      '**/*.test.ts',
+      '**/*.test-d.ts',
+      '**/*.test-d.vue',
+      '**/*.story.vue',
+      '**/story/**',
+      '**/stories/**',
+    ],
+    plugins: {
+      reka: {
+        rules: {
+          'add-undef-to-optional': addUndefToOptional,
+        },
+      },
+    },
+    rules: {
+      'reka/add-undef-to-optional': 'error',
+    },
   },
   {
     rules: {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@antfu/eslint-config": "^8.0.0",
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2",
+    "@typescript-eslint/utils": "^8.58.0",
     "bumpp": "^12.1.1",
     "eslint": "^10.2.0",
     "lint-staged": "^16.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,6 +68,7 @@
     "dist",
     "!src/**/*.story.vue",
     "!src/**/*.test.*",
+    "!src/**/*.test-d.*",
     "!src/**/_*.vue",
     "!src/**/__snapshots__",
     "!src/**/stories",

--- a/packages/core/src/Accordion/AccordionItem.vue
+++ b/packages/core/src/Accordion/AccordionItem.vue
@@ -42,11 +42,12 @@ export const [injectAccordionItemContext, provideAccordionItemContext]
 <script setup lang="ts">
 import { computed } from 'vue'
 import { CollapsibleRoot } from '@/Collapsible'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(
   defineProps<AccordionItemProps>(),
   {
-    unmountOnHide: undefined,
+    unmountOnHide: UNDEFINED_DEFAULT,
   },
 )
 

--- a/packages/core/src/Accordion/AccordionItem.vue
+++ b/packages/core/src/Accordion/AccordionItem.vue
@@ -17,7 +17,7 @@ export interface AccordionItemProps
    *
    * @defaultValue false
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * A string value for the accordion item. All items within an accordion should use a unique value.
    */
@@ -51,10 +51,10 @@ const props = withDefaults(
 )
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const rootContext = injectAccordionRootContext()

--- a/packages/core/src/Accordion/AccordionRoot.vue
+++ b/packages/core/src/Accordion/AccordionRoot.vue
@@ -12,35 +12,35 @@ export interface AccordionRootProps<T = string | string[]>
    *
    * @defaultValue false
    */
-  collapsible?: boolean
+  collapsible?: boolean | undefined
 
   /**
    * When `true`, prevents the user from interacting with the accordion and all its items
    *
    * @defaultValue false
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
 
   /**
    * The reading direction of the accordion when applicable. If omitted, assumes LTR (left-to-right) reading mode.
    *
    * @defaultValue "ltr"
    */
-  dir?: Direction
+  dir?: Direction | undefined
 
   /**
    * The orientation of the accordion.
    *
    * @defaultValue "vertical"
    */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
 
   /**
    * When `true`, the element will be unmounted on closed state.
    *
    * @defaultValue `true`
    */
-  unmountOnHide?: boolean
+  unmountOnHide?: boolean | undefined
 }
 
 export type AccordionRootEmits<T extends SingleOrMultipleType = SingleOrMultipleType> = {
@@ -81,10 +81,10 @@ const props = withDefaults(defineProps<AccordionRootProps<T>>(), {
 const emits = defineEmits<AccordionRootEmits<ExplicitType>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current active value */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { dir, disabled, unmountOnHide } = toRefs(props)

--- a/packages/core/src/AlertDialog/AlertDialogContent.vue
+++ b/packages/core/src/AlertDialog/AlertDialogContent.vue
@@ -19,12 +19,13 @@ export interface AlertDialogContentProps extends DialogContentProps {}
 <script setup lang="ts">
 import { nextTick, ref } from 'vue'
 import { DialogContent } from '@/Dialog'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<AlertDialogContentProps>(), {
   // Keep `undefined` (instead of Vue's boolean coercion to `false`) so
   // DialogContent can preserve the modal default while still honoring an
   // explicit `:disable-outside-pointer-events="false"`.
-  disableOutsidePointerEvents: undefined,
+  disableOutsidePointerEvents: UNDEFINED_DEFAULT,
 })
 const emits = defineEmits<AlertDialogContentEmits>()
 

--- a/packages/core/src/AspectRatio/AspectRatio.vue
+++ b/packages/core/src/AspectRatio/AspectRatio.vue
@@ -7,7 +7,7 @@ export interface AspectRatioProps extends PrimitiveProps {
    * The desired ratio. Eg: 16/9
    * @defaultValue 1
    */
-  ratio?: number
+  ratio?: number | undefined
 }
 </script>
 
@@ -23,10 +23,10 @@ const props = withDefaults(defineProps<AspectRatioProps>(), {
   ratio: 1,
 })
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current aspect ratio (in %) */
     aspect: typeof aspect.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { forwardRef } = useForwardExpose()

--- a/packages/core/src/Autocomplete/AutocompleteRoot.vue
+++ b/packages/core/src/Autocomplete/AutocompleteRoot.vue
@@ -68,9 +68,10 @@ import { createEventHook, useVModel } from '@vueuse/core'
 import { computed, getCurrentInstance, nextTick, onMounted, ref, toRefs } from 'vue'
 import { ListboxRoot } from '@/Listbox'
 import { PopperRoot } from '@/Popper'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<AutocompleteRootProps>(), {
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   resetSearchTermOnBlur: false,
   openOnFocus: false,
   openOnClick: false,

--- a/packages/core/src/Autocomplete/AutocompleteRoot.vue
+++ b/packages/core/src/Autocomplete/AutocompleteRoot.vue
@@ -8,42 +8,42 @@ import { createContext, useDirection, useFilter } from '@/shared'
 
 export interface AutocompleteRootProps extends PrimitiveProps {
   /** The controlled value of the Autocomplete (the input text). Can be bound with `v-model`. */
-  modelValue?: string
+  modelValue?: string | undefined
   /** The value of the autocomplete when initially rendered. Use when you do not need to control the state. */
-  defaultValue?: string
+  defaultValue?: string | undefined
   /** The controlled open state of the Autocomplete. Can be bound with `v-model:open`. */
-  open?: boolean
+  open?: boolean | undefined
   /** The open state of the autocomplete when it is initially rendered. Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
   /** When `true`, prevents the user from interacting with autocomplete */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** The reading direction of the autocomplete when applicable. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** The name of the field. Submitted with its owning form as part of a name/value pair. */
-  name?: string
+  name?: string | undefined
   /** When `true`, indicates that the user must set the value before the owning form can be submitted. */
-  required?: boolean
+  required?: boolean | undefined
   /**
    * Whether to reset the searchTerm when the Autocomplete input blurred
    * @defaultValue `false`
    */
-  resetSearchTermOnBlur?: boolean
+  resetSearchTermOnBlur?: boolean | undefined
   /**
    * Whether to open the autocomplete when the input is focused
    * @defaultValue `false`
    */
-  openOnFocus?: boolean
+  openOnFocus?: boolean | undefined
   /**
    * Whether to open the autocomplete when the input is clicked
    * @defaultValue `false`
    */
-  openOnClick?: boolean
+  openOnClick?: boolean | undefined
   /**
    * When `true`, disable the default filters
    */
-  ignoreFilter?: boolean
+  ignoreFilter?: boolean | undefined
   /** When `true`, hover over item will trigger highlight */
-  highlightOnHover?: boolean
+  highlightOnHover?: boolean | undefined
 }
 
 export type AutocompleteRootEmits = {
@@ -79,12 +79,12 @@ const props = withDefaults(defineProps<AutocompleteRootProps>(), {
 const emits = defineEmits<AutocompleteRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
     /** Current active value */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { primitiveElement, currentElement: parentElement } = usePrimitiveElement<GenericComponentInstance<typeof ListboxRoot>>()

--- a/packages/core/src/Avatar/AvatarFallback.vue
+++ b/packages/core/src/Avatar/AvatarFallback.vue
@@ -5,7 +5,7 @@ import { useForwardExpose } from '@/shared'
 
 export interface AvatarFallbackProps extends PrimitiveProps {
   /** Useful for delaying rendering so it only appears for those with slower connections. */
-  delayMs?: number
+  delayMs?: number | undefined
 }
 </script>
 

--- a/packages/core/src/Avatar/AvatarImage.vue
+++ b/packages/core/src/Avatar/AvatarImage.vue
@@ -12,8 +12,8 @@ export type AvatarImageEmits = {
 }
 export interface AvatarImageProps extends PrimitiveProps {
   src: string
-  referrerPolicy?: ImgHTMLAttributes['referrerpolicy']
-  crossOrigin?: ImgHTMLAttributes['crossorigin']
+  referrerPolicy?: ImgHTMLAttributes['referrerpolicy'] | undefined
+  crossOrigin?: ImgHTMLAttributes['crossorigin'] | undefined
 }
 </script>
 

--- a/packages/core/src/Avatar/utils.ts
+++ b/packages/core/src/Avatar/utils.ts
@@ -17,7 +17,7 @@ function resolveLoadingStatus(image: HTMLImageElement | null, src?: string): Ima
   return image.complete && image.naturalWidth > 0 ? 'loaded' : 'loading'
 }
 
-export function useImageLoadingStatus(src: Ref<string>, { referrerPolicy, crossOrigin }: { referrerPolicy?: Ref<ImgHTMLAttributes['referrerpolicy']>, crossOrigin?: Ref<ImgHTMLAttributes['crossorigin']> } = {}) {
+export function useImageLoadingStatus(src: Ref<string>, { referrerPolicy, crossOrigin }: { referrerPolicy?: Ref<ImgHTMLAttributes['referrerpolicy']> | undefined, crossOrigin?: Ref<ImgHTMLAttributes['crossorigin']> | undefined } = {}) {
   const isMounted = ref(false)
   const imageRef = ref<HTMLImageElement | null>(null)
   const image = computed(() => {

--- a/packages/core/src/Calendar/CalendarCellTrigger.vue
+++ b/packages/core/src/Calendar/CalendarCellTrigger.vue
@@ -20,7 +20,7 @@ export interface CalendarCellTriggerProps extends PrimitiveProps {
 }
 
 export interface CalendarCellTriggerSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current day */
     dayValue: string
     /** Current disable state */
@@ -35,7 +35,7 @@ export interface CalendarCellTriggerSlot {
     outsideVisibleView: boolean
     /** Current unavailable state */
     unavailable: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/Calendar/CalendarHeading.vue
+++ b/packages/core/src/Calendar/CalendarHeading.vue
@@ -11,10 +11,10 @@ import { injectCalendarRootContext } from './CalendarRoot.vue'
 const props = withDefaults(defineProps<CalendarHeadingProps>(), { as: 'div' })
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current month and year */
     headingValue: string
-  }) => any
+  }) => any) | undefined
 }>()
 
 const rootContext = injectCalendarRootContext()

--- a/packages/core/src/Calendar/CalendarNext.vue
+++ b/packages/core/src/Calendar/CalendarNext.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface CalendarNextProps extends PrimitiveProps {
   /** The function to be used for the next page. Overwrites the `nextPage` function set on the `CalendarRoot`. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface CalendarNextSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/Calendar/CalendarPrev.vue
+++ b/packages/core/src/Calendar/CalendarPrev.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface CalendarPrevProps extends PrimitiveProps {
   /** The function to be used for the prev page. Overwrites the `prevPage` function set on the `CalendarRoot`. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface CalendarPrevSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/Calendar/CalendarRoot.vue
+++ b/packages/core/src/Calendar/CalendarRoot.vue
@@ -122,7 +122,6 @@ import { computed, onMounted, toRefs, watch } from 'vue'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
 
 const props = withDefaults(defineProps<CalendarRootProps>(), {
-  defaultValue: undefined,
   as: 'div',
   pagedNavigation: false,
   preventDeselect: false,
@@ -133,9 +132,6 @@ const props = withDefaults(defineProps<CalendarRootProps>(), {
   disabled: false,
   readonly: false,
   initialFocus: false,
-  placeholder: undefined,
-  isDateDisabled: undefined,
-  isDateUnavailable: undefined,
   disableDaysOutsideCurrentView: false,
 })
 const emits = defineEmits<CalendarRootEmits>()

--- a/packages/core/src/Calendar/CalendarRoot.vue
+++ b/packages/core/src/Calendar/CalendarRoot.vue
@@ -37,7 +37,7 @@ type CalendarRootContext = {
   isInvalid: Ref<boolean>
   isDateDisabled: Matcher
   isDateSelected: Matcher
-  isDateUnavailable?: Matcher
+  isDateUnavailable?: Matcher | undefined
   isOutsideVisibleView: (date: DateValue) => boolean
   prevPage: (prevPageFunc?: (date: DateValue) => DateValue) => void
   nextPage: (nextPageFunc?: (date: DateValue) => DateValue) => void
@@ -56,53 +56,53 @@ type CalendarRootContext = {
 
 export interface CalendarRootProps extends PrimitiveProps {
   /** The default value for the calendar */
-  defaultValue?: DateValue
+  defaultValue?: DateValue | undefined
   /** The default placeholder date */
-  defaultPlaceholder?: DateValue
+  defaultPlaceholder?: DateValue | undefined
   /** The placeholder date, which is used to determine what month to display when no date is selected */
-  placeholder?: DateValue
+  placeholder?: DateValue | undefined
   /** This property causes the previous and next buttons to navigate by the number of months displayed at once, rather than one month */
-  pagedNavigation?: boolean
+  pagedNavigation?: boolean | undefined
   /** Whether or not to prevent the user from deselecting a date without selecting another date first */
-  preventDeselect?: boolean
+  preventDeselect?: boolean | undefined
   /** The day of the week to start the calendar on */
-  weekStartsOn?: WeekStartsOn
+  weekStartsOn?: WeekStartsOn | undefined
   /** The format to use for the weekday strings provided via the weekdays slot prop */
-  weekdayFormat?: WeekDayFormat
+  weekdayFormat?: WeekDayFormat | undefined
   /** The accessible label for the calendar */
-  calendarLabel?: string
+  calendarLabel?: string | undefined
   /** Whether or not to always display 6 weeks in the calendar */
-  fixedWeeks?: boolean
+  fixedWeeks?: boolean | undefined
   /** The maximum date that can be selected */
-  maxValue?: DateValue
+  maxValue?: DateValue | undefined
   /** The minimum date that can be selected */
-  minValue?: DateValue
+  minValue?: DateValue | undefined
   /** The locale to use for formatting dates */
-  locale?: string
+  locale?: string | undefined
   /** The number of months to display at once */
-  numberOfMonths?: number
+  numberOfMonths?: number | undefined
   /** Whether the calendar is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether the calendar is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** If true, the calendar will focus the selected day, today, or the first day of the month depending on what is visible when the calendar is mounted */
-  initialFocus?: boolean
+  initialFocus?: boolean | undefined
   /** A function that returns whether or not a date is disabled */
-  isDateDisabled?: Matcher
+  isDateDisabled?: Matcher | undefined
   /** A function that returns whether or not a date is unavailable */
-  isDateUnavailable?: Matcher
+  isDateUnavailable?: Matcher | undefined
   /** The reading direction of the calendar when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** A function that returns the next page of the calendar. It receives the current placeholder as an argument inside the component. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** A function that returns the previous page of the calendar. It receives the current placeholder as an argument inside the component. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** The controlled selected date value of the calendar. Can be bound as `v-model`. */
-  modelValue?: DateValue | DateValue[] | null
+  modelValue?: DateValue | DateValue[] | null | undefined
   /** Whether multiple dates can be selected */
-  multiple?: boolean
+  multiple?: boolean | undefined
   /** Whether or not to disable days outside the current view. */
-  disableDaysOutsideCurrentView?: boolean
+  disableDaysOutsideCurrentView?: boolean | undefined
 }
 
 export type CalendarRootEmits = {
@@ -140,7 +140,7 @@ const props = withDefaults(defineProps<CalendarRootProps>(), {
 })
 const emits = defineEmits<CalendarRootEmits>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current date of the placeholder */
     date: DateValue
     /** The grid of dates */
@@ -155,7 +155,7 @@ defineSlots<{
     fixedWeeks: boolean
     /** The current date of the calendar */
     modelValue: DateValue | DateValue[] | undefined
-  }) => any
+  }) => any) | undefined
 }>()
 
 const {

--- a/packages/core/src/Calendar/useCalendar.ts
+++ b/packages/core/src/Calendar/useCalendar.ts
@@ -22,8 +22,8 @@ export type UseCalendarProps = {
   disabled: Ref<boolean>
   weekdayFormat: Ref<WeekDayFormat>
   pagedNavigation: Ref<boolean>
-  isDateDisabled?: Matcher
-  isDateUnavailable?: Matcher
+  isDateDisabled?: Matcher | undefined
+  isDateUnavailable?: Matcher | undefined
   calendarLabel: Ref<string | undefined>
   nextPage: Ref<((placeholder: DateValue) => DateValue) | undefined>
   prevPage: Ref<((placeholder: DateValue) => DateValue) | undefined>

--- a/packages/core/src/Checkbox/CheckboxGroupRoot.vue
+++ b/packages/core/src/Checkbox/CheckboxGroupRoot.vue
@@ -9,13 +9,13 @@ import { createContext, useDirection, useFormControl } from '@/shared'
 
 export interface CheckboxGroupRootProps<T = AcceptableValue> extends Pick<RovingFocusGroupProps, 'as' | 'asChild' | 'dir' | 'orientation' | 'loop'>, FormFieldProps {
   /** The value of the checkbox when it is initially rendered. Use when you do not need to control its value. */
-  defaultValue?: T[]
+  defaultValue?: T[] | undefined
   /** The controlled value of the checkbox. Can be binded with v-model. */
-  modelValue?: T[]
+  modelValue?: T[] | undefined
   /** When `false`, navigating through the items using arrow keys will be disabled. */
-  rovingFocus?: boolean
+  rovingFocus?: boolean | undefined
   /** When `true`, prevents the user from interacting with the checkboxes */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export type CheckboxGroupRootEmits<T = AcceptableValue> = {

--- a/packages/core/src/Checkbox/CheckboxIndicator.vue
+++ b/packages/core/src/Checkbox/CheckboxIndicator.vue
@@ -7,7 +7,7 @@ export interface CheckboxIndicatorProps extends PrimitiveProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Checkbox/CheckboxRoot.vue
+++ b/packages/core/src/Checkbox/CheckboxRoot.vue
@@ -58,11 +58,10 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<CheckboxRootProps<T>>(), {
-  modelValue: undefined,
   value: 'on',
   as: 'button',
-  trueValue: (() => true) as unknown as undefined,
-  falseValue: (() => false) as unknown as undefined,
+  trueValue: (() => true) as unknown as never,
+  falseValue: (() => false) as unknown as never,
 })
 const emits = defineEmits<CheckboxRootEmits<T>>()
 

--- a/packages/core/src/Checkbox/CheckboxRoot.vue
+++ b/packages/core/src/Checkbox/CheckboxRoot.vue
@@ -9,26 +9,26 @@ import { injectCheckboxGroupRootContext } from './CheckboxGroupRoot.vue'
 
 export interface CheckboxRootProps<T = boolean> extends PrimitiveProps, FormFieldProps {
   /** The value of the checkbox when it is initially rendered. Use when you do not need to control its value. */
-  defaultValue?: T | 'indeterminate'
+  defaultValue?: T | 'indeterminate' | undefined
   /** The controlled value of the checkbox. Can be binded with v-model. */
-  modelValue?: T | 'indeterminate' | null
+  modelValue?: T | 'indeterminate' | null | undefined
   /** When `true`, prevents the user from interacting with the checkbox */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * The value given as data when submitted with a `name`.
    *  @defaultValue "on"
    */
-  value?: AcceptableValue
+  value?: AcceptableValue | undefined
   /** Id of the element */
-  id?: string
+  id?: string | undefined
   /**
    * The value used when the checkbox is checked. Defaults to `true`.
    */
-  trueValue?: T
+  trueValue?: T | undefined
   /**
    * The value used when the checkbox is unchecked. Defaults to `false`.
    */
-  falseValue?: T
+  falseValue?: T | undefined
 }
 
 export type CheckboxRootEmits<T = boolean> = {
@@ -67,12 +67,12 @@ const props = withDefaults(defineProps<CheckboxRootProps<T>>(), {
 const emits = defineEmits<CheckboxRootEmits<T>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current value */
     modelValue: typeof modelValue.value
     /** Current state */
     state: typeof checkboxState.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { forwardRef, currentElement } = useForwardExpose()

--- a/packages/core/src/Collapsible/CollapsibleContent.vue
+++ b/packages/core/src/Collapsible/CollapsibleContent.vue
@@ -6,7 +6,7 @@ export interface CollapsibleContentProps extends PrimitiveProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 
 export type CollapsibleContentEmits = {

--- a/packages/core/src/Collapsible/CollapsibleRoot.vue
+++ b/packages/core/src/Collapsible/CollapsibleRoot.vue
@@ -35,9 +35,10 @@ export const [injectCollapsibleRootContext, provideCollapsibleRootContext]
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
 import { Primitive } from '@/Primitive'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<CollapsibleRootProps>(), {
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   defaultOpen: false,
   unmountOnHide: true,
 })

--- a/packages/core/src/Collapsible/CollapsibleRoot.vue
+++ b/packages/core/src/Collapsible/CollapsibleRoot.vue
@@ -6,13 +6,13 @@ import { createContext, useForwardExpose } from '@/shared'
 
 export interface CollapsibleRootProps extends PrimitiveProps {
   /** The open state of the collapsible when it is initially rendered. <br> Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
   /** The controlled open state of the collapsible. Can be binded with `v-model`. */
-  open?: boolean
+  open?: boolean | undefined
   /** When `true`, prevents the user from interacting with the collapsible. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** When `true`, the element will be unmounted on closed state. */
-  unmountOnHide?: boolean
+  unmountOnHide?: boolean | undefined
 }
 
 export type CollapsibleRootEmits = {
@@ -22,7 +22,7 @@ export type CollapsibleRootEmits = {
 
 interface CollapsibleRootContext {
   contentId: string
-  disabled?: Ref<boolean>
+  disabled?: Ref<boolean> | undefined
   open: Ref<boolean>
   unmountOnHide: Ref<boolean>
   onOpenToggle: () => void
@@ -45,10 +45,10 @@ const props = withDefaults(defineProps<CollapsibleRootProps>(), {
 const emit = defineEmits<CollapsibleRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const open = useVModel(props, 'open', emit, {

--- a/packages/core/src/Collection/Collection.ts
+++ b/packages/core/src/Collection/Collection.ts
@@ -9,7 +9,7 @@ interface CollectionContext<ItemData = {}> {
 
 const ITEM_DATA_ATTR = 'data-reka-collection-item'
 
-export function useCollection<ItemData = {}>(options: { key?: string, isProvider?: boolean } = {}) {
+export function useCollection<ItemData = {}>(options: { key?: string | undefined, isProvider?: boolean | undefined } = {}) {
   const { key = '', isProvider = false } = options
   const injectionKey = `${key}CollectionProvider`
   let context: CollectionContext<ItemData>

--- a/packages/core/src/ColorArea/ColorAreaRoot.vue
+++ b/packages/core/src/ColorArea/ColorAreaRoot.vue
@@ -7,21 +7,21 @@ import { createContext, useFormControl, useForwardExpose } from '@/shared'
 
 export interface ColorAreaRootProps extends PrimitiveProps, FormFieldProps {
   /** The color value (controlled). Can be a hex string or Color object. */
-  modelValue?: string | Color
+  modelValue?: string | Color | undefined
   /** The default color value (uncontrolled). */
-  defaultValue?: string | Color
+  defaultValue?: string | Color | undefined
   /** The color space to operate in. */
-  colorSpace?: ColorSpace
+  colorSpace?: ColorSpace | undefined
   /** Color channel for the horizontal (x) axis. */
-  xChannel?: ColorChannel
+  xChannel?: ColorChannel | undefined
   /** Color channel for the vertical (y) axis. */
-  yChannel?: ColorChannel
+  yChannel?: ColorChannel | undefined
   /** When `true`, prevents the user from interacting with the area. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** The name of the x channel input element for form submission. */
-  xName?: string
+  xName?: string | undefined
   /** The name of the y channel input element for form submission. */
-  yName?: string
+  yName?: string | undefined
 }
 
 export type ColorAreaRootEmits = {
@@ -78,10 +78,10 @@ const props = withDefaults(defineProps<ColorAreaRootProps>(), {
 const emits = defineEmits<ColorAreaRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** CSS styles for the color area background gradient */
     style: CSSProperties
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { colorSpace, xChannel, yChannel, disabled } = toRefs(props)

--- a/packages/core/src/ColorField/ColorFieldRoot.vue
+++ b/packages/core/src/ColorField/ColorFieldRoot.vue
@@ -7,25 +7,25 @@ import { createContext, useFormControl, useForwardExpose, useLocale } from '@/sh
 
 export interface ColorFieldRootProps extends PrimitiveProps, FormFieldProps {
   /** The color value (controlled). Can be a hex string or Color object. */
-  modelValue?: string | Color
+  modelValue?: string | Color | undefined
   /** The default color value (uncontrolled). */
-  defaultValue?: string | Color
+  defaultValue?: string | Color | undefined
   /** The color space to operate in when displaying a channel. */
-  colorSpace?: ColorSpace
+  colorSpace?: ColorSpace | undefined
   /** The color channel to display. If not provided, displays hex value. */
-  channel?: ColorChannel
+  channel?: ColorChannel | undefined
   /** Placeholder text when the field is empty. */
-  placeholder?: string
+  placeholder?: string | undefined
   /** When `true`, prevents the user from interacting with the field. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** When `true`, the field is read-only. */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** When `true`, prevents the value from changing on wheel scroll. */
-  disableWheelChange?: boolean
+  disableWheelChange?: boolean | undefined
   /** The locale to use for number formatting. */
-  locale?: string
+  locale?: string | undefined
   /** Custom step value for increment/decrement. Defaults to channel step or 1 for hex. */
-  step?: number
+  step?: number | undefined
 }
 
 export type ColorFieldRootEmits = {

--- a/packages/core/src/ColorSlider/ColorSliderRoot.vue
+++ b/packages/core/src/ColorSlider/ColorSliderRoot.vue
@@ -7,23 +7,23 @@ import { createContext, useDirection, useFormControl, useForwardExpose } from '@
 
 export interface ColorSliderRootProps extends PrimitiveProps, FormFieldProps {
   /** The color value (controlled). Can be a hex string or Color object. */
-  modelValue?: string | Color
+  modelValue?: string | Color | undefined
   /** The default color value (uncontrolled). */
-  defaultValue?: string | Color
+  defaultValue?: string | Color | undefined
   /** The color space to operate in. */
-  colorSpace?: ColorSpace
+  colorSpace?: ColorSpace | undefined
   /** The color channel that this slider manipulates. */
   channel: ColorChannel
   /** The orientation of the slider. */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
   /** The reading direction of the slider. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** Whether the slider is visually inverted. */
-  inverted?: boolean
+  inverted?: boolean | undefined
   /** When `true`, prevents the user from interacting with the slider. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Custom step value for increment/decrement. Defaults to the channel's natural step. */
-  step?: number
+  step?: number | undefined
 }
 
 export type ColorSliderRootEmits = {

--- a/packages/core/src/ColorSlider/ColorSliderThumb.vue
+++ b/packages/core/src/ColorSlider/ColorSliderThumb.vue
@@ -15,12 +15,12 @@ const props = withDefaults(defineProps<ColorSliderThumbProps>(), {
 })
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The display name of the current channel */
     channelName: string
     /** The current numeric value of the channel */
     channelValue: number
-  }) => any
+  }) => any) | undefined
 }>()
 
 const rootContext = injectColorSliderRootContext()

--- a/packages/core/src/ColorSwatch/ColorSwatch.vue
+++ b/packages/core/src/ColorSwatch/ColorSwatch.vue
@@ -7,11 +7,11 @@ export interface ColorSwatchProps extends PrimitiveProps {
    * The color to display in the swatch as a hex string or Color object.
    * Example: `#16a372`, `#ff5733`, or `{ space: 'hsl', h: 120, s: 100, l: 50, alpha: 1 }`.
    */
-  color?: string | Color
+  color?: string | Color | undefined
   /**
    * Optional accessible label for the color. If omitted, the color name will be derived from the color value.
    */
-  label?: string
+  label?: string | undefined
 }
 </script>
 

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
@@ -16,10 +16,8 @@ import { ListboxContent, ListboxRoot } from '@/Listbox'
 
 const props = withDefaults(defineProps<ColorSwatchPickerRootProps>(), {
   as: 'div',
-  defaultValue: undefined,
   dir: 'ltr',
   disabled: false,
-  loop: false,
   orientation: 'horizontal',
 })
 

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
@@ -4,8 +4,8 @@ import { useVModel } from '@vueuse/core'
 import { useForwardPropsEmits } from '@/shared'
 
 export interface ColorSwatchPickerRootProps extends Omit<ListboxRootProps, 'by'> {
-  defaultValue?: string | string[]
-  modelValue?: string | string[]
+  defaultValue?: string | string[] | undefined
+  modelValue?: string | string[] | undefined
 }
 
 export type ColorSwatchPickerRootEmits = ListboxRootEmits

--- a/packages/core/src/Combobox/ComboboxContent.vue
+++ b/packages/core/src/Combobox/ComboboxContent.vue
@@ -7,7 +7,7 @@ export interface ComboboxContentProps extends ComboboxContentImplProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -14,14 +14,14 @@ export interface ComboboxContentImplProps extends PopperContentProps, Dismissabl
    * `inline` is the default and you can control the position using CSS. <br>
    * `popper` positions content in the same way as our other primitives, for example `Popover` or `DropdownMenu`.
    */
-  position?: 'inline' | 'popper'
+  position?: 'inline' | 'popper' | undefined
   /** The document.body will be lock, and scrolling will be disabled. */
-  bodyLock?: boolean
+  bodyLock?: boolean | undefined
   /**
    * When `true`, hides the content when there are no items matching the filter.
    * @defaultValue false
    */
-  hideWhenEmpty?: boolean
+  hideWhenEmpty?: boolean | undefined
 }
 
 export const [injectComboboxContentContext, provideComboboxContentContext]

--- a/packages/core/src/Combobox/ComboboxInput.vue
+++ b/packages/core/src/Combobox/ComboboxInput.vue
@@ -8,7 +8,7 @@ import { useComposing } from '@/shared'
 export type ComboboxInputEmits = ListboxFilterEmits
 export interface ComboboxInputProps extends ListboxFilterProps {
   /** The display value of input for selected item. Does not work with `multiple`. */
-  displayValue?: (val: any) => string
+  displayValue?: ((val: any) => string) | undefined
 }
 </script>
 

--- a/packages/core/src/Combobox/ComboboxItem.vue
+++ b/packages/core/src/Combobox/ComboboxItem.vue
@@ -16,7 +16,7 @@ export interface ComboboxItemProps<T = AcceptableValue> extends ListboxItemProps
    *
    * If the children are not plain text, then the `textValue` prop must also be set to a plain text representation, which will be used for autocomplete in the ComboBox.
    */
-  textValue?: string
+  textValue?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Combobox/ComboboxLabel.vue
+++ b/packages/core/src/Combobox/ComboboxLabel.vue
@@ -2,7 +2,7 @@
 import type { PrimitiveProps } from '@/Primitive'
 
 export interface ComboboxLabelProps extends PrimitiveProps {
-  for?: string
+  for?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -86,9 +86,10 @@ import { createEventHook, useVModel } from '@vueuse/core'
 import { computed, getCurrentInstance, nextTick, onMounted, ref, toRefs } from 'vue'
 import { ListboxRoot } from '@/Listbox'
 import { PopperRoot } from '@/Popper'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<ComboboxRootProps<T>>(), {
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   resetSearchTermOnBlur: true,
   resetSearchTermOnSelect: true,
   openOnFocus: false,

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -46,37 +46,37 @@ export type ComboboxRootEmits<T = AcceptableValue> = {
 
 export interface ComboboxRootProps<T = AcceptableValue> extends Omit<ListboxRootProps<T>, 'orientation' | 'selectionBehavior'> {
   /** The controlled open state of the Combobox. Can be binded with `v-model:open`. */
-  open?: boolean
+  open?: boolean | undefined
   /** The open state of the combobox when it is initially rendered. <br> Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
   /**
    * Whether to reset the searchTerm when the Combobox input blurred
    * @defaultValue `true`
    */
-  resetSearchTermOnBlur?: boolean
+  resetSearchTermOnBlur?: boolean | undefined
   /**
    * Whether to reset the searchTerm when the Combobox value is selected
    * @defaultValue `true`
    */
-  resetSearchTermOnSelect?: boolean
+  resetSearchTermOnSelect?: boolean | undefined
   /**
    * Whether to open the combobox when the input is focused
    * @defaultValue `false`
    */
-  openOnFocus?: boolean
+  openOnFocus?: boolean | undefined
   /**
    * Whether to open the combobox when the input is clicked
    * @defaultValue `false`
    */
-  openOnClick?: boolean
+  openOnClick?: boolean | undefined
   /**
    * When `true`, disable the default filters
    */
-  ignoreFilter?: boolean
+  ignoreFilter?: boolean | undefined
   /**
    * When `true` the `modelValue` will be reset to `null` (or `[]` if `multiple`)
    */
-  resetModelValueOnClear?: boolean
+  resetModelValueOnClear?: boolean | undefined
 }
 </script>
 
@@ -99,12 +99,12 @@ const props = withDefaults(defineProps<ComboboxRootProps<T>>(), {
 const emits = defineEmits<ComboboxRootEmits<T>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
     /** Current active value */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { primitiveElement, currentElement: parentElement } = usePrimitiveElement<GenericComponentInstance<typeof ListboxRoot>>()

--- a/packages/core/src/Combobox/ComboboxTrigger.vue
+++ b/packages/core/src/Combobox/ComboboxTrigger.vue
@@ -3,7 +3,7 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface ComboboxTriggerProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with item */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Combobox/ComboboxViewport.vue
+++ b/packages/core/src/Combobox/ComboboxViewport.vue
@@ -9,7 +9,7 @@ export interface ComboboxViewportProps extends PrimitiveProps {
   /**
    * Will add `nonce` attribute to the style tag which can be used by Content Security Policy. <br> If omitted, inherits globally from `ConfigProvider`.
    */
-  nonce?: string
+  nonce?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Combobox/ComboboxVirtualizer.vue
+++ b/packages/core/src/Combobox/ComboboxVirtualizer.vue
@@ -12,11 +12,11 @@ import { injectComboboxRootContext } from './ComboboxRoot.vue'
 const props = defineProps<ComboboxVirtualizerProps<T>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     option: T
     virtualizer: Virtualizer<HTMLElement, Element>
     virtualItem: VirtualItem
-  }) => any
+  }) => any) | undefined
 }>()
 
 const rootContext = injectComboboxRootContext()

--- a/packages/core/src/ConfigProvider/ConfigProvider.vue
+++ b/packages/core/src/ConfigProvider/ConfigProvider.vue
@@ -4,12 +4,12 @@ import type { Direction, ScrollBodyOption } from '@/shared/types'
 import { createContext } from '@/shared'
 
 interface ConfigProviderContextValue {
-  dir?: Ref<Direction>
-  locale?: Ref<string>
-  scrollBody?: Ref<boolean | ScrollBodyOption>
-  nonce?: Ref<string | undefined>
-  teleportTo?: Ref<string | HTMLElement | undefined>
-  useId?: () => string
+  dir?: Ref<Direction> | undefined
+  locale?: Ref<string> | undefined
+  scrollBody?: Ref<boolean | ScrollBodyOption> | undefined
+  nonce?: Ref<string | undefined> | undefined
+  teleportTo?: Ref<string | HTMLElement | undefined> | undefined
+  useId?: (() => string) | undefined
 }
 
 export const [injectConfigProviderContext, provideConfigProviderContext]
@@ -20,33 +20,33 @@ export interface ConfigProviderProps {
    * The global reading direction of your application. This will be inherited by all primitives.
    * @defaultValue 'ltr'
    */
-  dir?: Direction
+  dir?: Direction | undefined
   /**
    * The global locale of your application. This will be inherited by all primitives.
    * @defaultValue 'en'
    */
-  locale?: string
+  locale?: string | undefined
   /**
    * The global scroll body behavior of your application. This will be inherited by the related primitives.
    * @type boolean | ScrollBodyOption
    */
-  scrollBody?: boolean | ScrollBodyOption
+  scrollBody?: boolean | ScrollBodyOption | undefined
   /**
    * The global `nonce` value of your application. This will be inherited by the related primitives.
    * @type string
    */
-  nonce?: string
+  nonce?: string | undefined
   /**
    * The global default teleport target for all portalled primitives (e.g. `Dialog`, `Popover`, `Tooltip`).
    * Individual `*Portal` components can still override this via their own `to` prop.
    * Useful when rendering inside a custom element / shadow DOM.
    * @type string | HTMLElement
    */
-  teleportTo?: string | HTMLElement
+  teleportTo?: string | HTMLElement | undefined
   /**
    * The global `useId` injection as a workaround for preventing hydration issue.
    */
-  useId?: () => string
+  useId?: (() => string) | undefined
 }
 </script>
 

--- a/packages/core/src/ConfigProvider/ConfigProvider.vue
+++ b/packages/core/src/ConfigProvider/ConfigProvider.vue
@@ -61,9 +61,6 @@ const props = withDefaults(defineProps<ConfigProviderProps>(), {
   dir: 'ltr',
   locale: 'en',
   scrollBody: true,
-  nonce: undefined,
-  teleportTo: undefined,
-  useId: undefined,
 })
 
 const { dir, locale, scrollBody, nonce, teleportTo } = toRefs(props)

--- a/packages/core/src/ConfigProvider/_ConfigProvider.vue
+++ b/packages/core/src/ConfigProvider/_ConfigProvider.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { ConfigProviderProps } from './ConfigProvider.vue'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import DropdownMenu from '../DropdownMenu/story/_DropdownMenu.vue'
 import ConfigProvider from './ConfigProvider.vue'
 
-const props = withDefaults(defineProps<ConfigProviderProps>(), { scrollBody: undefined })
+const props = withDefaults(defineProps<ConfigProviderProps>(), { scrollBody: UNDEFINED_DEFAULT })
 </script>
 
 <template>

--- a/packages/core/src/ContextMenu/ContextMenuRoot.vue
+++ b/packages/core/src/ContextMenu/ContextMenuRoot.vue
@@ -19,7 +19,7 @@ export interface ContextMenuRootProps extends Omit<MenuProps, 'open'> {
    *
    * @defaultValue 700
    */
-  pressOpenDelay?: number
+  pressOpenDelay?: number | undefined
 }
 export type ContextMenuRootEmits = MenuEmits
 

--- a/packages/core/src/ContextMenu/ContextMenuSub.vue
+++ b/packages/core/src/ContextMenu/ContextMenuSub.vue
@@ -13,9 +13,10 @@ export interface ContextMenuSubProps extends MenuSubProps {
 import { useVModel } from '@vueuse/core'
 import { MenuSub } from '@/Menu'
 import { useForwardExpose } from '@/shared'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<ContextMenuSubProps>(), {
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
 })
 const emit = defineEmits<ContextMenuSubEmits>()
 

--- a/packages/core/src/ContextMenu/ContextMenuSub.vue
+++ b/packages/core/src/ContextMenu/ContextMenuSub.vue
@@ -5,7 +5,7 @@ import type { MenuSubEmits, MenuSubProps } from '@/Menu'
 export type ContextMenuSubEmits = MenuSubEmits
 export interface ContextMenuSubProps extends MenuSubProps {
   /** The open state of the submenu when it is initially rendered. Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
 }
 </script>
 
@@ -20,10 +20,10 @@ const props = withDefaults(defineProps<ContextMenuSubProps>(), {
 const emit = defineEmits<ContextMenuSubEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 useForwardExpose()

--- a/packages/core/src/ContextMenu/ContextMenuTrigger.vue
+++ b/packages/core/src/ContextMenu/ContextMenuTrigger.vue
@@ -8,7 +8,7 @@ export interface ContextMenuTriggerProps extends PrimitiveProps {
    *
    * Note that this will also restore the native context menu.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/DateField/DateFieldRoot.vue
+++ b/packages/core/src/DateField/DateFieldRoot.vue
@@ -99,11 +99,8 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<DateFieldRootProps>(), {
-  defaultValue: undefined,
   disabled: false,
   readonly: false,
-  placeholder: undefined,
-  isDateUnavailable: undefined,
   stepSnapping: false,
 })
 const emits = defineEmits<DateFieldRootEmits>()

--- a/packages/core/src/DateField/DateFieldRoot.vue
+++ b/packages/core/src/DateField/DateFieldRoot.vue
@@ -25,7 +25,7 @@ type DateFieldRootContext = {
   locale: Ref<string>
   modelValue: Ref<DateValue | undefined>
   placeholder: Ref<DateValue>
-  isDateUnavailable?: Matcher
+  isDateUnavailable?: Matcher | undefined
   isInvalid: Ref<boolean>
   disabled: Ref<boolean>
   readonly: Ref<boolean>
@@ -42,39 +42,39 @@ type DateFieldRootContext = {
 
 export interface DateFieldRootProps extends PrimitiveProps, FormFieldProps {
   /** The default value for the calendar */
-  defaultValue?: DateValue
+  defaultValue?: DateValue | undefined
   /** The default placeholder date */
-  defaultPlaceholder?: DateValue
+  defaultPlaceholder?: DateValue | undefined
   /** The placeholder date, which is used to determine what month to display when no date is selected. This updates as the user navigates the calendar and can be used to programmatically control the calendar view */
-  placeholder?: DateValue
+  placeholder?: DateValue | undefined
   /** The controlled value of the field. Can be bound as `v-model`. */
-  modelValue?: DateValue | null
+  modelValue?: DateValue | null | undefined
   /** The hour cycle used for formatting times. Defaults to the local preference */
-  hourCycle?: HourCycle
+  hourCycle?: HourCycle | undefined
   /** The stepping interval for the time fields. Defaults to `1`. */
-  step?: DateStep
+  step?: DateStep | undefined
   /** Whether to enforce snapping the time value to the nearest step increment after input. Defaults to `false`. */
-  stepSnapping?: boolean
+  stepSnapping?: boolean | undefined
   /** The granularity to use for formatting times. Defaults to day if a CalendarDate is provided, otherwise defaults to minute. The field will render segments for each part of the date up to and including the specified granularity */
-  granularity?: Granularity
+  granularity?: Granularity | undefined
   /** Whether or not to hide the time zone segment of the field */
-  hideTimeZone?: boolean
+  hideTimeZone?: boolean | undefined
   /** The maximum date that can be selected */
-  maxValue?: DateValue
+  maxValue?: DateValue | undefined
   /** The minimum date that can be selected */
-  minValue?: DateValue
+  minValue?: DateValue | undefined
   /** The locale to use for formatting dates */
-  locale?: string
+  locale?: string | undefined
   /** Whether or not the date field is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether or not the date field is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** A function that returns whether or not a date is unavailable */
-  isDateUnavailable?: Matcher
+  isDateUnavailable?: Matcher | undefined
   /** Id of the element */
-  id?: string
+  id?: string | undefined
   /** The reading direction of the date field when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
 }
 
 export type DateFieldRootEmits = {
@@ -108,14 +108,14 @@ const props = withDefaults(defineProps<DateFieldRootProps>(), {
 })
 const emits = defineEmits<DateFieldRootEmits>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current date of the field */
     modelValue: DateValue | undefined
     /** The date field segment contents */
     segments: { part: SegmentPart, value: string }[]
     /** Value if the input is invalid */
     isInvalid: boolean
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { disabled, readonly, isDateUnavailable: propsIsDateUnavailable, granularity, defaultValue, stepSnapping, dir: propDir, locale: propLocale } = toRefs(props)

--- a/packages/core/src/DatePicker/DatePickerContent.vue
+++ b/packages/core/src/DatePicker/DatePickerContent.vue
@@ -8,7 +8,7 @@ export interface DatePickerContentProps extends PopoverContentProps {
   /**
    * Props to control the portal wrapped around the content.
    */
-  portal?: PopoverPortalProps
+  portal?: PopoverPortalProps | undefined
 }
 export interface DatePickerContentEmits extends PopoverContentEmits {}
 </script>

--- a/packages/core/src/DatePicker/DatePickerHeading.vue
+++ b/packages/core/src/DatePicker/DatePickerHeading.vue
@@ -8,10 +8,10 @@ export interface DatePickerHeadingProps extends CalendarHeadingProps {}
 <script setup lang="ts">
 const props = defineProps<DatePickerHeadingProps>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current month and year */
     headingValue: string
-  }) => any
+  }) => any) | undefined
 }>()
 </script>
 

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -33,8 +33,8 @@ type DatePickerRootContext = {
   numberOfMonths: Ref<number>
   disabled: Ref<boolean>
   readonly: Ref<boolean>
-  isDateDisabled?: Matcher
-  isDateUnavailable?: Matcher
+  isDateDisabled?: Matcher | undefined
+  isDateUnavailable?: Matcher | undefined
   defaultOpen: Ref<boolean>
   open: Ref<boolean>
   modal: Ref<boolean>
@@ -47,7 +47,7 @@ type DatePickerRootContext = {
 
 export type DatePickerRootProps = Omit<DateFieldRootProps, 'as' | 'asChild'> & PopoverRootProps & Pick<CalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect'> & {
   /** Whether or not to close the popover on date select */
-  closeOnSelect?: boolean
+  closeOnSelect?: boolean | undefined
 }
 
 export type DatePickerRootEmits = PopoverRootEmits & {

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -63,14 +63,14 @@ export const [injectDatePickerRootContext, provideDatePickerRootContext]
 
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 defineOptions({
   inheritAttrs: false,
 })
 const props = withDefaults(defineProps<DatePickerRootProps>(), {
-  defaultValue: undefined,
   defaultOpen: false,
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   modal: false,
   pagedNavigation: false,
   preventDeselect: false,
@@ -79,9 +79,6 @@ const props = withDefaults(defineProps<DatePickerRootProps>(), {
   numberOfMonths: 1,
   disabled: false,
   readonly: false,
-  placeholder: undefined,
-  isDateDisabled: undefined,
-  isDateUnavailable: undefined,
   closeOnSelect: false,
 })
 const emits = defineEmits<DatePickerRootEmits>()

--- a/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
+++ b/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
@@ -33,7 +33,7 @@ type DateRangeFieldRootContext = {
   startValue: Ref<DateValue | undefined>
   endValue: Ref<DateValue | undefined>
   placeholder: Ref<DateValue>
-  isDateUnavailable?: Matcher
+  isDateUnavailable?: Matcher | undefined
   isInvalid: Ref<boolean>
   disabled: Ref<boolean>
   readonly: Ref<boolean>
@@ -49,37 +49,37 @@ type DateRangeFieldRootContext = {
 
 export interface DateRangeFieldRootProps extends PrimitiveProps, FormFieldProps {
   /** The default value for the calendar */
-  defaultValue?: DateRange
+  defaultValue?: DateRange | undefined
   /** The default placeholder date */
-  defaultPlaceholder?: DateValue
+  defaultPlaceholder?: DateValue | undefined
   /** The placeholder date, which is used to determine what month to display when no date is selected. This updates as the user navigates the calendar and can be used to programmatically control the calendar view */
-  placeholder?: DateValue
+  placeholder?: DateValue | undefined
   /** The controlled value of the field. Can be bound as `v-model`. */
-  modelValue?: DateRange | null
+  modelValue?: DateRange | null | undefined
   /** The hour cycle used for formatting times. Defaults to the local preference */
-  hourCycle?: HourCycle
+  hourCycle?: HourCycle | undefined
   /** The stepping interval for the time fields. Defaults to `1`. */
-  step?: DateStep
+  step?: DateStep | undefined
   /** The granularity to use for formatting times. Defaults to day if a CalendarDate is provided, otherwise defaults to minute. The field will render segments for each part of the date up to and including the specified granularity */
-  granularity?: Granularity
+  granularity?: Granularity | undefined
   /** Whether or not to hide the time zone segment of the field */
-  hideTimeZone?: boolean
+  hideTimeZone?: boolean | undefined
   /** The maximum date that can be selected */
-  maxValue?: DateValue
+  maxValue?: DateValue | undefined
   /** The minimum date that can be selected */
-  minValue?: DateValue
+  minValue?: DateValue | undefined
   /** The locale to use for formatting dates */
-  locale?: string
+  locale?: string | undefined
   /** Whether or not the date field is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether or not the date field is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** A function that returns whether or not a date is unavailable */
-  isDateUnavailable?: Matcher
+  isDateUnavailable?: Matcher | undefined
   /** Id of the element */
-  id?: string
+  id?: string | undefined
   /** The reading direction of the date field when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
 }
 
 export type DateRangeFieldRootEmits = {
@@ -112,14 +112,14 @@ const props = withDefaults(defineProps<DateRangeFieldRootProps>(), {
 })
 const emits = defineEmits<DateRangeFieldRootEmits>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current date range of the field */
     modelValue: DateRange | null
     /** The date field segment contents */
     segments: { start: { part: SegmentPart, value: string }[], end: { part: SegmentPart, value: string }[] }
     /** Value if the input is invalid */
     isInvalid: boolean
-  }) => any
+  }) => any) | undefined
 }>()
 const { disabled, readonly, isDateUnavailable: propsIsDateUnavailable, dir: propDir, locale: propLocale } = toRefs(props)
 const locale = useLocale(propLocale)

--- a/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
+++ b/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
@@ -104,11 +104,8 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<DateRangeFieldRootProps>(), {
-  defaultValue: undefined,
   disabled: false,
   readonly: false,
-  placeholder: undefined,
-  isDateUnavailable: undefined,
 })
 const emits = defineEmits<DateRangeFieldRootEmits>()
 defineSlots<{

--- a/packages/core/src/DateRangePicker/DateRangePickerContent.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerContent.vue
@@ -8,7 +8,7 @@ export interface DateRangePickerContentProps extends PopoverContentProps {
   /**
    * Props to control the portal wrapped around the content.
    */
-  portal?: PopoverPortalProps
+  portal?: PopoverPortalProps | undefined
 }
 export interface DateRangePickerContentEmits extends PopoverContentEmits {}
 </script>

--- a/packages/core/src/DateRangePicker/DateRangePickerHeading.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerHeading.vue
@@ -8,10 +8,10 @@ export interface DateRangePickerHeadingProps extends RangeCalendarHeadingProps {
 <script setup lang="ts">
 const props = defineProps<DateRangePickerHeadingProps>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current month and year */
     headingValue: string
-  }) => any
+  }) => any) | undefined
 }>()
 </script>
 

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -33,9 +33,9 @@ type DateRangePickerRootContext = {
   numberOfMonths: Ref<number>
   disabled: Ref<boolean>
   readonly: Ref<boolean>
-  isDateDisabled?: Matcher
-  isDateUnavailable?: Matcher
-  isDateHighlightable?: Matcher
+  isDateDisabled?: Matcher | undefined
+  isDateUnavailable?: Matcher | undefined
+  isDateHighlightable?: Matcher | undefined
   defaultOpen: Ref<boolean>
   open: Ref<boolean>
   modal: Ref<boolean>
@@ -45,14 +45,14 @@ type DateRangePickerRootContext = {
   dir: Ref<Direction>
   allowNonContiguousRanges: Ref<boolean>
   fixedDate: Ref<'start' | 'end' | undefined>
-  maximumDays?: Ref<number | undefined>
+  maximumDays?: Ref<number | undefined> | undefined
   step: Ref<DateStep | undefined>
-  closeOnSelect?: Ref<boolean>
+  closeOnSelect?: Ref<boolean> | undefined
 }
 
 export type DateRangePickerRootProps = Omit<DateRangeFieldRootProps, 'as' | 'asChild'> & PopoverRootProps & Pick<RangeCalendarRootProps, 'isDateDisabled' | 'pagedNavigation' | 'weekStartsOn' | 'weekdayFormat' | 'fixedWeeks' | 'numberOfMonths' | 'preventDeselect' | 'isDateUnavailable' | 'isDateHighlightable' | 'allowNonContiguousRanges' | 'fixedDate' | 'maximumDays'> & {
   /** Whether or not to close the popover on range select */
-  closeOnSelect?: boolean
+  closeOnSelect?: boolean | undefined
 }
 
 export type DateRangePickerRootEmits = PopoverRootEmits & {

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -71,6 +71,7 @@ export const [injectDateRangePickerRootContext, provideDateRangePickerRootContex
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
 import { computed, ref, toRefs, watch } from 'vue'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 defineOptions({
   inheritAttrs: false,
@@ -78,7 +79,7 @@ defineOptions({
 const props = withDefaults(defineProps<DateRangePickerRootProps>(), {
   defaultValue: () => ({ start: undefined, end: undefined }),
   defaultOpen: false,
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   modal: false,
   pagedNavigation: false,
   preventDeselect: false,
@@ -87,12 +88,7 @@ const props = withDefaults(defineProps<DateRangePickerRootProps>(), {
   numberOfMonths: 1,
   disabled: false,
   readonly: false,
-  placeholder: undefined,
-  isDateDisabled: undefined,
-  isDateUnavailable: undefined,
-  isDateHighlightable: undefined,
   allowNonContiguousRanges: false,
-  maximumDays: undefined,
   closeOnSelect: false,
 })
 const emits = defineEmits<DateRangePickerRootEmits>()

--- a/packages/core/src/Dialog/DialogContent.vue
+++ b/packages/core/src/Dialog/DialogContent.vue
@@ -11,7 +11,7 @@ export interface DialogContentProps extends Omit<DialogContentImplProps, 'trapFo
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Dialog/DialogContent.vue
+++ b/packages/core/src/Dialog/DialogContent.vue
@@ -18,6 +18,7 @@ export interface DialogContentProps extends Omit<DialogContentImplProps, 'trapFo
 <script setup lang="ts">
 import { Presence } from '@/Presence'
 import { useEmitAsProps, useForwardExpose } from '@/shared'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import DialogContentModal from './DialogContentModal.vue'
 import DialogContentNonModal from './DialogContentNonModal.vue'
 import { injectDialogRootContext } from './DialogRoot.vue'
@@ -27,7 +28,7 @@ const props = withDefaults(defineProps<DialogContentProps>(), {
   // modal/non-modal child can apply its own default. This lets a modal
   // `DialogContent` stay locked by default while still honoring an explicit
   // `:disable-outside-pointer-events="false"` (#2677).
-  disableOutsidePointerEvents: undefined,
+  disableOutsidePointerEvents: UNDEFINED_DEFAULT,
 })
 const emits = defineEmits<DialogContentEmits>()
 

--- a/packages/core/src/Dialog/DialogContentImpl.vue
+++ b/packages/core/src/Dialog/DialogContentImpl.vue
@@ -23,13 +23,13 @@ export interface DialogContentImplProps extends DismissableLayerProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling transition with Vue native transition or other animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
   /**
    * When `true`, focus cannot escape the `Content` via keyboard,
    * pointer, or a programmatic focus.
    * @defaultValue false
    */
-  trapFocus?: boolean
+  trapFocus?: boolean | undefined
 }
 </script>
 
@@ -45,7 +45,7 @@ const props = defineProps<DialogContentImplProps & {
   /** Whether the content is currently visible. Forwarded to `FocusScope` and
    * `DismissableLayer` so a force-mounted dialog (`unmountOnHide: false`)
    * auto-focuses on show and leaves the layer/scope stacks while hidden. */
-  present?: boolean
+  present?: boolean | undefined
 }>()
 const emits = defineEmits<DialogContentImplEmits>()
 

--- a/packages/core/src/Dialog/DialogOverlay.vue
+++ b/packages/core/src/Dialog/DialogOverlay.vue
@@ -8,7 +8,7 @@ export interface DialogOverlayProps extends DialogOverlayImplProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Dialog/DialogOverlayImpl.vue
+++ b/packages/core/src/Dialog/DialogOverlayImpl.vue
@@ -11,7 +11,7 @@ import { useForwardExpose } from '@/shared'
 import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 import { injectDialogRootContext } from './DialogRoot.vue'
 
-const props = withDefaults(defineProps<DialogOverlayImplProps & { present?: boolean }>(), {
+const props = withDefaults(defineProps<DialogOverlayImplProps & { present?: boolean | undefined }>(), {
   present: true,
 })
 const rootContext = injectDialogRootContext()

--- a/packages/core/src/Dialog/DialogRoot.vue
+++ b/packages/core/src/Dialog/DialogRoot.vue
@@ -46,13 +46,14 @@ export const [injectDialogRootContext, provideDialogRootContext]
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
 import { ref, toRefs } from 'vue'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 defineOptions({
   inheritAttrs: false,
 })
 
 const props = withDefaults(defineProps<DialogRootProps>(), {
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   defaultOpen: false,
   modal: true,
   unmountOnHide: true,

--- a/packages/core/src/Dialog/DialogRoot.vue
+++ b/packages/core/src/Dialog/DialogRoot.vue
@@ -4,20 +4,20 @@ import { createContext } from '@/shared'
 
 export interface DialogRootProps {
   /** The controlled open state of the dialog. Can be binded as `v-model:open`. */
-  open?: boolean
+  open?: boolean | undefined
   /** The open state of the dialog when it is initially rendered. Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
   /**
    * The modality of the dialog When set to `true`, <br>
    * interaction with outside elements will be disabled and only dialog content will be visible to screen readers.
    */
-  modal?: boolean
+  modal?: boolean | undefined
   /**
    * When set to `false`, the dialog content will not be unmounted when closed, but instead hidden with CSS. <br>
    * Useful for SEO or when you want to improve performance by not remounting the component on every open.
    * @defaultValue true
    */
-  unmountOnHide?: boolean
+  unmountOnHide?: boolean | undefined
 }
 
 export type DialogRootEmits = {
@@ -60,12 +60,12 @@ const props = withDefaults(defineProps<DialogRootProps>(), {
 const emit = defineEmits<DialogRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
     /** Close the dialog */
     close: () => void
-  }) => any
+  }) => any) | undefined
 }>()
 
 const open = useVModel(props, 'open', emit, {

--- a/packages/core/src/Dialog/utils.ts
+++ b/packages/core/src/Dialog/utils.ts
@@ -5,9 +5,9 @@ const DEFAULT_TITLE_NAME = 'DialogTitle'
 const DEFAULT_CONTENT_NAME = 'DialogContent'
 
 export type WarningProps = {
-  titleName?: string
-  contentName?: string
-  componentLink?: string
+  titleName?: string | undefined
+  contentName?: string | undefined
+  componentLink?: string | undefined
   titleId: string
   descriptionId: string
   contentElement: Ref<HTMLElement | undefined>

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -20,7 +20,7 @@ export interface DismissableLayerProps extends PrimitiveProps {
    * the `DismissableLayer`. Users will need to click twice on outside elements to
    * interact with them: once to close the `DismissableLayer`, and again to trigger the element.
    */
-  disableOutsidePointerEvents?: boolean
+  disableOutsidePointerEvents?: boolean | undefined
 }
 
 export type DismissableLayerEmits = {
@@ -76,7 +76,7 @@ const props = withDefaults(defineProps<DismissableLayerProps & {
    * Kept out of the public `DismissableLayerProps` on purpose — it is
    * internal plumbing between primitives.
    */
-  present?: boolean
+  present?: boolean | undefined
 }>(), {
   disableOutsidePointerEvents: false,
   present: true,

--- a/packages/core/src/Drawer/DrawerContent.vue
+++ b/packages/core/src/Drawer/DrawerContent.vue
@@ -3,7 +3,7 @@ import type { DrawerContentImplEmits, DrawerContentImplProps } from './DrawerCon
 
 export type DrawerContentEmits = DrawerContentImplEmits
 export interface DrawerContentProps extends Omit<DrawerContentImplProps, 'trapFocus'> {
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Drawer/DrawerContentImpl.vue
+++ b/packages/core/src/Drawer/DrawerContentImpl.vue
@@ -10,21 +10,21 @@ export type DrawerContentImplEmits = DismissableLayerEmits & {
 }
 
 export interface DrawerContentImplProps extends DismissableLayerProps {
-  trapFocus?: boolean
+  trapFocus?: boolean | undefined
   /**
    * Initial focus target when the drawer opens.
    * - `true` / default: focus the first focusable element inside
    * - `false`: do not focus anything
    * - element ref: focus that specific element
    */
-  initialFocus?: boolean | HTMLElement | null
+  initialFocus?: boolean | HTMLElement | null | undefined
   /**
    * Final focus target when the drawer closes.
    * - `true` / default: focus the trigger
    * - `false`: do not restore focus
    * - element ref: focus that specific element
    */
-  finalFocus?: boolean | HTMLElement | null
+  finalFocus?: boolean | HTMLElement | null | undefined
 }
 </script>
 

--- a/packages/core/src/Drawer/DrawerOverlay.vue
+++ b/packages/core/src/Drawer/DrawerOverlay.vue
@@ -3,9 +3,9 @@ import type { DrawerOverlayImplProps } from './DrawerOverlayImpl.vue'
 
 export interface DrawerOverlayProps extends DrawerOverlayImplProps {
   /** Keep mounted for animation control. */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
   /** Render even when inside a nested drawer. @default false */
-  forceRender?: boolean
+  forceRender?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Drawer/DrawerRoot.vue
+++ b/packages/core/src/Drawer/DrawerRoot.vue
@@ -95,17 +95,15 @@ export const [injectDrawerRootContext, provideDrawerRootContext]
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
 import { computed, onUnmounted, ref, toRefs, watch } from 'vue'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import { injectDrawerProviderContext } from './DrawerProvider.vue'
 import { createNestedSwipeProgressStore } from './utils'
 
 const props = withDefaults(defineProps<DrawerRootProps>(), {
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   defaultOpen: false,
   modal: true,
   swipeDirection: 'down',
-  snapPoints: undefined,
-  snapPoint: undefined,
-  defaultSnapPoint: undefined,
   snapToSequentialPoints: false,
 })
 const emit = defineEmits<DrawerRootEmits>()

--- a/packages/core/src/Drawer/DrawerRoot.vue
+++ b/packages/core/src/Drawer/DrawerRoot.vue
@@ -19,33 +19,33 @@ export type DrawerOpenChangeReason
     | 'close-press'
 
 export interface DrawerOpenChangeDetails {
-  reason?: DrawerOpenChangeReason
+  reason?: DrawerOpenChangeReason | undefined
 }
 
 export interface DrawerRootProps {
   /** v-model:open */
-  open?: boolean
-  defaultOpen?: boolean
+  open?: boolean | undefined
+  defaultOpen?: boolean | undefined
   /**
    * Modality of the drawer.
    * - `true` (default): modal with focus trap, scroll lock, and outside-press dismiss
    * - `'trap-focus'`: traps focus but allows outside pointer events (non-modal side panels)
    * - `false`: non-modal
    */
-  modal?: DrawerModal
+  modal?: DrawerModal | undefined
   /** Direction to swipe to dismiss. @default 'down' */
-  swipeDirection?: SwipeDirection
+  swipeDirection?: SwipeDirection | undefined
   /** Preset snap positions (fractions 0-1, pixels >1, or '148px'/'30rem' strings) */
-  snapPoints?: DrawerSnapPoint[]
+  snapPoints?: DrawerSnapPoint[] | undefined
   /** v-model:snapPoint */
-  snapPoint?: DrawerSnapPoint | null
-  defaultSnapPoint?: DrawerSnapPoint | null
+  snapPoint?: DrawerSnapPoint | null | undefined
+  defaultSnapPoint?: DrawerSnapPoint | null | undefined
   /**
    * When true, snaps to the next sequential snap point (one step at a time).
    * When false, snaps to the nearest snap point by distance.
    * @default false
    */
-  snapToSequentialPoints?: boolean
+  snapToSequentialPoints?: boolean | undefined
 }
 
 export type DrawerRootEmits = {
@@ -77,10 +77,10 @@ export interface DrawerRootContext {
   onNestedSwipingChange: (swiping: boolean) => void
   onNestedSwipeProgressChange: (progress: number) => void
   onSwipingChange: (swiping: boolean) => void
-  notifyParentFrontmostHeight?: (height: number) => void
-  notifyParentSwipingChange?: (swiping: boolean) => void
-  notifyParentSwipeProgressChange?: (progress: number) => void
-  notifyParentHasNestedDrawer?: (present: boolean) => void
+  notifyParentFrontmostHeight?: ((height: number) => void) | undefined
+  notifyParentSwipingChange?: ((swiping: boolean) => void) | undefined
+  notifyParentSwipeProgressChange?: ((progress: number) => void) | undefined
+  notifyParentHasNestedDrawer?: ((present: boolean) => void) | undefined
   triggerElement: Ref<HTMLElement | undefined>
   contentElement: Ref<HTMLElement | undefined>
   contentId: string
@@ -111,7 +111,7 @@ const props = withDefaults(defineProps<DrawerRootProps>(), {
 const emit = defineEmits<DrawerRootEmits>()
 
 defineSlots<{
-  default?: (props: { open: boolean, close: () => void }) => any
+  default?: ((props: { open: boolean, close: () => void }) => any) | undefined
 }>()
 
 // Manual open state management — we need to pass optional details on emit

--- a/packages/core/src/Drawer/DrawerSwipeArea.vue
+++ b/packages/core/src/Drawer/DrawerSwipeArea.vue
@@ -4,9 +4,9 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface DrawerSwipeAreaProps extends PrimitiveProps {
   /** Override the open swipe direction (defaults to opposite of Root's swipeDirection). */
-  swipeDirection?: SwipeDirection
+  swipeDirection?: SwipeDirection | undefined
   /** Disable swipe-to-open. */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Drawer/composables/useSwipeDismiss.ts
+++ b/packages/core/src/Drawer/composables/useSwipeDismiss.ts
@@ -15,21 +15,21 @@ export interface UseSwipeDismissOptions {
   elementRef: Ref<HTMLElement | null | undefined>
   directions: MaybeRef<SwipeDirection[]>
   movementCssVars: { x: string, y: string }
-  swipeThreshold?: number | ((opts: { element: HTMLElement, direction: SwipeDirection }) => number)
-  ignoreScrollableAncestors?: boolean
-  canStart?: () => boolean
-  onDismiss?: () => void
-  onProgress?: (progress: number, details?: SwipeProgressDetails) => void
-  onCancel?: () => void
-  onSwipeStart?: () => void
+  swipeThreshold?: number | ((opts: { element: HTMLElement, direction: SwipeDirection }) => number) | undefined
+  ignoreScrollableAncestors?: boolean | undefined
+  canStart?: (() => boolean) | undefined
+  onDismiss?: (() => void) | undefined
+  onProgress?: ((progress: number, details?: SwipeProgressDetails) => void) | undefined
+  onCancel?: (() => void) | undefined
+  onSwipeStart?: (() => void) | undefined
   /**
    * Fired on release with the measured velocity vector. Return `true` to signal
    * that the callback fully owns the open/close + transform outcome (e.g. the
    * snap-point release math), so `finishSwipe` skips its own dismiss-vs-cancel
    * decision (no `data-swipe-dismissed`, no `onDismiss`/`onCancel`).
    */
-  onRelease?: (velocity: { x: number, y: number }) => boolean | void
-  onSwipingChange?: (swiping: boolean) => void
+  onRelease?: ((velocity: { x: number, y: number }) => boolean | void) | undefined
+  onSwipingChange?: ((swiping: boolean) => void) | undefined
 }
 
 const DEFAULT_SWIPE_THRESHOLD = 40

--- a/packages/core/src/DropdownMenu/DropdownMenuFilter.vue
+++ b/packages/core/src/DropdownMenu/DropdownMenuFilter.vue
@@ -10,11 +10,11 @@ import { useComposing } from '@/shared'
 
 export interface DropdownMenuFilterProps extends PrimitiveProps {
   /** The controlled value of the filter. Can be binded with v-model. */
-  modelValue?: string
+  modelValue?: string | undefined
   /** Focus on element when mounted. */
-  autoFocus?: boolean
+  autoFocus?: boolean | undefined
   /** When `true`, prevents the user from interacting with item */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export type DropdownMenuFilterEmits = {
@@ -29,10 +29,10 @@ const props = withDefaults(defineProps<DropdownMenuFilterProps>(), {
 const emits = defineEmits<DropdownMenuFilterEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const modelValue = useVModel(props, 'modelValue', emits, {

--- a/packages/core/src/DropdownMenu/DropdownMenuRoot.vue
+++ b/packages/core/src/DropdownMenu/DropdownMenuRoot.vue
@@ -6,7 +6,7 @@ import { createContext, useDirection, useForwardExpose } from '@/shared'
 
 export interface DropdownMenuRootProps extends MenuProps {
   /** The open state of the dropdown menu when it is initially rendered. Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
 }
 export type DropdownMenuRootEmits = MenuEmits
 
@@ -37,10 +37,10 @@ const props = withDefaults(defineProps<DropdownMenuRootProps>(), {
 const emit = defineEmits<DropdownMenuRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 useForwardExpose()

--- a/packages/core/src/DropdownMenu/DropdownMenuRoot.vue
+++ b/packages/core/src/DropdownMenu/DropdownMenuRoot.vue
@@ -29,10 +29,11 @@ export const [injectDropdownMenuRootContext, provideDropdownMenuRootContext]
 import { useVModel } from '@vueuse/core'
 import { ref, toRefs } from 'vue'
 import { MenuRoot } from '@/Menu'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<DropdownMenuRootProps>(), {
   modal: true,
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
 })
 const emit = defineEmits<DropdownMenuRootEmits>()
 

--- a/packages/core/src/DropdownMenu/DropdownMenuSub.vue
+++ b/packages/core/src/DropdownMenu/DropdownMenuSub.vue
@@ -13,9 +13,10 @@ export interface DropdownMenuSubProps extends MenuSubProps {
 import { useVModel } from '@vueuse/core'
 import { MenuSub } from '@/Menu'
 import { useForwardExpose } from '@/shared'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<DropdownMenuSubProps>(), {
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
 })
 const emit = defineEmits<DropdownMenuSubEmits>()
 

--- a/packages/core/src/DropdownMenu/DropdownMenuSub.vue
+++ b/packages/core/src/DropdownMenu/DropdownMenuSub.vue
@@ -5,7 +5,7 @@ import type { MenuSubEmits, MenuSubProps } from '@/Menu'
 export type DropdownMenuSubEmits = MenuSubEmits
 export interface DropdownMenuSubProps extends MenuSubProps {
   /** The open state of the dropdown menu when it is initially rendered. Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
 }
 </script>
 
@@ -20,10 +20,10 @@ const props = withDefaults(defineProps<DropdownMenuSubProps>(), {
 const emit = defineEmits<DropdownMenuSubEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const open = useVModel(props, 'open', emit, {

--- a/packages/core/src/DropdownMenu/DropdownMenuTrigger.vue
+++ b/packages/core/src/DropdownMenu/DropdownMenuTrigger.vue
@@ -4,7 +4,7 @@ import { useForwardExpose, useId } from '@/shared'
 
 export interface DropdownMenuTriggerProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with item */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Editable/EditableRoot.vue
+++ b/packages/core/src/Editable/EditableRoot.vue
@@ -31,31 +31,31 @@ type EditableRootContext = {
 
 export interface EditableRootProps extends PrimitiveProps, FormFieldProps {
   /** The default value of the editable field */
-  defaultValue?: string
+  defaultValue?: string | undefined
   /** The value of the editable field */
-  modelValue?: string | null
+  modelValue?: string | null | undefined
   /** The placeholder for the editable field */
-  placeholder?: string | { edit: string, preview: string }
+  placeholder?: string | { edit: string, preview: string } | undefined
   /** The reading direction of the calendar when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** Whether the editable field is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether the editable field is read-only */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** The activation event of the editable field */
-  activationMode?: ActivationMode
+  activationMode?: ActivationMode | undefined
   /** Whether to select the text in the input when it is focused. */
-  selectOnFocus?: boolean
+  selectOnFocus?: boolean | undefined
   /** The submit event of the editable field */
-  submitMode?: SubmitMode
+  submitMode?: SubmitMode | undefined
   /** Whether to start with the edit mode active */
-  startWithEditMode?: boolean
+  startWithEditMode?: boolean | undefined
   /** The maximum number of characters allowed */
-  maxLength?: number
+  maxLength?: number | undefined
   /** Whether the editable field should auto resize */
-  autoResize?: boolean
+  autoResize?: boolean | undefined
   /** The id of the field */
-  id?: string
+  id?: string | undefined
 }
 
 export type EditableRootEmits = {
@@ -95,7 +95,7 @@ const props = withDefaults(defineProps<EditableRootProps>(), {
 
 const emits = defineEmits<EditableRootEmits>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Whether the editable field is in edit mode */
     isEditing: boolean
     /** The value of the editable field */
@@ -108,7 +108,7 @@ defineSlots<{
     cancel: () => void
     /** Function to set the editable in edit mode */
     edit: () => void
-  }) => any
+  }) => any) | undefined
 }>()
 
 const {

--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -22,14 +22,14 @@ export interface FocusScopeProps extends PrimitiveProps {
    * and shift+tab from first item will focus last tababble.
    * @defaultValue false
    */
-  loop?: boolean
+  loop?: boolean | undefined
 
   /**
    * When `true`, focus cannot escape the focus scope via keyboard,
    * pointer, or a programmatic focus.
    * @defaultValue false
    */
-  trapped?: boolean
+  trapped?: boolean | undefined
 
   /**
    * Whether the scope is currently visible. Lets a consumer keep the scope
@@ -39,7 +39,7 @@ export interface FocusScopeProps extends PrimitiveProps {
    * only while visible are unaffected.
    * @defaultValue true
    */
-  present?: boolean
+  present?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/FocusScope/utils.ts
+++ b/packages/core/src/FocusScope/utils.ts
@@ -72,7 +72,7 @@ export function findVisible(elements: HTMLElement[], container: HTMLElement) {
   }
 }
 
-export function isHidden(node: HTMLElement, { upTo }: { upTo?: HTMLElement }) {
+export function isHidden(node: HTMLElement, { upTo }: { upTo?: HTMLElement | undefined }) {
   if (getComputedStyle(node).visibility === 'hidden')
     return true
   while (node) {

--- a/packages/core/src/HoverCard/HoverCardContent.vue
+++ b/packages/core/src/HoverCard/HoverCardContent.vue
@@ -8,7 +8,7 @@ export interface HoverCardContentProps extends HoverCardContentImplProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/HoverCard/HoverCardRoot.vue
+++ b/packages/core/src/HoverCard/HoverCardRoot.vue
@@ -40,10 +40,11 @@ export const [injectHoverCardRootContext, provideHoverCardRootContext]
 import { useVModel } from '@vueuse/core'
 import { ref, toRefs } from 'vue'
 import { PopperRoot } from '@/Popper'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<HoverCardRootProps>(), {
   defaultOpen: false,
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   openDelay: 700,
   closeDelay: 300,
   enableTouch: false,

--- a/packages/core/src/HoverCard/HoverCardRoot.vue
+++ b/packages/core/src/HoverCard/HoverCardRoot.vue
@@ -4,15 +4,15 @@ import { createContext, useForwardExpose } from '@/shared'
 
 export interface HoverCardRootProps {
   /** The open state of the hover card when it is initially rendered. Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
   /** The controlled open state of the hover card. Can be binded as `v-model:open`. */
-  open?: boolean
+  open?: boolean | undefined
   /** The duration from when the mouse enters the trigger until the hover card opens. */
-  openDelay?: number
+  openDelay?: number | undefined
   /** The duration from when the mouse leaves the trigger or content until the hover card closes. */
-  closeDelay?: number
+  closeDelay?: number | undefined
   /** When `true`, tapping the trigger on touch devices toggles the hover card open/closed. By default touch interactions are ignored to match pointer hover semantics. */
-  enableTouch?: boolean
+  enableTouch?: boolean | undefined
 }
 export type HoverCardRootEmits = {
   /** Event handler called when the open state of the hover card changes. */
@@ -51,10 +51,10 @@ const props = withDefaults(defineProps<HoverCardRootProps>(), {
 const emit = defineEmits<HoverCardRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { openDelay, closeDelay, enableTouch } = toRefs(props)

--- a/packages/core/src/Label/Label.vue
+++ b/packages/core/src/Label/Label.vue
@@ -4,7 +4,7 @@ import { useForwardExpose } from '@/shared'
 
 export interface LabelProps extends PrimitiveProps {
   /** The id of the element the label is associated with. */
-  for?: string
+  for?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Listbox/ListboxFilter.vue
+++ b/packages/core/src/Listbox/ListboxFilter.vue
@@ -9,11 +9,11 @@ import { injectListboxRootContext } from './ListboxRoot.vue'
 
 export interface ListboxFilterProps extends PrimitiveProps {
   /** The controlled value of the filter. Can be binded with v-model. */
-  modelValue?: string
+  modelValue?: string | undefined
   /** Focus on element when mounted. */
-  autoFocus?: boolean
+  autoFocus?: boolean | undefined
   /** When `true`, prevents the user from interacting with item */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export type ListboxFilterEmits = {
@@ -28,10 +28,10 @@ const props = withDefaults(defineProps<ListboxFilterProps>(), {
 const emits = defineEmits<ListboxFilterEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const modelValue = useVModel(props, 'modelValue', emits, {

--- a/packages/core/src/Listbox/ListboxGroupLabel.vue
+++ b/packages/core/src/Listbox/ListboxGroupLabel.vue
@@ -2,7 +2,7 @@
 import type { PrimitiveProps } from '@/Primitive'
 
 export interface ListboxGroupLabelProps extends PrimitiveProps {
-  for?: string
+  for?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Listbox/ListboxItem.vue
+++ b/packages/core/src/Listbox/ListboxItem.vue
@@ -5,9 +5,9 @@ export interface ListboxItemProps<T = AcceptableValue> extends PrimitiveProps {
   /** The value given as data when submitted with a `name`. */
   value: T
   /** When `true`, prevents the user from interacting with the item. */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
-export type SelectEvent<T> = CustomEvent<{ originalEvent: PointerEvent, value?: T }>
+export type SelectEvent<T> = CustomEvent<{ originalEvent: PointerEvent, value?: T | undefined }>
 
 export type ListboxItemEmits<T = AcceptableValue> = {
   /** Event handler called when the selecting item. <br> It can be prevented by calling `event.preventDefault`. */

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -16,12 +16,12 @@ type ListboxRootContext<T> = {
   highlightOnHover: Ref<boolean>
   highlightedElement: Ref<HTMLElement | null>
   isVirtual: Ref<boolean>
-  virtualFocusHook: EventHook<{ event?: Event, scroll: boolean }>
+  virtualFocusHook: EventHook<{ event?: Event | undefined, scroll: boolean }>
   virtualKeydownHook: EventHook<KeyboardEvent>
   virtualHighlightHook: EventHook<any>
-  by?: string | ((a: T, b: T) => boolean)
-  firstValue?: Ref<T | undefined>
-  selectionBehavior?: Ref<'toggle' | 'replace'>
+  by?: string | ((a: T, b: T) => boolean) | undefined
+  firstValue?: Ref<T | undefined> | undefined
+  selectionBehavior?: Ref<'toggle' | 'replace'> | undefined
 
   focusable: Ref<boolean>
 
@@ -41,26 +41,26 @@ export const [injectListboxRootContext, provideListboxRootContext]
 
 export interface ListboxRootProps<T = AcceptableValue> extends PrimitiveProps, FormFieldProps {
   /** The controlled value of the listbox. Can be binded with `v-model`. */
-  modelValue?: T | Array<T>
+  modelValue?: T | Array<T> | undefined
   /** The value of the listbox when initially rendered. Use when you do not need to control the state of the Listbox */
-  defaultValue?: T | Array<T>
+  defaultValue?: T | Array<T> | undefined
   /** Whether multiple options can be selected or not. */
-  multiple?: boolean
+  multiple?: boolean | undefined
   /** The orientation of the listbox. <br>Mainly so arrow navigation is done accordingly (left & right vs. up & down) */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
   /** The reading direction of the listbox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** When `true`, prevents the user from interacting with listbox */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * How multiple selection should behave in the collection.
    * @defaultValue 'toggle'
    */
-  selectionBehavior?: 'toggle' | 'replace'
+  selectionBehavior?: 'toggle' | 'replace' | undefined
   /** When `true`, hover over item will trigger highlight */
-  highlightOnHover?: boolean
+  highlightOnHover?: boolean | undefined
   /** Use this to compare objects by a particular field, or pass your own comparison function for complete control over how objects are compared. */
-  by?: string | ((a: T, b: T) => boolean)
+  by?: string | ((a: T, b: T) => boolean) | undefined
 }
 
 export type ListboxRootEmits<T = AcceptableValue> = {
@@ -92,10 +92,10 @@ const props = withDefaults(defineProps<ListboxRootProps>(), {
 const emits = defineEmits<ListboxRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current active value */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { multiple, highlightOnHover, orientation, disabled, selectionBehavior, dir: propDir } = toRefs(props)
@@ -150,7 +150,7 @@ const highlightedElement = ref<HTMLElement | null>(null)
 const previousElement = ref<HTMLElement | null>(null)
 const isVirtual = ref(false)
 const isComposing = ref(false)
-const virtualFocusHook = createEventHook<{ event?: Event, scroll: boolean }>()
+const virtualFocusHook = createEventHook<{ event?: Event | undefined, scroll: boolean }>()
 const virtualKeydownHook = createEventHook<KeyboardEvent>()
 const virtualHighlightHook = createEventHook<T>()
 

--- a/packages/core/src/Listbox/ListboxVirtualizer.vue
+++ b/packages/core/src/Listbox/ListboxVirtualizer.vue
@@ -3,11 +3,11 @@ export interface ListboxVirtualizerProps<T extends AcceptableValue = AcceptableV
   /** List of items */
   options: T[]
   /** Number of items rendered outside the visible area */
-  overscan?: number
+  overscan?: number | undefined
   /** Estimated size (in px) of each item */
-  estimateSize?: number | ((index: number) => number)
+  estimateSize?: number | ((index: number) => number) | undefined
   /** Text content for each item to achieve type-ahead feature */
-  textContent?: (option: T) => string
+  textContent?: ((option: T) => string) | undefined
 }
 </script>
 
@@ -29,11 +29,11 @@ import { compare, queryCheckedElement } from './utils'
 const props = defineProps<ListboxVirtualizerProps<T>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     option: T
     virtualizer: Virtualizer<HTMLElement, Element>
     virtualItem: VirtualItem
-  }) => any
+  }) => any) | undefined
 }>()
 
 const slots = useSlots()

--- a/packages/core/src/Menu/MenuCheckboxItem.vue
+++ b/packages/core/src/Menu/MenuCheckboxItem.vue
@@ -13,7 +13,7 @@ export type MenuCheckboxItemEmits = MenuItemEmits & {
 
 export interface MenuCheckboxItemProps extends MenuItemProps {
   /** The controlled checked state of the item. Can be used as `v-model`. */
-  modelValue?: CheckedState
+  modelValue?: CheckedState | undefined
 }
 </script>
 
@@ -29,10 +29,10 @@ const props = withDefaults(defineProps<MenuCheckboxItemProps>(), {
 const emits = defineEmits<MenuCheckboxItemEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current modelValue state */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const delegatedProps = reactiveOmit(props, ['modelValue'])

--- a/packages/core/src/Menu/MenuContent.vue
+++ b/packages/core/src/Menu/MenuContent.vue
@@ -11,7 +11,7 @@ export interface MenuContentProps extends MenuRootContentTypeProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -46,18 +46,18 @@ export interface MenuContentImplPrivateProps {
    * the `DismissableLayer`. Users will need to click twice on outside elements to
    * interact with them: once to close the `DismissableLayer`, and again to trigger the element.
    */
-  disableOutsidePointerEvents?: DismissableLayerProps['disableOutsidePointerEvents']
+  disableOutsidePointerEvents?: DismissableLayerProps['disableOutsidePointerEvents'] | undefined
   /**
    * Whether scrolling outside the `MenuContent` should be prevented
    * @defaultValue false
    */
-  disableOutsideScroll?: boolean
+  disableOutsideScroll?: boolean | undefined
 
   /**
    * Whether focus should be trapped within the `MenuContent`
    * @defaultValue also
    */
-  trapFocus?: FocusScopeProps['trapped']
+  trapFocus?: FocusScopeProps['trapped'] | undefined
 }
 
 export type MenuContentImplEmits = DismissableLayerEmits & Omit<RovingFocusGroupEmits, 'update:currentTabStopId'> & {
@@ -83,7 +83,7 @@ export interface MenuContentImplProps
    * When `true`, keyboard navigation will loop from last item to first, and vice versa.
    * @defaultValue false
    */
-  loop?: boolean
+  loop?: boolean | undefined
 }
 
 export interface MenuRootContentTypeProps

--- a/packages/core/src/Menu/MenuItemImpl.vue
+++ b/packages/core/src/Menu/MenuItemImpl.vue
@@ -3,12 +3,12 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface MenuItemImplProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with the item. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Optional text used for typeahead purposes. By default the typeahead behavior will use the `.textContent` of the item. <br>
    *  Use this when the content is complex, or you have non-textual content inside.
    */
-  textValue?: string
+  textValue?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Menu/MenuItemIndicator.vue
+++ b/packages/core/src/Menu/MenuItemIndicator.vue
@@ -13,7 +13,7 @@ export interface MenuItemIndicatorProps extends PrimitiveProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 
 export const [injectMenuItemIndicatorContext, provideMenuItemIndicatorContext]

--- a/packages/core/src/Menu/MenuRadioGroup.vue
+++ b/packages/core/src/Menu/MenuRadioGroup.vue
@@ -11,7 +11,7 @@ interface MenuRadioGroupContext {
 
 export interface MenuRadioGroupProps extends MenuGroupProps {
   /** The value of the selected item in the group. */
-  modelValue?: AcceptableValue
+  modelValue?: AcceptableValue | undefined
 }
 
 export type MenuRadioGroupEmits = {
@@ -33,10 +33,10 @@ const props = withDefaults(defineProps<MenuRadioGroupProps>(), {
 const emits = defineEmits<MenuRadioGroupEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const delegatedProps = reactiveOmit(props, ['modelValue'])

--- a/packages/core/src/Menu/MenuRoot.vue
+++ b/packages/core/src/Menu/MenuRoot.vue
@@ -20,19 +20,19 @@ export interface MenuRootContext {
 
 export interface MenuProps {
   /** The controlled open state of the menu. Can be used as `v-model:open`. */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * The reading direction of the combobox when applicable.
    *
    * If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
-  dir?: Direction
+  dir?: Direction | undefined
   /**
    * The modality of the dropdown menu.
    *
    * When set to `true`, interaction with outside elements will be disabled and only menu content will be visible to screen readers.
    */
-  modal?: boolean
+  modal?: boolean | undefined
 }
 
 export type MenuEmits = {

--- a/packages/core/src/Menu/MenuSub.vue
+++ b/packages/core/src/Menu/MenuSub.vue
@@ -32,10 +32,11 @@ import {
   watchEffect,
 } from 'vue'
 import { PopperRoot } from '@/Popper'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import { injectMenuContext, provideMenuContext } from './MenuRoot.vue'
 
 const props = withDefaults(defineProps<MenuSubProps>(), {
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
 })
 const emits = defineEmits<MenuSubEmits>()
 

--- a/packages/core/src/Menu/MenuSub.vue
+++ b/packages/core/src/Menu/MenuSub.vue
@@ -8,7 +8,7 @@ export interface MenuSubContext {
   triggerId: string
   trigger: Ref<HTMLElement | undefined>
   onTriggerChange: (trigger: HTMLElement | undefined) => void
-  parentMenuContext?: MenuContext
+  parentMenuContext?: MenuContext | undefined
 }
 
 export const [injectMenuSubContext, provideMenuSubContext]
@@ -16,7 +16,7 @@ export const [injectMenuSubContext, provideMenuSubContext]
 
 export interface MenuSubProps {
   /** The controlled open state of the menu. Can be used as `v-model:open`. */
-  open?: boolean
+  open?: boolean | undefined
 }
 
 export type MenuSubEmits = {

--- a/packages/core/src/Menu/MenuSubContent.vue
+++ b/packages/core/src/Menu/MenuSubContent.vue
@@ -12,7 +12,7 @@ export interface MenuSubContentProps extends Omit<MenuContentImplProps, 'disable
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Menubar/MenubarMenu.vue
+++ b/packages/core/src/Menubar/MenubarMenu.vue
@@ -8,7 +8,7 @@ export interface MenubarMenuProps {
    *
    * This prop is managed automatically when uncontrolled.
    */
-  value?: string
+  value?: string | undefined
 }
 
 type MenubarMenuContext = {

--- a/packages/core/src/Menubar/MenubarRoot.vue
+++ b/packages/core/src/Menubar/MenubarRoot.vue
@@ -6,17 +6,17 @@ import { createContext, useDirection, useForwardExpose } from '@/shared'
 
 export interface MenubarRootProps {
   /** The controlled value of the menu to open. Can be used as `v-model`. */
-  modelValue?: string
+  modelValue?: string | undefined
   /** The value of the menu that should be open when initially rendered. Use when you do not need to control the value state. */
-  defaultValue?: string
+  defaultValue?: string | undefined
   /**
    * The reading direction of the combobox when applicable.
    *
    *  If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
-  dir?: Direction
+  dir?: Direction | undefined
   /** When `true`, keyboard navigation will loop from last item to first, and vice versa. */
-  loop?: boolean
+  loop?: boolean | undefined
 }
 export type MenubarRootEmits = {
   /** Event handler called when the value changes. */
@@ -48,10 +48,10 @@ const props = withDefaults(defineProps<MenubarRootProps>(), {
 const emit = defineEmits<MenubarRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { forwardRef } = useForwardExpose()

--- a/packages/core/src/Menubar/MenubarSub.vue
+++ b/packages/core/src/Menubar/MenubarSub.vue
@@ -5,7 +5,7 @@ import type { MenuSubEmits, MenuSubProps } from '@/Menu'
 export type MenubarSubEmits = MenuSubEmits
 export interface MenubarSubProps extends MenuSubProps {
   /** The open state of the submenu when it is initially rendered. Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
 }
 </script>
 
@@ -20,10 +20,10 @@ const props = withDefaults(defineProps<MenubarSubProps>(), {
 const emit = defineEmits<MenubarSubEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 useForwardExpose()

--- a/packages/core/src/Menubar/MenubarSub.vue
+++ b/packages/core/src/Menubar/MenubarSub.vue
@@ -13,9 +13,10 @@ export interface MenubarSubProps extends MenuSubProps {
 import { useVModel } from '@vueuse/core'
 import { MenuSub } from '@/Menu'
 import { useForwardExpose } from '@/shared'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<MenubarSubProps>(), {
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
 })
 const emit = defineEmits<MenubarSubEmits>()
 

--- a/packages/core/src/Menubar/MenubarTrigger.vue
+++ b/packages/core/src/Menubar/MenubarTrigger.vue
@@ -5,7 +5,7 @@ import { useForwardExpose } from '@/shared'
 
 export interface MenubarTriggerProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with item */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/MonthPicker/MonthPickerCellTrigger.vue
+++ b/packages/core/src/MonthPicker/MonthPickerCellTrigger.vue
@@ -12,7 +12,7 @@ export interface MonthPickerCellTriggerProps extends PrimitiveProps {
 }
 
 export interface MonthPickerCellTriggerSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current month value (short name) */
     monthValue: string
     /** Current disable state */
@@ -23,7 +23,7 @@ export interface MonthPickerCellTriggerSlot {
     today: boolean
     /** Current unavailable state */
     unavailable: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/MonthPicker/MonthPickerHeading.vue
+++ b/packages/core/src/MonthPicker/MonthPickerHeading.vue
@@ -11,10 +11,10 @@ import { injectMonthPickerRootContext } from './MonthPickerRoot.vue'
 const props = withDefaults(defineProps<MonthPickerHeadingProps>(), { as: 'div' })
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current year heading */
     headingValue: string
-  }) => any
+  }) => any) | undefined
 }>()
 
 const rootContext = injectMonthPickerRootContext()

--- a/packages/core/src/MonthPicker/MonthPickerNext.vue
+++ b/packages/core/src/MonthPicker/MonthPickerNext.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface MonthPickerNextProps extends PrimitiveProps {
   /** The function to be used for the next page. Overwrites the `nextPage` function set on the `MonthPickerRoot`. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface MonthPickerNextSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/MonthPicker/MonthPickerPrev.vue
+++ b/packages/core/src/MonthPicker/MonthPickerPrev.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface MonthPickerPrevProps extends PrimitiveProps {
   /** The function to be used for the prev page. Overwrites the `prevPage` function set on the `MonthPickerRoot`. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface MonthPickerPrevSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/MonthPicker/MonthPickerRoot.vue
+++ b/packages/core/src/MonthPicker/MonthPickerRoot.vue
@@ -96,16 +96,12 @@ import { onMounted, toRefs, watch } from 'vue'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
 
 const props = withDefaults(defineProps<MonthPickerRootProps>(), {
-  defaultValue: undefined,
   as: 'div',
   preventDeselect: false,
   multiple: false,
   disabled: false,
   readonly: false,
   initialFocus: false,
-  placeholder: undefined,
-  isMonthDisabled: undefined,
-  isMonthUnavailable: undefined,
 })
 const emits = defineEmits<MonthPickerRootEmits>()
 defineSlots<{

--- a/packages/core/src/MonthPicker/MonthPickerRoot.vue
+++ b/packages/core/src/MonthPicker/MonthPickerRoot.vue
@@ -29,7 +29,7 @@ type MonthPickerRootContext = {
   isInvalid: Ref<boolean>
   isMonthDisabled: Matcher
   isMonthSelected: Matcher
-  isMonthUnavailable?: Matcher
+  isMonthUnavailable?: Matcher | undefined
   prevPage: (prevPageFunc?: (date: DateValue) => DateValue) => void
   nextPage: (nextPageFunc?: (date: DateValue) => DateValue) => void
   isNextButtonDisabled: (nextPageFunc?: (date: DateValue) => DateValue) => boolean
@@ -42,41 +42,41 @@ type MonthPickerRootContext = {
 
 export interface MonthPickerRootProps extends PrimitiveProps {
   /** The default value for the month picker */
-  defaultValue?: DateValue
+  defaultValue?: DateValue | undefined
   /** The default placeholder date */
-  defaultPlaceholder?: DateValue
+  defaultPlaceholder?: DateValue | undefined
   /** The placeholder date, which is used to determine what year to display when no date is selected */
-  placeholder?: DateValue
+  placeholder?: DateValue | undefined
   /** Whether or not to prevent the user from deselecting a date without selecting another date first */
-  preventDeselect?: boolean
+  preventDeselect?: boolean | undefined
   /** The accessible label for the month picker */
-  calendarLabel?: string
+  calendarLabel?: string | undefined
   /** The maximum date that can be selected */
-  maxValue?: DateValue
+  maxValue?: DateValue | undefined
   /** The minimum date that can be selected */
-  minValue?: DateValue
+  minValue?: DateValue | undefined
   /** The locale to use for formatting dates */
-  locale?: string
+  locale?: string | undefined
   /** Whether the month picker is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether the month picker is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** If true, the month picker will focus the selected month, today, or the first month of the year on mount */
-  initialFocus?: boolean
+  initialFocus?: boolean | undefined
   /** A function that returns whether or not a month is disabled */
-  isMonthDisabled?: Matcher
+  isMonthDisabled?: Matcher | undefined
   /** A function that returns whether or not a month is unavailable */
-  isMonthUnavailable?: Matcher
+  isMonthUnavailable?: Matcher | undefined
   /** The reading direction of the calendar when applicable. If omitted, inherits globally from `ConfigProvider` or assumes LTR. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** A function that returns the next page of the month picker. Receives the current placeholder as an argument. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** A function that returns the previous page of the month picker. Receives the current placeholder as an argument. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** The controlled selected month value of the month picker. Can be bound as `v-model`. */
-  modelValue?: DateValue | DateValue[] | null
+  modelValue?: DateValue | DateValue[] | null | undefined
   /** Whether multiple months can be selected */
-  multiple?: boolean
+  multiple?: boolean | undefined
 }
 
 export type MonthPickerRootEmits = {
@@ -109,7 +109,7 @@ const props = withDefaults(defineProps<MonthPickerRootProps>(), {
 })
 const emits = defineEmits<MonthPickerRootEmits>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current date of the placeholder */
     date: DateValue
     /** The grid of months */
@@ -118,7 +118,7 @@ defineSlots<{
     locale: string
     /** The current selected value */
     modelValue: DateValue | DateValue[] | undefined
-  }) => any
+  }) => any) | undefined
 }>()
 
 const {

--- a/packages/core/src/MonthPicker/useMonthPicker.ts
+++ b/packages/core/src/MonthPicker/useMonthPicker.ts
@@ -13,8 +13,8 @@ export type UseMonthPickerProps = {
   minValue: Ref<DateValue | undefined>
   maxValue: Ref<DateValue | undefined>
   disabled: Ref<boolean>
-  isMonthDisabled?: Matcher | Ref<Matcher | undefined>
-  isMonthUnavailable?: Matcher | Ref<Matcher | undefined>
+  isMonthDisabled?: Matcher | Ref<Matcher | undefined> | undefined
+  isMonthUnavailable?: Matcher | Ref<Matcher | undefined> | undefined
   calendarLabel: Ref<string | undefined>
   nextPage: Ref<((placeholder: DateValue) => DateValue) | undefined>
   prevPage: Ref<((placeholder: DateValue) => DateValue) | undefined>

--- a/packages/core/src/MonthRangePicker/MonthRangePickerCellTrigger.vue
+++ b/packages/core/src/MonthRangePicker/MonthRangePickerCellTrigger.vue
@@ -12,7 +12,7 @@ export interface MonthRangePickerCellTriggerProps extends PrimitiveProps {
 }
 
 export interface MonthRangePickerCellTriggerSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current month value (short name) */
     monthValue: string
     /** Current disable state */
@@ -33,7 +33,7 @@ export interface MonthRangePickerCellTriggerSlot {
     selectionStart: boolean
     /** Current selection end state */
     selectionEnd: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/MonthRangePicker/MonthRangePickerHeading.vue
+++ b/packages/core/src/MonthRangePicker/MonthRangePickerHeading.vue
@@ -11,10 +11,10 @@ import { injectMonthRangePickerRootContext } from './MonthRangePickerRoot.vue'
 const props = withDefaults(defineProps<MonthRangePickerHeadingProps>(), { as: 'div' })
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current year heading */
     headingValue: string
-  }) => any
+  }) => any) | undefined
 }>()
 
 const rootContext = injectMonthRangePickerRootContext()

--- a/packages/core/src/MonthRangePicker/MonthRangePickerNext.vue
+++ b/packages/core/src/MonthRangePicker/MonthRangePickerNext.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface MonthRangePickerNextProps extends PrimitiveProps {
   /** The function to be used for the next page. Overwrites the `nextPage` function set on the Root. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface MonthRangePickerNextSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/MonthRangePicker/MonthRangePickerPrev.vue
+++ b/packages/core/src/MonthRangePicker/MonthRangePickerPrev.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface MonthRangePickerPrevProps extends PrimitiveProps {
   /** The function to be used for the prev page. Overwrites the `prevPage` function set on the Root. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface MonthRangePickerPrevSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/MonthRangePicker/MonthRangePickerRoot.vue
+++ b/packages/core/src/MonthRangePicker/MonthRangePickerRoot.vue
@@ -120,11 +120,7 @@ const props = withDefaults(defineProps<MonthRangePickerRootProps>(), {
   disabled: false,
   readonly: false,
   initialFocus: false,
-  placeholder: undefined,
-  isMonthDisabled: undefined,
-  isMonthUnavailable: undefined,
   allowNonContiguousRanges: false,
-  maximumMonths: undefined,
 })
 const emits = defineEmits<MonthRangePickerRootEmits>()
 

--- a/packages/core/src/MonthRangePicker/MonthRangePickerRoot.vue
+++ b/packages/core/src/MonthRangePicker/MonthRangePickerRoot.vue
@@ -30,7 +30,7 @@ type MonthRangePickerRootContext = {
   headingId: string
   isInvalid: Ref<boolean>
   isMonthDisabled: Matcher
-  isMonthUnavailable?: Matcher
+  isMonthUnavailable?: Matcher | undefined
   allowNonContiguousRanges: Ref<boolean>
   highlightedRange: Ref<{ start: DateValue, end: DateValue } | null>
   focusedValue: Ref<DateValue | undefined>
@@ -54,45 +54,45 @@ type MonthRangePickerRootContext = {
 
 export interface MonthRangePickerRootProps extends PrimitiveProps {
   /** The default placeholder date */
-  defaultPlaceholder?: DateValue
+  defaultPlaceholder?: DateValue | undefined
   /** The default value for the calendar */
-  defaultValue?: DateRange
+  defaultValue?: DateRange | undefined
   /** The controlled selected month range of the month range picker. Can be bound as `v-model`. */
-  modelValue?: DateRange | null
+  modelValue?: DateRange | null | undefined
   /** The placeholder date, which is used to determine what year to display when no date is selected. */
-  placeholder?: DateValue
+  placeholder?: DateValue | undefined
   /** When combined with `isMonthUnavailable`, determines whether non-contiguous ranges may be selected. */
-  allowNonContiguousRanges?: boolean
+  allowNonContiguousRanges?: boolean | undefined
   /** Whether or not to prevent the user from deselecting a date without selecting another date first */
-  preventDeselect?: boolean
+  preventDeselect?: boolean | undefined
   /** The maximum number of months that can be selected in a range */
-  maximumMonths?: number
+  maximumMonths?: number | undefined
   /** The accessible label for the calendar */
-  calendarLabel?: string
+  calendarLabel?: string | undefined
   /** The maximum date that can be selected */
-  maxValue?: DateValue
+  maxValue?: DateValue | undefined
   /** The minimum date that can be selected */
-  minValue?: DateValue
+  minValue?: DateValue | undefined
   /** The locale to use for formatting dates */
-  locale?: string
+  locale?: string | undefined
   /** Whether or not the calendar is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether or not the calendar is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** If true, the calendar will focus the selected month on mount */
-  initialFocus?: boolean
+  initialFocus?: boolean | undefined
   /** A function that returns whether or not a month is disabled */
-  isMonthDisabled?: Matcher
+  isMonthDisabled?: Matcher | undefined
   /** A function that returns whether or not a month is unavailable */
-  isMonthUnavailable?: Matcher
+  isMonthUnavailable?: Matcher | undefined
   /** The reading direction of the calendar when applicable. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** A function that returns the next page of the calendar. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** A function that returns the previous page of the calendar. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** Which part of the range should be fixed */
-  fixedDate?: 'start' | 'end'
+  fixedDate?: 'start' | 'end' | undefined
 }
 
 export type MonthRangePickerRootEmits = {
@@ -129,7 +129,7 @@ const props = withDefaults(defineProps<MonthRangePickerRootProps>(), {
 const emits = defineEmits<MonthRangePickerRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current date of the placeholder */
     date: DateValue
     /** The grid of months */
@@ -138,7 +138,7 @@ defineSlots<{
     locale: string
     /** The current date range */
     modelValue: DateRange
-  }) => any
+  }) => any) | undefined
 }>()
 
 const {

--- a/packages/core/src/MonthRangePicker/useRangeMonthPicker.ts
+++ b/packages/core/src/MonthRangePicker/useRangeMonthPicker.ts
@@ -12,7 +12,7 @@ export type UseRangeMonthPickerProps = {
   focusedValue: Ref<DateValue | undefined>
   allowNonContiguousRanges: Ref<boolean>
   fixedDate: Ref<'start' | 'end' | undefined>
-  maximumMonths?: Ref<number | undefined>
+  maximumMonths?: Ref<number | undefined> | undefined
 }
 
 export function useRangeMonthPickerState(props: UseRangeMonthPickerProps) {

--- a/packages/core/src/NavigationMenu/NavigationMenuContent.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuContent.vue
@@ -8,7 +8,7 @@ export interface NavigationMenuContentProps extends NavigationMenuContentImplPro
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/NavigationMenu/NavigationMenuIndicator.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuIndicator.vue
@@ -6,7 +6,7 @@ export interface NavigationMenuIndicatorProps extends PrimitiveProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/NavigationMenu/NavigationMenuItem.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuItem.vue
@@ -10,7 +10,7 @@ export interface NavigationMenuItemProps extends PrimitiveProps {
    *
    *  This prop is managed automatically when uncontrolled.
    */
-  value?: string
+  value?: string | undefined
 }
 
 export type NavigationMenuItemContext = {

--- a/packages/core/src/NavigationMenu/NavigationMenuLink.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuLink.vue
@@ -13,7 +13,7 @@ export type NavigationMenuLinkEmits = {
 }
 export interface NavigationMenuLinkProps extends PrimitiveProps {
   /** Used to identify the link as the currently active page. */
-  active?: boolean
+  active?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
@@ -104,7 +104,6 @@ import {
 } from '@/Primitive'
 
 const props = withDefaults(defineProps<NavigationMenuRootProps>(), {
-  modelValue: undefined,
   delayDuration: 200,
   skipDelayDuration: 300,
   orientation: 'horizontal',

--- a/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuRoot.vue
@@ -9,54 +9,54 @@ import { EVENT_ROOT_CONTENT_DISMISS } from './utils'
 
 export interface NavigationMenuRootProps extends PrimitiveProps {
   /** The controlled value of the menu item to activate. Can be used as `v-model`. */
-  modelValue?: string
+  modelValue?: string | undefined
   /**
    * The value of the menu item that should be active when initially rendered.
    *
    * Use when you do not need to control the value state.
    */
-  defaultValue?: string
+  defaultValue?: string | undefined
   /**
    * The reading direction of the combobox when applicable.
    *
    *  If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
-  dir?: Direction
+  dir?: Direction | undefined
   /** The orientation of the menu. */
-  orientation?: Orientation
+  orientation?: Orientation | undefined
   /**
    * The duration from when the pointer enters the trigger until the tooltip gets opened.
    * @defaultValue 200
    */
-  delayDuration?: number
+  delayDuration?: number | undefined
   /**
    * How much time a user has to enter another trigger without incurring a delay again.
    * @defaultValue 300
    */
-  skipDelayDuration?: number
+  skipDelayDuration?: number | undefined
 
   /**
    * If `true`, menu cannot be open by click on trigger
    * @defaultValue false
    */
-  disableClickTrigger?: boolean
+  disableClickTrigger?: boolean | undefined
   /**
    * If `true`, menu cannot be open by hover on trigger
    * @defaultValue false
    */
-  disableHoverTrigger?: boolean
+  disableHoverTrigger?: boolean | undefined
   /**
    * If `true`, menu will not close during pointer leave event
    * @defaultValue false
    */
-  disablePointerLeaveClose?: boolean
+  disablePointerLeaveClose?: boolean | undefined
 
   /**
    * When `true`, the element will be unmounted on closed state.
    *
    * @defaultValue `true`
    */
-  unmountOnHide?: boolean
+  unmountOnHide?: boolean | undefined
 }
 export type NavigationMenuRootEmits = {
   /** Event handler called when the value changes. */
@@ -116,10 +116,10 @@ const props = withDefaults(defineProps<NavigationMenuRootProps>(), {
 const emits = defineEmits<NavigationMenuRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const modelValue = useVModel(props, 'modelValue', emits, {

--- a/packages/core/src/NavigationMenu/NavigationMenuSub.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuSub.vue
@@ -11,15 +11,15 @@ export type NavigationMenuSubEmits = {
 
 export interface NavigationMenuSubProps extends PrimitiveProps {
   /** The controlled value of the sub menu item to activate. Can be used as `v-model`. */
-  modelValue?: string
+  modelValue?: string | undefined
   /**
    * The value of the menu item that should be active when initially rendered.
    *
    * Use when you do not need to control the value state.
    */
-  defaultValue?: string
+  defaultValue?: string | undefined
   /** The orientation of the menu. */
-  orientation?: Orientation
+  orientation?: Orientation | undefined
 }
 </script>
 
@@ -38,10 +38,10 @@ const props = withDefaults(defineProps<NavigationMenuSubProps>(), {
 const emits = defineEmits<NavigationMenuSubEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const modelValue = useVModel(props, 'modelValue', emits, {

--- a/packages/core/src/NavigationMenu/NavigationMenuTrigger.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuTrigger.vue
@@ -6,7 +6,7 @@ import { useForwardExpose } from '@/shared'
 
 export interface NavigationMenuTriggerProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with item */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/NavigationMenu/NavigationMenuViewport.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuViewport.vue
@@ -7,12 +7,12 @@ export interface NavigationMenuViewportProps extends PrimitiveProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
   /**
    * Placement of the viewport for css variables `(--reka-navigation-menu-viewport-left, --reka-navigation-menu-viewport-top)`.
    * @defaultValue 'center'
    */
-  align?: 'start' | 'center' | 'end'
+  align?: 'start' | 'center' | 'end' | undefined
 }
 </script>
 

--- a/packages/core/src/NumberField/NumberFieldDecrement.vue
+++ b/packages/core/src/NumberField/NumberFieldDecrement.vue
@@ -5,7 +5,7 @@ import { injectNumberFieldRootContext } from './NumberFieldRoot.vue'
 import { usePressedHold } from './utils'
 
 export interface NumberFieldDecrementProps extends PrimitiveProps {
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/NumberField/NumberFieldIncrement.vue
+++ b/packages/core/src/NumberField/NumberFieldIncrement.vue
@@ -5,7 +5,7 @@ import { injectNumberFieldRootContext } from './NumberFieldRoot.vue'
 import { usePressedHold } from './utils'
 
 export interface NumberFieldIncrementProps extends PrimitiveProps {
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -7,32 +7,32 @@ import { computed, ref, toRefs } from 'vue'
 import { clamp, createContext, isNullish, snapValueToStep, useFormControl, useLocale } from '@/shared'
 
 export interface NumberFieldRootProps extends PrimitiveProps, FormFieldProps {
-  defaultValue?: number
-  modelValue?: number | null
+  defaultValue?: number | undefined
+  modelValue?: number | null | undefined
   /** The smallest value allowed for the input. */
-  min?: number
+  min?: number | undefined
   /** The largest value allowed for the input. */
-  max?: number
+  max?: number | undefined
   /** The amount that the input value changes with each increment or decrement "tick". */
-  step?: number
+  step?: number | undefined
   /** When `false`, prevents the value from snapping to the nearest increment of the step value */
-  stepSnapping?: boolean
+  stepSnapping?: boolean | undefined
   /** When `true`, the input will be focused when the value changes. */
-  focusOnChange?: boolean
+  focusOnChange?: boolean | undefined
   /** Formatting options for the value displayed in the number field. This also affects what characters are allowed to be typed by the user. */
-  formatOptions?: Intl.NumberFormatOptions
+  formatOptions?: Intl.NumberFormatOptions | undefined
   /** The locale to use for formatting and currencies */
-  locale?: string
+  locale?: string | undefined
   /** When `true`, prevents the user from interacting with the Number Field. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** When `true`, the Number Field is read-only. */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** When `true`, prevents the value from changing on wheel scroll. */
-  disableWheelChange?: boolean
+  disableWheelChange?: boolean | undefined
   /** When `true`, inverts the direction of the wheel change. */
-  invertWheelChange?: boolean
+  invertWheelChange?: boolean | undefined
   /** Id of the element */
-  id?: string
+  id?: string | undefined
 }
 
 export type NumberFieldRootEmits = {

--- a/packages/core/src/NumberField/NumberFieldRoot.vue
+++ b/packages/core/src/NumberField/NumberFieldRoot.vue
@@ -75,7 +75,6 @@ defineOptions({
 
 const props = withDefaults(defineProps<NumberFieldRootProps>(), {
   as: 'div',
-  defaultValue: undefined,
   step: 1,
   stepSnapping: true,
   focusOnChange: true,

--- a/packages/core/src/NumberField/utils.ts
+++ b/packages/core/src/NumberField/utils.ts
@@ -5,7 +5,7 @@ import { unrefElement, useEventListener } from '@vueuse/core'
 import { createEventHook, isClient, reactiveComputed } from '@vueuse/shared'
 import { computed, ref } from 'vue'
 
-export function usePressedHold(options: { target?: MaybeComputedElementRef, disabled: Ref<boolean> }) {
+export function usePressedHold(options: { target?: MaybeComputedElementRef | undefined, disabled: Ref<boolean> }) {
   const { disabled } = options
   const timeout = ref<number>()
   const triggerHook = createEventHook()

--- a/packages/core/src/NumberField/utils.ts
+++ b/packages/core/src/NumberField/utils.ts
@@ -1,3 +1,4 @@
+import type { NumberFormatOptions } from '@internationalized/number'
 import type { MaybeComputedElementRef } from '@vueuse/core'
 import type { Ref } from 'vue'
 import { NumberFormatter, NumberParser } from '@internationalized/number'
@@ -63,7 +64,10 @@ export function usePressedHold(options: { target?: MaybeComputedElementRef | und
 }
 
 export function useNumberFormatter(locale: Ref<string>, options: Ref<Intl.NumberFormatOptions | undefined> = ref({})) {
-  return reactiveComputed(() => new NumberFormatter(locale.value, options.value))
+  // `@internationalized/number` declares `numberingSystem?: string` while the TS
+  // lib declares it as `string | undefined`, so the two shapes are only
+  // assignable without `exactOptionalPropertyTypes`. They are otherwise identical.
+  return reactiveComputed(() => new NumberFormatter(locale.value, options.value as NumberFormatOptions | undefined))
 }
 
 export function useNumberParser(locale: Ref<string>, options: Ref<Intl.NumberFormatOptions | undefined> = ref({})) {

--- a/packages/core/src/Pagination/PaginationList.vue
+++ b/packages/core/src/Pagination/PaginationList.vue
@@ -14,10 +14,10 @@ import { getRange, transform } from './utils'
 const props = defineProps<PaginationListProps>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Pages item */
     items: typeof transformedRange.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 useForwardExpose()

--- a/packages/core/src/Pagination/PaginationRoot.vue
+++ b/packages/core/src/Pagination/PaginationRoot.vue
@@ -14,23 +14,23 @@ type PaginationRootContext = {
 
 export interface PaginationRootProps extends PrimitiveProps {
   /** The controlled value of the current page. Can be binded as `v-model:page`. */
-  page?: number
+  page?: number | undefined
   /**
    * The value of the page that should be active when initially rendered.
    *
    * Use when you do not need to control the value state.
    */
-  defaultPage?: number
+  defaultPage?: number | undefined
   /** Number of items per page */
   itemsPerPage: number
   /** Number of items in your list */
-  total?: number
+  total?: number | undefined
   /** Number of sibling should be shown around the current page */
-  siblingCount?: number
+  siblingCount?: number | undefined
   /** When `true`, prevents the user from interacting with item */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** When `true`, always show first page, last page, and ellipsis */
-  showEdges?: boolean
+  showEdges?: boolean | undefined
 }
 
 export type PaginationRootEmits = {
@@ -57,12 +57,12 @@ const props = withDefaults(defineProps<PaginationRootProps>(), {
 const emits = defineEmits<PaginationRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current page state */
     page: typeof page.value
     /** Number of pages */
     pageCount: typeof pageCount.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { siblingCount, disabled, showEdges } = toRefs(props)

--- a/packages/core/src/PinInput/PinInputInput.vue
+++ b/packages/core/src/PinInput/PinInputInput.vue
@@ -9,7 +9,7 @@ export interface PinInputInputProps extends PrimitiveProps {
   /** Position of the value this input binds to. */
   index: number
   /** When `true`, prevents the user from interacting with the pin input */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/PinInput/PinInputRoot.vue
+++ b/packages/core/src/PinInput/PinInputRoot.vue
@@ -27,23 +27,23 @@ export type PinInputRootEmits<Type extends PinInputType = 'text'> = {
 
 export interface PinInputRootProps<Type extends PinInputType = 'text'> extends PrimitiveProps, FormFieldProps {
   /** The controlled checked state of the pin input. Can be binded as `v-model`. */
-  modelValue?: PinInputValue<Type> | null
+  modelValue?: PinInputValue<Type> | null | undefined
   /** The default value of the pin inputs when it is initially rendered. Use when you do not need to control its checked state. */
-  defaultValue?: PinInputValue<Type>
+  defaultValue?: PinInputValue<Type> | undefined
   /** The placeholder character to use for empty pin-inputs. */
-  placeholder?: string
+  placeholder?: string | undefined
   /** When `true`, pin inputs will be treated as password. */
-  mask?: boolean
+  mask?: boolean | undefined
   /** When `true`, mobile devices will autodetect the OTP from messages or clipboard, and enable the autocomplete field. */
-  otp?: boolean
+  otp?: boolean | undefined
   /** Input type for the inputs. */
-  type?: Type
+  type?: Type | undefined
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** When `true`, prevents the user from interacting with the pin input */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Id of the element */
-  id?: string
+  id?: string | undefined
 }
 
 export interface PinInputRootContext<Type extends PinInputType = 'text'> {
@@ -56,7 +56,7 @@ export interface PinInputRootContext<Type extends PinInputType = 'text'> {
   dir: Ref<Direction>
   disabled: Ref<boolean>
   isCompleted: ComputedRef<boolean>
-  inputElements?: Ref<Set<HTMLInputElement>>
+  inputElements?: Ref<Set<HTMLInputElement>> | undefined
   onInputElementChange: (el: HTMLInputElement) => void
   isNumericMode: ComputedRef<boolean>
 }
@@ -80,10 +80,10 @@ const props = withDefaults(defineProps<PinInputRootProps<Type>>(), {
 const emits = defineEmits<PinInputRootEmits<Type>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { mask, otp, placeholder, type, disabled, dir: propDir } = toRefs(props)

--- a/packages/core/src/Popover/PopoverContent.vue
+++ b/packages/core/src/Popover/PopoverContent.vue
@@ -11,7 +11,7 @@ export interface PopoverContentProps extends PopoverContentImplProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Popover/PopoverContentImpl.vue
+++ b/packages/core/src/Popover/PopoverContentImpl.vue
@@ -27,7 +27,7 @@ interface PopoverContentImplPrivateProps extends PopoverContentImplProps {
    * Whether focus should be trapped within the `MenuContent`
    * @defaultValue false
    */
-  trapFocus?: FocusScopeProps['trapped']
+  trapFocus?: FocusScopeProps['trapped'] | undefined
 }
 </script>
 

--- a/packages/core/src/Popover/PopoverRoot.vue
+++ b/packages/core/src/Popover/PopoverRoot.vue
@@ -44,10 +44,11 @@ export const [injectPopoverRootContext, providePopoverRootContext]
 import { useVModel } from '@vueuse/core'
 import { ref, toRefs } from 'vue'
 import { PopperRoot } from '@/Popper'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 const props = withDefaults(defineProps<PopoverRootProps>(), {
   defaultOpen: false,
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   modal: false,
 })
 const emit = defineEmits<PopoverRootEmits>()

--- a/packages/core/src/Popover/PopoverRoot.vue
+++ b/packages/core/src/Popover/PopoverRoot.vue
@@ -6,17 +6,17 @@ export interface PopoverRootProps {
   /**
    * The open state of the popover when it is initially rendered. Use when you do not need to control its open state.
    */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
   /**
    * The controlled open state of the popover.
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * The modality of the popover. When set to true, interaction with outside elements will be disabled and only popover content will be visible to screen readers.
    *
    * @defaultValue false
    */
-  modal?: boolean
+  modal?: boolean | undefined
 }
 export type PopoverRootEmits = {
   /**
@@ -53,12 +53,12 @@ const props = withDefaults(defineProps<PopoverRootProps>(), {
 const emit = defineEmits<PopoverRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
     /** Close the popover */
     close: () => void
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { modal } = toRefs(props)

--- a/packages/core/src/Popper/PopperAnchor.vue
+++ b/packages/core/src/Popper/PopperAnchor.vue
@@ -9,7 +9,7 @@ export interface PopperAnchorProps extends PrimitiveProps {
    *
    *  If not provided will use the current component as anchor.
    */
-  reference?: ReferenceElement
+  reference?: ReferenceElement | undefined
 }
 </script>
 

--- a/packages/core/src/Popper/PopperContent.vue
+++ b/packages/core/src/Popper/PopperContent.vue
@@ -36,7 +36,7 @@ export interface PopperContentProps extends PrimitiveProps {
   /**
    * Reactive dependencies that should invalidate the memoized content subtree.
    */
-  memoDependencies?: unknown[]
+  memoDependencies?: unknown[] | undefined
 
   /**
    * The preferred side of the trigger to render against when open.
@@ -45,21 +45,21 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue "bottom"
    */
-  side?: Side
+  side?: Side | undefined
 
   /**
    * The distance in pixels from the trigger.
    *
    * @defaultValue 0
    */
-  sideOffset?: number
+  sideOffset?: number | undefined
 
   /**
    * Flip to the opposite side when colliding with boundary.
    *
    * @defaultValue true
    */
-  sideFlip?: boolean
+  sideFlip?: boolean | undefined
 
   /**
    * The preferred alignment against the trigger.
@@ -67,14 +67,14 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue "center"
    */
-  align?: Align
+  align?: Align | undefined
 
   /**
    * An offset in pixels from the `start` or `end` alignment options.
    *
    * @defaultValue 0
    */
-  alignOffset?: number
+  alignOffset?: number | undefined
 
   /**
    * Flip alignment when colliding with boundary.
@@ -82,7 +82,7 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue true
    */
-  alignFlip?: boolean
+  alignFlip?: boolean | undefined
 
   /**
    * When `true`, overrides the side and align preferences
@@ -90,7 +90,7 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue true
    */
-  avoidCollisions?: boolean
+  avoidCollisions?: boolean | undefined
 
   /**
    * The element used as the collision boundary. By default
@@ -99,7 +99,7 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue []
    */
-  collisionBoundary?: Element | null | Array<Element | null>
+  collisionBoundary?: Element | null | Array<Element | null> | undefined
 
   /**
    * The distance in pixels from the boundary edges where collision
@@ -108,7 +108,7 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue 0
    */
-  collisionPadding?: number | Partial<Record<Side, number>>
+  collisionPadding?: number | Partial<Record<Side, number>> | undefined
 
   /**
    * The padding between the arrow and the edges of the content.
@@ -117,7 +117,7 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue 0
    */
-  arrowPadding?: number
+  arrowPadding?: number | undefined
 
   /**
    * When `true`, hides the arrow when it cannot be centered
@@ -125,7 +125,7 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue true
    */
-  hideShiftedArrow?: boolean
+  hideShiftedArrow?: boolean | undefined
 
   /**
    * The sticky behavior on the align axis. `partial` will keep the
@@ -135,33 +135,33 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue "partial"
    */
-  sticky?: 'partial' | 'always'
+  sticky?: 'partial' | 'always' | undefined
 
   /**
    * Whether to hide the content when the trigger becomes fully occluded.
    *
    * @defaultValue false
    */
-  hideWhenDetached?: boolean
+  hideWhenDetached?: boolean | undefined
 
   /**
    *  The type of CSS position property to use.
    */
-  positionStrategy?: 'absolute' | 'fixed'
+  positionStrategy?: 'absolute' | 'fixed' | undefined
 
   /**
    * Strategy to update the position of the floating element on every animation frame.
    *
    * @defaultValue 'optimized'
    */
-  updatePositionStrategy?: 'optimized' | 'always'
+  updatePositionStrategy?: 'optimized' | 'always' | undefined
 
   /**
    * Whether to disable the update position for the content when the layout shifted.
    *
    * @defaultValue false
    */
-  disableUpdateOnLayoutShift?: boolean
+  disableUpdateOnLayoutShift?: boolean | undefined
 
   /**
    * Force content to be position within the viewport.
@@ -170,7 +170,7 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    * @defaultValue false
    */
-  prioritizePosition?: boolean
+  prioritizePosition?: boolean | undefined
 
   /**
    *  The custom element or virtual element that will be set as the reference
@@ -178,19 +178,19 @@ export interface PopperContentProps extends PrimitiveProps {
    *
    *  If provided, it will replace the default anchor element.
    */
-  reference?: ReferenceElement
+  reference?: ReferenceElement | undefined
 
   /**
    * The reading direction of the popper content when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
-  dir?: Direction
+  dir?: Direction | undefined
 }
 
 export interface PopperContentContext {
   placedSide: Ref<Side>
   onArrowChange: (arrow: HTMLElement | undefined) => void
-  arrowX?: Ref<number>
-  arrowY?: Ref<number>
+  arrowX?: Ref<number> | undefined
+  arrowY?: Ref<number> | undefined
   shouldHideArrow: Ref<boolean>
 }
 

--- a/packages/core/src/Popper/PopperContent.vue
+++ b/packages/core/src/Popper/PopperContent.vue
@@ -291,7 +291,7 @@ const computedMiddleware = computed(() => {
     && shift({
       mainAxis: true,
       crossAxis: !!props.prioritizePosition,
-      limiter: props.sticky === 'partial' ? limitShift() : undefined,
+      ...(props.sticky === 'partial' ? { limiter: limitShift() } : {}),
       ...detectOverflowOptions.value,
     }),
     !props.prioritizePosition

--- a/packages/core/src/Popper/utils.ts
+++ b/packages/core/src/Popper/utils.ts
@@ -14,7 +14,7 @@ export function isNotNull<T>(value: T | null): value is T {
 export function transformOrigin(options: {
   arrowWidth: number
   arrowHeight: number
-  dir?: Direction
+  dir?: Direction | undefined
 }): Middleware {
   return {
     name: 'transformOrigin',

--- a/packages/core/src/Presence/Presence.ts
+++ b/packages/core/src/Presence/Presence.ts
@@ -1,4 +1,5 @@
 import type {
+  PropType,
   SlotsType,
   VNode,
 } from 'vue'
@@ -38,7 +39,9 @@ export default defineComponent({
       required: true,
     },
     forceMount: {
-      type: Boolean,
+      // `Boolean` alone widens to `forceMount?: boolean`, which rejects an
+      // explicit `undefined` under `exactOptionalPropertyTypes`.
+      type: Boolean as PropType<boolean | undefined>,
     },
   },
   slots: {} as SlotsType<{

--- a/packages/core/src/Presence/Presence.ts
+++ b/packages/core/src/Presence/Presence.ts
@@ -27,7 +27,7 @@ export interface PresenceProps {
    *
    * @defaultValue false
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 
 export default defineComponent({

--- a/packages/core/src/Primitive/Primitive.ts
+++ b/packages/core/src/Primitive/Primitive.ts
@@ -48,7 +48,7 @@ export const Primitive = defineComponent({
       default: false,
     },
     as: {
-      type: [String, Object] as PropType<AsTag | Component>,
+      type: [String, Object] as PropType<AsTag | Component | undefined>,
       default: 'div',
     },
   },

--- a/packages/core/src/Primitive/Primitive.ts
+++ b/packages/core/src/Primitive/Primitive.ts
@@ -44,7 +44,9 @@ export const Primitive = defineComponent({
   inheritAttrs: false,
   props: {
     asChild: {
-      type: Boolean,
+      // `Boolean` alone widens to `asChild?: boolean`, which rejects an explicit
+      // `undefined` under `exactOptionalPropertyTypes`.
+      type: Boolean as PropType<boolean | undefined>,
       default: false,
     },
     as: {

--- a/packages/core/src/Primitive/Primitive.ts
+++ b/packages/core/src/Primitive/Primitive.ts
@@ -28,12 +28,12 @@ export interface PrimitiveProps {
    *
    * Read our [Composition](https://www.reka-ui.com/docs/guides/composition) guide for more details.
    */
-  asChild?: boolean
+  asChild?: boolean | undefined
   /**
    * The element or component this component should render as. Can be overwritten by `asChild`.
    * @defaultValue "div"
    */
-  as?: AsTag | Component
+  as?: AsTag | Component | undefined
 }
 
 // For self closing tags, don't provide default slots because of hydration issue

--- a/packages/core/src/Progress/ProgressRoot.vue
+++ b/packages/core/src/Progress/ProgressRoot.vue
@@ -12,25 +12,25 @@ export type ProgressRootEmits = {
 
 export interface ProgressRootProps extends PrimitiveProps {
   /** The progress value. Can be bind as `v-model`. */
-  modelValue?: number | null
+  modelValue?: number | null | undefined
   /** The maximum progress value. */
-  max?: number
+  max?: number | undefined
   /**
    * A function to get the accessible label text in a human-readable format.
    *
    *  If not provided, the value label will be read as the numeric value as a percentage of the max value.
    */
-  getValueLabel?: (value: number | null | undefined, max: number) => string | undefined
+  getValueLabel?: ((value: number | null | undefined, max: number) => string | undefined) | undefined
   /**
    * A function to get the accessible value text representing the current value in a human-readable format.
    */
-  getValueText?: (value: number | null | undefined, max: number) => string | undefined
+  getValueText?: ((value: number | null | undefined, max: number) => string | undefined) | undefined
 }
 
 const DEFAULT_MAX = 100
 
 interface ProgressRootContext {
-  modelValue?: Readonly<Ref<ProgressRootProps['modelValue']>>
+  modelValue?: Readonly<Ref<ProgressRootProps['modelValue']>> | undefined
   max: Readonly<Ref<number>>
   progressState: ComputedRef<ProgressState>
 }
@@ -86,10 +86,10 @@ const props = withDefaults(defineProps<ProgressRootProps>(), {
 const emit = defineEmits<ProgressRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 useForwardExpose()

--- a/packages/core/src/RadioGroup/Radio.vue
+++ b/packages/core/src/RadioGroup/Radio.vue
@@ -9,12 +9,12 @@ export type RadioEmits = {
 }
 
 export interface RadioProps extends PrimitiveProps, FormFieldProps {
-  id?: string
+  id?: string | undefined
   /** The value given as data when submitted with a `name`. */
-  value?: AcceptableValue
+  value?: AcceptableValue | undefined
   /** When `true`, prevents the user from interacting with the radio item. */
-  disabled?: boolean
-  checked?: boolean
+  disabled?: boolean | undefined
+  checked?: boolean | undefined
 }
 </script>
 
@@ -38,10 +38,10 @@ const props = withDefaults(defineProps<RadioProps>(), {
 const emits = defineEmits<RadioEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current checked state */
     checked: typeof checked.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const checked = useVModel(props, 'checked', emits, {

--- a/packages/core/src/RadioGroup/Radio.vue
+++ b/packages/core/src/RadioGroup/Radio.vue
@@ -23,6 +23,7 @@ import { useVModel } from '@vueuse/core'
 import { computed, toRefs } from 'vue'
 import { Primitive } from '@/Primitive'
 import { useFormControl, useForwardExpose, useForwardScopeId } from '@/shared'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
 import { handleSelect } from './utils'
 
@@ -32,7 +33,7 @@ defineOptions({
 
 const props = withDefaults(defineProps<RadioProps>(), {
   disabled: false,
-  checked: undefined,
+  checked: UNDEFINED_DEFAULT,
   as: 'button',
 })
 const emits = defineEmits<RadioEmits>()

--- a/packages/core/src/RadioGroup/RadioGroupIndicator.vue
+++ b/packages/core/src/RadioGroup/RadioGroupIndicator.vue
@@ -7,7 +7,7 @@ export interface RadioGroupIndicatorProps extends PrimitiveProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/RadioGroup/RadioGroupItem.vue
+++ b/packages/core/src/RadioGroup/RadioGroupItem.vue
@@ -38,14 +38,14 @@ const props = withDefaults(defineProps<RadioGroupItemProps>(), {
 const emits = defineEmits<RadioGroupItemEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current checked state */
     checked: typeof checked.value
     /** Required state */
     required: typeof required.value
     /** Disabled state */
     disabled: typeof disabled.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { forwardRef, currentElement } = useForwardExpose()

--- a/packages/core/src/RadioGroup/RadioGroupRoot.vue
+++ b/packages/core/src/RadioGroup/RadioGroupRoot.vue
@@ -51,7 +51,6 @@ import { VisuallyHiddenInput } from '@/VisuallyHidden'
 const props = withDefaults(defineProps<RadioGroupRootProps>(), {
   disabled: false,
   required: false,
-  orientation: undefined,
   loop: true,
 })
 

--- a/packages/core/src/RadioGroup/RadioGroupRoot.vue
+++ b/packages/core/src/RadioGroup/RadioGroupRoot.vue
@@ -6,21 +6,21 @@ import { createContext, useDirection, useFormControl, useForwardExpose } from '@
 
 export interface RadioGroupRootProps extends PrimitiveProps, FormFieldProps {
   /** The controlled value of the radio item to check. Can be binded as `v-model`. */
-  modelValue?: AcceptableValue
+  modelValue?: AcceptableValue | undefined
   /**
    * The value of the radio item that should be checked when initially rendered.
    *
    * Use when you do not need to control the state of the radio items.
    */
-  defaultValue?: AcceptableValue
+  defaultValue?: AcceptableValue | undefined
   /** When `true`, prevents the user from interacting with radio items. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** The orientation of the component. */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** When `true`, keyboard navigation will loop from last item to first, and vice versa. */
-  loop?: boolean
+  loop?: boolean | undefined
 }
 export type RadioGroupRootEmits = {
   /** Event handler called when the radio group value changes */
@@ -28,12 +28,12 @@ export type RadioGroupRootEmits = {
 }
 
 interface RadioGroupRootContext {
-  modelValue?: Readonly<Ref<AcceptableValue | undefined>>
+  modelValue?: Readonly<Ref<AcceptableValue | undefined>> | undefined
   changeModelValue: (value?: AcceptableValue) => void
   disabled: Ref<boolean>
   loop: Ref<boolean>
   orientation: Ref<DataOrientation | undefined>
-  name?: string
+  name?: string | undefined
   required: Ref<boolean>
 }
 
@@ -58,10 +58,10 @@ const props = withDefaults(defineProps<RadioGroupRootProps>(), {
 const emits = defineEmits<RadioGroupRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { forwardRef, currentElement } = useForwardExpose()

--- a/packages/core/src/RadioGroup/utils.ts
+++ b/packages/core/src/RadioGroup/utils.ts
@@ -1,7 +1,7 @@
 import type { AcceptableValue } from '@/shared/types'
 import { handleAndDispatchCustomEvent } from '@/shared'
 
-export type SelectEvent = CustomEvent<{ originalEvent: MouseEvent, value?: AcceptableValue }>
+export type SelectEvent = CustomEvent<{ originalEvent: MouseEvent, value?: AcceptableValue | undefined }>
 export const RADIO_SELECT = 'radio.select'
 
 export function handleSelect(event: MouseEvent, value: AcceptableValue | undefined, callback: (event: SelectEvent) => void) {

--- a/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarCellTrigger.vue
@@ -18,7 +18,7 @@ export interface RangeCalendarCellTriggerProps extends PrimitiveProps {
 }
 
 export interface RangeCalendarCellTriggerSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current day */
     dayValue: string
     /** Current disable state */
@@ -44,7 +44,7 @@ export interface RangeCalendarCellTriggerSlot {
     /** Current selection end state */
     selectionEnd: boolean
 
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/RangeCalendar/RangeCalendarHeading.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarHeading.vue
@@ -10,10 +10,10 @@ import { injectRangeCalendarRootContext } from './RangeCalendarRoot.vue'
 
 const props = withDefaults(defineProps<RangeCalendarHeadingProps>(), { as: 'div' })
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current month and year */
     headingValue: string
-  }) => any
+  }) => any) | undefined
 }>()
 const rootContext = injectRangeCalendarRootContext()
 </script>

--- a/packages/core/src/RangeCalendar/RangeCalendarNext.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarNext.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface RangeCalendarNextProps extends PrimitiveProps {
   /** The function to be used for the next page. Overwrites the `nextPage` function set on the `RangeCalendarRoot`. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface RangeCalendarNextSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/RangeCalendar/RangeCalendarPrev.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarPrev.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface RangeCalendarPrevProps extends PrimitiveProps {
   /** The function to be used for the prev page. Overwrites the `prevPage` function set on the `RangeCalendarRoot`. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface RangeCalendarPrevSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
@@ -164,12 +164,7 @@ const props = withDefaults(defineProps<RangeCalendarRootProps>(), {
   disabled: false,
   readonly: false,
   initialFocus: false,
-  placeholder: undefined,
-  isDateDisabled: undefined,
-  isDateUnavailable: undefined,
-  isDateHighlightable: undefined,
   allowNonContiguousRanges: false,
-  maximumDays: undefined,
   disableDaysOutsideCurrentView: false,
 
 })

--- a/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
+++ b/packages/core/src/RangeCalendar/RangeCalendarRoot.vue
@@ -41,8 +41,8 @@ type RangeCalendarRootContext = {
   headingValue: Ref<string>
   isInvalid: Ref<boolean>
   isDateDisabled: Matcher
-  isDateUnavailable?: Matcher
-  isDateHighlightable?: Matcher
+  isDateUnavailable?: Matcher | undefined
+  isDateHighlightable?: Matcher | undefined
   isOutsideVisibleView: (date: DateValue) => boolean
   allowNonContiguousRanges: Ref<boolean>
   highlightedRange: Ref<{ start: DateValue, end: DateValue } | null>
@@ -77,59 +77,59 @@ type RangeCalendarRootContext = {
 
 export interface RangeCalendarRootProps extends PrimitiveProps {
   /** The default placeholder date */
-  defaultPlaceholder?: DateValue
+  defaultPlaceholder?: DateValue | undefined
   /** The default value for the calendar */
-  defaultValue?: DateRange
+  defaultValue?: DateRange | undefined
   /** The controlled selected date range of the calendar. Can be bound as `v-model`. */
-  modelValue?: DateRange | null
+  modelValue?: DateRange | null | undefined
   /** The placeholder date, which is used to determine what month to display when no date is selected. This updates as the user navigates the calendar and can be used to programmatically control the calendar view */
-  placeholder?: DateValue
+  placeholder?: DateValue | undefined
   /** When combined with `isDateUnavailable`, determines whether non-contiguous ranges, i.e. ranges containing unavailable dates, may be selected. */
-  allowNonContiguousRanges?: boolean
+  allowNonContiguousRanges?: boolean | undefined
   /** This property causes the previous and next buttons to navigate by the number of months displayed at once, rather than one month */
-  pagedNavigation?: boolean
+  pagedNavigation?: boolean | undefined
   /** Whether or not to prevent the user from deselecting a date without selecting another date first */
-  preventDeselect?: boolean
+  preventDeselect?: boolean | undefined
   /** The maximum number of days that can be selected in a range */
-  maximumDays?: number
+  maximumDays?: number | undefined
   /** The day of the week to start the calendar on */
-  weekStartsOn?: WeekStartsOn
+  weekStartsOn?: WeekStartsOn | undefined
   /** The format to use for the weekday strings provided via the weekdays slot prop */
-  weekdayFormat?: WeekDayFormat
+  weekdayFormat?: WeekDayFormat | undefined
   /** The accessible label for the calendar */
-  calendarLabel?: string
+  calendarLabel?: string | undefined
   /** Whether or not to always display 6 weeks in the calendar */
-  fixedWeeks?: boolean
+  fixedWeeks?: boolean | undefined
   /** The maximum date that can be selected */
-  maxValue?: DateValue
+  maxValue?: DateValue | undefined
   /** The minimum date that can be selected */
-  minValue?: DateValue
+  minValue?: DateValue | undefined
   /** The locale to use for formatting dates */
-  locale?: string
+  locale?: string | undefined
   /** The number of months to display at once */
-  numberOfMonths?: number
+  numberOfMonths?: number | undefined
   /** Whether or not the calendar is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether or not the calendar is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** If true, the calendar will focus the selected day, today, or the first day of the month depending on what is visible when the calendar is mounted */
-  initialFocus?: boolean
+  initialFocus?: boolean | undefined
   /** A function that returns whether or not a date is disabled */
-  isDateDisabled?: Matcher
+  isDateDisabled?: Matcher | undefined
   /** A function that returns whether or not a date is unavailable */
-  isDateUnavailable?: Matcher
+  isDateUnavailable?: Matcher | undefined
   /** A function that returns whether or not a date is hightable */
-  isDateHighlightable?: Matcher
+  isDateHighlightable?: Matcher | undefined
   /** The reading direction of the calendar when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** A function that returns the next page of the calendar. It receives the current placeholder as an argument inside the component. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** A function that returns the previous page of the calendar. It receives the current placeholder as an argument inside the component. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** Whether or not to disable days outside the current view. */
-  disableDaysOutsideCurrentView?: boolean
+  disableDaysOutsideCurrentView?: boolean | undefined
   /** Which part of the range should be fixed */
-  fixedDate?: 'start' | 'end'
+  fixedDate?: 'start' | 'end' | undefined
 
 }
 
@@ -176,7 +176,7 @@ const props = withDefaults(defineProps<RangeCalendarRootProps>(), {
 const emits = defineEmits<RangeCalendarRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current date of the placeholder */
     date: DateValue
     /** The grid of dates */
@@ -191,7 +191,7 @@ defineSlots<{
     fixedWeeks: boolean
     /** The current date range */
     modelValue: DateRange
-  }) => any
+  }) => any) | undefined
 }>()
 
 const {

--- a/packages/core/src/RangeCalendar/useRangeCalendar.ts
+++ b/packages/core/src/RangeCalendar/useRangeCalendar.ts
@@ -14,11 +14,11 @@ export type UseRangeCalendarProps = {
   end: Ref<DateValue | undefined>
   isDateDisabled: Matcher
   isDateUnavailable: Matcher
-  isDateHighlightable?: Matcher
+  isDateHighlightable?: Matcher | undefined
   focusedValue: Ref<DateValue | undefined>
   allowNonContiguousRanges: Ref<boolean>
   fixedDate: Ref<'start' | 'end' | undefined>
-  maximumDays?: Ref<number | undefined>
+  maximumDays?: Ref<number | undefined> | undefined
 }
 
 export function useRangeCalendarState(props: UseRangeCalendarProps) {

--- a/packages/core/src/Rating/RatingItem.vue
+++ b/packages/core/src/Rating/RatingItem.vue
@@ -22,9 +22,9 @@ export const [injectRatingItemContext, provideRatingItemContext]
 <script setup lang="ts">
 const props = withDefaults(defineProps<RatingItemProps>(), { as: 'label' })
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     steps: number[]
-  }) => any
+  }) => any) | undefined
 }>()
 
 const rootContext = injectRatingRootContext()

--- a/packages/core/src/Rating/RatingRoot.vue
+++ b/packages/core/src/Rating/RatingRoot.vue
@@ -18,17 +18,17 @@ export interface RatingRootProps extends Omit<RadioGroupRootProps, 'modelValue' 
   /**
    * The rating value when initially rendered. Use when you do not need to control the state of the rating.
    */
-  defaultValue?: number
+  defaultValue?: number | undefined
   /** The controlled rating value. Can be bound with `v-model`. */
-  modelValue?: number
+  modelValue?: number | undefined
   /** The number of rating items to render. */
-  length?: number
+  length?: number | undefined
   /** When `true`, clicking the currently selected rating resets the value to `0`. */
-  clearable?: boolean
+  clearable?: boolean | undefined
   /** When `true`, the rating previews the value under the pointer on hover. */
-  hoverable?: boolean
+  hoverable?: boolean | undefined
   /** The granularity each rating item is divided into. */
-  step?: 1 | 0.5 | 0.25 | 0.1
+  step?: 1 | 0.5 | 0.25 | 0.1 | undefined
 }
 export type RatingRootEmits = {
   /** Event handler called when the value changes */
@@ -51,10 +51,10 @@ const props = withDefaults(defineProps<RatingRootProps>(), {
 const emits = defineEmits<RatingRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     modelValue: number | undefined
     items: number[]
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { length, disabled, clearable, hoverable, step } = toRefs(props)

--- a/packages/core/src/RovingFocus/RovingFocusGroup.vue
+++ b/packages/core/src/RovingFocus/RovingFocusGroup.vue
@@ -65,7 +65,6 @@ import { ENTRY_FOCUS, EVENT_OPTIONS, focusFirst } from './utils'
 
 const props = withDefaults(defineProps<RovingFocusGroupProps>(), {
   loop: false,
-  orientation: undefined,
   preventScrollOnEntryFocus: false,
 })
 const emits = defineEmits<RovingFocusGroupEmits>()

--- a/packages/core/src/RovingFocus/RovingFocusGroup.vue
+++ b/packages/core/src/RovingFocus/RovingFocusGroup.vue
@@ -12,28 +12,28 @@ export interface RovingFocusGroupProps extends PrimitiveProps {
    * The orientation of the group.
    * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
    */
-  orientation?: Orientation
+  orientation?: Orientation | undefined
   /**
    * The direction of navigation between items.
    */
-  dir?: Direction
+  dir?: Direction | undefined
   /**
    * Whether keyboard navigation should loop around
    * @defaultValue false
    */
-  loop?: boolean
+  loop?: boolean | undefined
   /** The controlled value of the current stop item. Can be binded as `v-model`. */
-  currentTabStopId?: string | null
+  currentTabStopId?: string | null | undefined
   /**
    * The value of the current stop item.
    *
    * Use when you do not need to control the state of the stop item.
    */
-  defaultCurrentTabStopId?: string
+  defaultCurrentTabStopId?: string | undefined
   /**
    * When `true`, will prevent scrolling to the focus item when focused.
    */
-  preventScrollOnEntryFocus?: boolean
+  preventScrollOnEntryFocus?: boolean | undefined
 }
 
 export type RovingFocusGroupEmits = {

--- a/packages/core/src/RovingFocus/RovingFocusItem.vue
+++ b/packages/core/src/RovingFocus/RovingFocusItem.vue
@@ -2,16 +2,16 @@
 import type { PrimitiveProps } from '@/Primitive'
 
 export interface RovingFocusItemProps extends PrimitiveProps {
-  tabStopId?: string
+  tabStopId?: string | undefined
   /**
    * When `false`, item will not be focusable.
    * @defaultValue `true`
    */
-  focusable?: boolean
+  focusable?: boolean | undefined
   /** When `true`, item will be initially focused. */
-  active?: boolean
+  active?: boolean | undefined
   /** When `true`, shift + arrow key will allow focusing on next/previous item. */
-  allowShiftKey?: boolean
+  allowShiftKey?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/ScrollArea/ScrollAreaRoot.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaRoot.vue
@@ -38,11 +38,11 @@ export interface ScrollAreaRootProps extends PrimitiveProps {
    * `hover` - when the user is scrolling along its corresponding orientation and when the user is hovering over the scroll area.<br>
    * `glimpse` - a hybrid approach that briefly shows scrollbars when the user enters the scroll area, then hides them until further interaction.
    */
-  type?: ScrollType
+  type?: ScrollType | undefined
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** If type is set to either `scroll` or `hover`, this prop determines the length of time, in milliseconds, <br> before the scrollbars are hidden after the user stops interacting with scrollbars. */
-  scrollHideDelay?: number
+  scrollHideDelay?: number | undefined
 }
 </script>
 

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbar.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbar.vue
@@ -5,18 +5,18 @@ import { createContext, useForwardExpose } from '@/shared'
 
 export interface ScrollAreaScrollbarProps extends PrimitiveProps {
   /** The orientation of the scrollbar */
-  orientation?: 'vertical' | 'horizontal'
+  orientation?: 'vertical' | 'horizontal' | undefined
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 
 export interface ScrollAreaScrollbarContext {
   as: Ref<PrimitiveProps['as']>
   orientation: Ref<'vertical' | 'horizontal'>
-  forceMount?: Ref<boolean>
+  forceMount?: Ref<boolean> | undefined
   isHorizontal: Ref<boolean>
   asChild: Ref<boolean>
 }

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbarAuto.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbarAuto.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 export interface ScrollAreaScrollbarAutoProps {
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbarScroll.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbarScroll.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 export interface ScrollAreaScrollbarScrollProps {
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/ScrollArea/ScrollAreaViewport.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaViewport.vue
@@ -7,7 +7,7 @@ export interface ScrollAreaViewportProps extends PrimitiveProps {
   /**
    * Will add `nonce` attribute to the style tag which can be used by Content Security Policy. <br> If omitted, inherits globally from `ConfigProvider`.
    */
-  nonce?: string
+  nonce?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Select/BubbleSelect.vue
+++ b/packages/core/src/Select/BubbleSelect.vue
@@ -4,14 +4,14 @@ import { VisuallyHidden } from '@/VisuallyHidden'
 import { injectSelectRootContext } from './SelectRoot.vue'
 
 interface BubbleSelectProps {
-  autocomplete?: string
-  autofocus?: boolean
-  disabled?: boolean
-  form?: string
-  multiple?: boolean
-  name?: string
-  required?: boolean
-  size?: number
+  autocomplete?: string | undefined
+  autofocus?: boolean | undefined
+  disabled?: boolean | undefined
+  form?: string | undefined
+  multiple?: boolean | undefined
+  name?: string | undefined
+  required?: boolean | undefined
+  size?: number | undefined
   value?: any
 }
 

--- a/packages/core/src/Select/BubbleSelect.vue
+++ b/packages/core/src/Select/BubbleSelect.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { SelectHTMLAttributes } from 'vue'
 import { ref, watch } from 'vue'
 import { VisuallyHidden } from '@/VisuallyHidden'
 import { injectSelectRootContext } from './SelectRoot.vue'
@@ -58,7 +59,7 @@ function handleInput(event: Event) {
   <VisuallyHidden as-child>
     <select
       ref="selectElement"
-      v-bind="props"
+      v-bind="props as SelectHTMLAttributes"
       @input="handleInput"
     >
       <slot />

--- a/packages/core/src/Select/SelectContent.vue
+++ b/packages/core/src/Select/SelectContent.vue
@@ -12,7 +12,7 @@ export interface SelectContentProps extends SelectContentImplProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Select/SelectContentImpl.vue
+++ b/packages/core/src/Select/SelectContentImpl.vue
@@ -18,26 +18,26 @@ import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 import { valueComparator } from './utils'
 
 export interface SelectContentContext {
-  content?: Ref<HTMLElement | undefined>
-  viewport?: Ref<HTMLElement | undefined>
+  content?: Ref<HTMLElement | undefined> | undefined
+  viewport?: Ref<HTMLElement | undefined> | undefined
   onViewportChange: (node: HTMLElement | undefined) => void
   itemRefCallback: (
     node: HTMLElement | undefined,
     value: AcceptableValue,
     disabled: boolean,
   ) => void
-  selectedItem?: Ref<HTMLElement | undefined>
-  onItemLeave?: () => void
+  selectedItem?: Ref<HTMLElement | undefined> | undefined
+  onItemLeave?: (() => void) | undefined
   itemTextRefCallback: (
     node: HTMLElement | undefined,
     value: AcceptableValue,
     disabled: boolean,
   ) => void
-  focusSelectedItem?: () => void
-  selectedItemText?: Ref<HTMLElement | undefined>
-  position?: 'item-aligned' | 'popper'
-  isPositioned?: Ref<boolean>
-  searchRef?: Ref<string>
+  focusSelectedItem?: (() => void) | undefined
+  selectedItemText?: Ref<HTMLElement | undefined> | undefined
+  position?: 'item-aligned' | 'popper' | undefined
+  isPositioned?: Ref<boolean> | undefined
+  searchRef?: Ref<string> | undefined
 }
 
 export const SelectContentDefaultContextValue: SelectContentContext = {
@@ -67,13 +67,13 @@ export interface SelectContentImplProps extends PopperContentProps, DismissableL
    *  `item-aligned (default)` - behaves similarly to a native MacOS menu by positioning content relative to the active item. <br>
    *  `popper` - positions content in the same way as our other primitives, for example `Popover` or `DropdownMenu`.
    */
-  position?: 'item-aligned' | 'popper'
+  position?: 'item-aligned' | 'popper' | undefined
   /**
    * The document.body will be lock, and scrolling will be disabled.
    *
    * @defaultValue true
    */
-  bodyLock?: boolean
+  bodyLock?: boolean | undefined
 }
 
 export const [injectSelectContentContext, provideSelectContentContext]

--- a/packages/core/src/Select/SelectItem.vue
+++ b/packages/core/src/Select/SelectItem.vue
@@ -16,7 +16,7 @@ interface SelectItemContext<T = AcceptableValue> {
 export const [injectSelectItemContext, provideSelectItemContext]
   = createContext<SelectItemContext>('SelectItem')
 
-export type SelectEvent<T> = CustomEvent<{ originalEvent: PointerEvent | KeyboardEvent, value?: T }>
+export type SelectEvent<T> = CustomEvent<{ originalEvent: PointerEvent | KeyboardEvent, value?: T | undefined }>
 
 export type SelectItemEmits<T = AcceptableValue> = {
   /** Event handler called when the selecting item. <br> It can be prevented by calling `event.preventDefault`. */
@@ -27,7 +27,7 @@ export interface SelectItemProps<T = AcceptableValue> extends PrimitiveProps {
   /** The value given as data when submitted with a `name`. */
   value: T
   /** When `true`, prevents the user from interacting with the item. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Optional text used for typeahead purposes.
    *
@@ -35,7 +35,7 @@ export interface SelectItemProps<T = AcceptableValue> extends PrimitiveProps {
    *
    * Use this when the content is complex, or you have non-textual content inside.
    */
-  textValue?: string
+  textValue?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Select/SelectItemAlignedPosition.vue
+++ b/packages/core/src/Select/SelectItemAlignedPosition.vue
@@ -6,8 +6,8 @@ import { useCollection } from '@/Collection'
 import { clamp, createContext, useForwardExpose } from '@/shared'
 
 interface SelectItemAlignedPositionContext {
-  contentWrapper?: Ref<HTMLElement | undefined>
-  shouldExpandOnScrollRef?: Ref<boolean>
+  contentWrapper?: Ref<HTMLElement | undefined> | undefined
+  shouldExpandOnScrollRef?: Ref<boolean> | undefined
   onScrollButtonChange: (node: HTMLElement | undefined) => void
 }
 

--- a/packages/core/src/Select/SelectLabel.vue
+++ b/packages/core/src/Select/SelectLabel.vue
@@ -2,7 +2,7 @@
 import type { PrimitiveProps } from '@/Primitive'
 
 export interface SelectLabelProps extends PrimitiveProps {
-  for?: string
+  for?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Select/SelectRoot.vue
+++ b/packages/core/src/Select/SelectRoot.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { Ref } from 'vue'
+import type { OptionHTMLAttributes, Ref } from 'vue'
 import type { AcceptableValue, Direction, FormFieldProps } from '@/shared/types'
 import { useCollection } from '@/Collection'
 import { createContext, isNullish, useDirection, useFormControl } from '@/shared'
@@ -68,6 +68,7 @@ interface SelectOption { value: any, disabled?: boolean | undefined, textContent
 import { useVModel } from '@vueuse/core'
 import { computed, ref, toRefs } from 'vue'
 import { PopperRoot } from '@/Popper'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import BubbleSelect from './BubbleSelect.vue'
 
 defineOptions({
@@ -75,8 +76,7 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<SelectRootProps<T>>(), {
-  modelValue: undefined,
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   nullableValue: '',
 })
 const emits = defineEmits<SelectRootEmits<T>>()
@@ -222,7 +222,7 @@ provideSelectRootContext({
       <option
         v-for="option in Array.from(optionsSet)"
         :key="option.value ?? ''"
-        v-bind="option"
+        v-bind="option as OptionHTMLAttributes"
       />
     </BubbleSelect>
   </PopperRoot>

--- a/packages/core/src/Select/SelectRoot.vue
+++ b/packages/core/src/Select/SelectRoot.vue
@@ -7,25 +7,25 @@ import { compare, valueComparator } from './utils'
 
 export interface SelectRootProps<T = AcceptableValue> extends FormFieldProps {
   /** The controlled open state of the Select. Can be bind as `v-model:open`. */
-  open?: boolean
+  open?: boolean | undefined
   /** The open state of the select when it is initially rendered. Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
   /** The value of the select when initially rendered. Use when you do not need to control the state of the Select */
-  defaultValue?: T | Array<T>
+  defaultValue?: T | Array<T> | undefined
   /** The controlled value of the Select. Can be bind as `v-model`. */
-  modelValue?: T | Array<T>
+  modelValue?: T | Array<T> | undefined
   /** The value of the hidden native select option when the model value is nullish. */
-  nullableValue?: string
+  nullableValue?: string | undefined
   /** Use this to compare objects by a particular field, or pass your own comparison function for complete control over how objects are compared. */
-  by?: string | ((a: T, b: T) => boolean)
+  by?: string | ((a: T, b: T) => boolean) | undefined
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** Whether multiple options can be selected or not. */
-  multiple?: boolean
+  multiple?: boolean | undefined
   /** Native html input `autocomplete` attribute. */
-  autocomplete?: string
+  autocomplete?: string | undefined
   /** When `true`, prevents the user from interacting with Select */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export type SelectRootEmits<T = AcceptableValue> = {
@@ -45,13 +45,13 @@ export interface SelectRootContext<T> {
   onValueChange: (value: T) => void
   open: Ref<boolean>
   multiple: Ref<boolean>
-  required?: Ref<boolean>
-  by?: string | ((a: T, b: T) => boolean)
+  required?: Ref<boolean> | undefined
+  by?: string | ((a: T, b: T) => boolean) | undefined
   onOpenChange: (open: boolean) => void
   dir: Ref<Direction>
   triggerPointerDownPosRef: Ref<{ x: number, y: number } | null>
   isEmptyModelValue: Ref<boolean>
-  disabled?: Ref<boolean>
+  disabled?: Ref<boolean> | undefined
 
   optionsSet: Ref<Set<SelectOption>>
   onOptionAdd: (option: SelectOption) => void
@@ -61,7 +61,7 @@ export interface SelectRootContext<T> {
 export const [injectSelectRootContext, provideSelectRootContext]
   = createContext<SelectRootContext<AcceptableValue>>('SelectRoot')
 
-interface SelectOption { value: any, disabled?: boolean, textContent: string }
+interface SelectOption { value: any, disabled?: boolean | undefined, textContent: string }
 </script>
 
 <script setup lang="ts" generic="T extends AcceptableValue = AcceptableValue">
@@ -82,12 +82,12 @@ const props = withDefaults(defineProps<SelectRootProps<T>>(), {
 const emits = defineEmits<SelectRootEmits<T>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
     /** Current open state */
     open: typeof open.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { required, disabled, multiple, dir: propDir } = toRefs(props)

--- a/packages/core/src/Select/SelectTrigger.vue
+++ b/packages/core/src/Select/SelectTrigger.vue
@@ -2,7 +2,7 @@
 import { useCollection } from '@/Collection'
 
 export interface SelectTriggerProps extends PopperAnchorProps {
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Select/SelectValue.vue
+++ b/packages/core/src/Select/SelectValue.vue
@@ -5,7 +5,7 @@ import { valueComparator } from './utils'
 
 export interface SelectValueProps extends PrimitiveProps {
   /** The content that will be rendered inside the `SelectValue` when no `value` or `defaultValue` is set. */
-  placeholder?: string
+  placeholder?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Select/SelectViewport.vue
+++ b/packages/core/src/Select/SelectViewport.vue
@@ -7,7 +7,7 @@ export interface SelectViewportProps extends PrimitiveProps {
   /**
    * Will add `nonce` attribute to the style tag which can be used by Content Security Policy. <br> If omitted, inherits globally from `ConfigProvider`.
    */
-  nonce?: string
+  nonce?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Slider/SliderHorizontal.vue
+++ b/packages/core/src/Slider/SliderHorizontal.vue
@@ -7,7 +7,7 @@ import { injectSliderRootContext } from './SliderRoot.vue'
 import { BACK_KEYS, linearScale, provideSliderOrientationContext } from './utils'
 
 interface SliderHorizontalProps extends SliderOrientationPrivateProps {
-  dir?: Direction
+  dir?: Direction | undefined
 }
 
 const props = defineProps<SliderHorizontalProps>()

--- a/packages/core/src/Slider/SliderRoot.vue
+++ b/packages/core/src/Slider/SliderRoot.vue
@@ -9,32 +9,32 @@ type ThumbAlignment = 'contain' | 'overflow'
 
 export interface SliderRootProps extends PrimitiveProps, FormFieldProps {
   /** The value of the slider when initially rendered. Use when you do not need to control the state of the slider. */
-  defaultValue?: number[]
+  defaultValue?: number[] | undefined
   /** The controlled value of the slider. Can be bind as `v-model`. */
-  modelValue?: number[] | null
+  modelValue?: number[] | null | undefined
   /** When `true`, prevents the user from interacting with the slider. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** The orientation of the slider. */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** Whether the slider is visually inverted. */
-  inverted?: boolean
+  inverted?: boolean | undefined
   /** The minimum value for the range. */
-  min?: number
+  min?: number | undefined
   /** The maximum value for the range. */
-  max?: number
+  max?: number | undefined
   /** The stepping interval. */
-  step?: number
+  step?: number | undefined
   /** The minimum permitted steps between multiple thumbs. */
-  minStepsBetweenThumbs?: number
+  minStepsBetweenThumbs?: number | undefined
   /**
    * The alignment of the slider thumb.
    * - `contain`: thumbs will be contained within the bounds of the track.
    * - `overflow`: thumbs will not be bound by the track. No extra offset will be added.
    * @defaultValue 'contain'
    */
-  thumbAlignment?: ThumbAlignment
+  thumbAlignment?: ThumbAlignment | undefined
 }
 
 export type SliderRootEmits = {
@@ -55,7 +55,7 @@ export interface SliderRootContext {
   disabled: Ref<boolean>
   min: Ref<number>
   max: Ref<number>
-  modelValue?: Readonly<Ref<number[] | null | undefined>>
+  modelValue?: Readonly<Ref<number[] | null | undefined>> | undefined
   currentModelValue: ComputedRef<number[]>
   valueIndexToChangeRef: Ref<number>
   thumbElements: Ref<HTMLElement[]>
@@ -93,10 +93,10 @@ const props = withDefaults(defineProps<SliderRootProps>(), {
 const emits = defineEmits<SliderRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current slider values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { min, max, step, minStepsBetweenThumbs, orientation, disabled, thumbAlignment, dir: propDir } = toRefs(props)

--- a/packages/core/src/Splitter/SplitterGroup.vue
+++ b/packages/core/src/Splitter/SplitterGroup.vue
@@ -12,15 +12,15 @@ import {
 
 export interface SplitterGroupProps extends PrimitiveProps {
   /** Group id; falls back to `useId` when not provided. */
-  id?: string | null
+  id?: string | null | undefined
   /** Unique id used to auto-save group arrangement via `localStorage`. */
-  autoSaveId?: string | null
+  autoSaveId?: string | null | undefined
   /** The group orientation of splitter. */
   direction: Direction
   /** Step size when arrow key was pressed. */
-  keyboardResizeBy?: number | null
+  keyboardResizeBy?: number | null | undefined
   /** Custom storage API; defaults to localStorage */
-  storage?: PanelGroupStorage
+  storage?: PanelGroupStorage | undefined
 }
 
 export type SplitterGroupEmits = {
@@ -104,10 +104,10 @@ const props = withDefaults(defineProps<SplitterGroupProps>(), {
 const emits = defineEmits<SplitterGroupEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current size of layout */
     layout: typeof layout.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const debounceMap: {

--- a/packages/core/src/Splitter/SplitterPanel.vue
+++ b/packages/core/src/Splitter/SplitterPanel.vue
@@ -5,21 +5,21 @@ import { PRECISION } from './utils/constants'
 
 export interface SplitterPanelProps extends PrimitiveProps {
   /** The size of panel when it is collapsed; interpreted using `sizeUnit`. */
-  collapsedSize?: number
+  collapsedSize?: number | undefined
   /** Should panel collapse when resized beyond its `minSize`. When `true`, it will be collapsed to `collapsedSize`. */
-  collapsible?: boolean
+  collapsible?: boolean | undefined
   /** Initial size of panel, interpreted using `sizeUnit` (percent by default). */
-  defaultSize?: number
+  defaultSize?: number | undefined
   /** Panel id (unique within group); falls back to `useId` when not provided */
-  id?: string
+  id?: string | undefined
   /** The maximum allowable size of panel, interpreted using `sizeUnit`; defaults to `100` (percent). */
-  maxSize?: number
+  maxSize?: number | undefined
   /** The minimum allowable size of panel, interpreted using `sizeUnit`; defaults to `10` (percent). */
-  minSize?: number
+  minSize?: number | undefined
   /** The order of panel within group; required for groups with conditionally rendered panels */
-  order?: number
+  order?: number | undefined
   /** Unit used for sizing values; `%` by default, or `px` for fixed sizing. */
-  sizeUnit?: '%' | 'px'
+  sizeUnit?: '%' | 'px' | undefined
 }
 
 export type SplitterPanelEmits = {
@@ -39,9 +39,9 @@ export type PanelOnResize = (
 ) => void
 
 export type PanelCallbacks = {
-  onCollapse?: PanelOnCollapse
-  onExpand?: PanelOnExpand
-  onResize?: PanelOnResize
+  onCollapse?: PanelOnCollapse | undefined
+  onExpand?: PanelOnExpand | undefined
+  onResize?: PanelOnResize | undefined
 }
 
 export type PanelConstraints = {
@@ -72,7 +72,7 @@ const props = defineProps<SplitterPanelProps>()
 const emits = defineEmits<SplitterPanelEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Is the panel collapsed */
     isCollapsed: typeof isCollapsed.value
     /** Is the panel expanded */
@@ -83,7 +83,7 @@ defineSlots<{
     expand: typeof expand
     /** Resize panel to the specified percentage (1 - 100). */
     resize: typeof resize
-  }) => any
+  }) => any) | undefined
 }>()
 
 const panelGroupContext = injectPanelGroupContext()

--- a/packages/core/src/Splitter/SplitterResizeHandle.vue
+++ b/packages/core/src/Splitter/SplitterResizeHandle.vue
@@ -6,17 +6,17 @@ import { useWindowSplitterResizeHandlerBehavior } from './utils/composables/useW
 
 export interface SplitterResizeHandleProps extends PrimitiveProps {
   /** Resize handle id (unique within group); falls back to `useId` when not provided */
-  id?: string
+  id?: string | undefined
   /** Allow this much margin when determining resizable handle hit detection */
-  hitAreaMargins?: PointerHitAreaMargins
+  hitAreaMargins?: PointerHitAreaMargins | undefined
   /** Tabindex for the handle */
-  tabindex?: number
+  tabindex?: number | undefined
   /** Disable drag handle */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Will add `nonce` attribute to the style tag which can be used by Content Security Policy. <br> If omitted, inherits globally from `ConfigProvider`.
    */
-  nonce?: string
+  nonce?: string | undefined
 }
 
 export type PanelResizeHandleOnDragging = (isDragging: boolean) => void

--- a/packages/core/src/Splitter/utils/storage.ts
+++ b/packages/core/src/Splitter/utils/storage.ts
@@ -35,7 +35,7 @@ export type PanelConfigurationState = {
   layout: number[]
   sizeUnits?: {
     [panelIndex: number]: 'px' | '%'
-  }
+  } | undefined
 }
 
 export type SerializedPanelGroupState = {

--- a/packages/core/src/Splitter/utils/style.ts
+++ b/packages/core/src/Splitter/utils/style.ts
@@ -102,7 +102,7 @@ export function computePanelFlexBoxStyle({
   dragState: DragState | null
   panelData: PanelData[]
   panelIndex: number
-  precision?: number
+  precision?: number | undefined
 }): CSSProperties {
   const size = layout[panelIndex]
 

--- a/packages/core/src/Stepper/StepperIndicator.vue
+++ b/packages/core/src/Stepper/StepperIndicator.vue
@@ -12,10 +12,10 @@ export interface StepperIndicatorProps extends PrimitiveProps { }
 const props = withDefaults(defineProps<StepperIndicatorProps>(), { as: 'span' })
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current step */
     step: number
-  }) => any
+  }) => any) | undefined
 }>()
 
 const itemContext = injectStepperItemContext()

--- a/packages/core/src/Stepper/StepperItem.vue
+++ b/packages/core/src/Stepper/StepperItem.vue
@@ -24,9 +24,9 @@ export interface StepperItemProps extends PrimitiveProps {
   /** A unique value that associates the stepper item with an index */
   step: number
   /** When `true`, prevents the user from interacting with the step. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Shows whether the step is completed. */
-  completed?: boolean
+  completed?: boolean | undefined
 }
 </script>
 
@@ -37,10 +37,10 @@ const props = withDefaults(defineProps<StepperItemProps>(), {
 })
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current state of the stepper item */
     state: StepperState
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { disabled, step, completed } = toRefs(props)

--- a/packages/core/src/Stepper/StepperRoot.vue
+++ b/packages/core/src/Stepper/StepperRoot.vue
@@ -20,21 +20,21 @@ export interface StepperRootProps extends PrimitiveProps {
   /**
    * The value of the step that should be active when initially rendered. Use when you do not need to control the state of the steps.
    */
-  defaultValue?: number
+  defaultValue?: number | undefined
   /**
    * The orientation the steps are laid out.
    * Mainly so arrow navigation is done accordingly (left & right vs. up & down).
    * @defaultValue horizontal
    */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
   /**
    * The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
-  dir?: Direction
+  dir?: Direction | undefined
   /** The controlled value of the step to activate. Can be bound as `v-model`. */
-  modelValue?: number
+  modelValue?: number | undefined
   /** Whether or not the steps must be completed in order. */
-  linear?: boolean
+  linear?: boolean | undefined
 }
 export type StepperRootEmits = {
   /** Event handler called when the value changes */
@@ -54,7 +54,7 @@ const props = withDefaults(defineProps<StepperRootProps>(), {
 const emits = defineEmits<StepperRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current step */
     modelValue: number | undefined
     /** Total number of steps */
@@ -77,7 +77,7 @@ defineSlots<{
     hasNext: () => boolean
     /** Whether or not there is a previous step */
     hasPrev: () => boolean
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { dir: propDir, orientation: propOrientation, linear } = toRefs(props)

--- a/packages/core/src/Switch/SwitchRoot.vue
+++ b/packages/core/src/Switch/SwitchRoot.vue
@@ -6,22 +6,22 @@ import { createContext, useFormControl, useForwardExpose, useForwardScopeId } fr
 
 export interface SwitchRootProps<T = boolean> extends PrimitiveProps, FormFieldProps {
   /** The state of the switch when it is initially rendered. Use when you do not need to control its state. */
-  defaultValue?: T
+  defaultValue?: T | undefined
   /** The controlled state of the switch. Can be bind as `v-model`. */
-  modelValue?: T | null
+  modelValue?: T | null | undefined
   /** When `true`, prevents the user from interacting with the switch. */
-  disabled?: boolean
-  id?: string
+  disabled?: boolean | undefined
+  id?: string | undefined
   /** The value given as data when submitted with a `name`. */
-  value?: string
+  value?: string | undefined
   /**
    * The value used when the switch is on. Defaults to `true`.
    */
-  trueValue?: T
+  trueValue?: T | undefined
   /**
    * The value used when the switch is off. Defaults to `false`.
    */
-  falseValue?: T
+  falseValue?: T | undefined
 }
 
 export type SwitchRootEmits<T = boolean> = {
@@ -59,12 +59,12 @@ const props = withDefaults(defineProps<SwitchRootProps<T>>(), {
 const emit = defineEmits<SwitchRootEmits<T>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current value */
     modelValue: typeof modelValue.value
     /** Whether the switch is checked */
     checked: typeof checked.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { disabled } = toRefs(props)

--- a/packages/core/src/Switch/SwitchRoot.vue
+++ b/packages/core/src/Switch/SwitchRoot.vue
@@ -51,10 +51,9 @@ defineOptions({
 
 const props = withDefaults(defineProps<SwitchRootProps<T>>(), {
   as: 'button',
-  modelValue: undefined,
   value: 'on',
-  trueValue: (() => true) as unknown as undefined,
-  falseValue: (() => false) as unknown as undefined,
+  trueValue: (() => true) as unknown as never,
+  falseValue: (() => false) as unknown as never,
 })
 const emit = defineEmits<SwitchRootEmits<T>>()
 

--- a/packages/core/src/Tabs/TabsContent.vue
+++ b/packages/core/src/Tabs/TabsContent.vue
@@ -10,7 +10,7 @@ export interface TabsContentProps extends PrimitiveProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Tabs/TabsList.vue
+++ b/packages/core/src/Tabs/TabsList.vue
@@ -4,7 +4,7 @@ import { useForwardExpose } from '@/shared'
 
 export interface TabsListProps extends PrimitiveProps {
   /** When `true`, keyboard navigation will loop from last tab to first, and vice versa. */
-  loop?: boolean
+  loop?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Tabs/TabsRoot.vue
+++ b/packages/core/src/Tabs/TabsRoot.vue
@@ -23,30 +23,30 @@ export interface TabsRootProps<T extends StringOrNumber = StringOrNumber> extend
   /**
    * The value of the tab that should be active when initially rendered. Use when you do not need to control the state of the tabs
    */
-  defaultValue?: T
+  defaultValue?: T | undefined
   /**
    * The orientation the tabs are laid out.
    * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
    * @defaultValue horizontal
    */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
   /**
    * The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
-  dir?: Direction
+  dir?: Direction | undefined
   /**
    * Whether a tab is activated automatically (on focus) or manually (on click).
    * @defaultValue automatic
    */
-  activationMode?: 'automatic' | 'manual'
+  activationMode?: 'automatic' | 'manual' | undefined
   /** The controlled value of the tab to activate. Can be bind as `v-model`. */
-  modelValue?: T
+  modelValue?: T | undefined
   /**
    * When `true`, the element will be unmounted on closed state.
    *
    * @defaultValue `true`
    */
-  unmountOnHide?: boolean
+  unmountOnHide?: boolean | undefined
 }
 export type TabsRootEmits<T extends StringOrNumber = StringOrNumber> = {
   /** Event handler called when the value changes */
@@ -69,10 +69,10 @@ const props = withDefaults(defineProps<TabsRootProps<T>>(), {
 const emits = defineEmits<TabsRootEmits<T>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { orientation, unmountOnHide, dir: propDir } = toRefs(props)

--- a/packages/core/src/Tabs/TabsTrigger.vue
+++ b/packages/core/src/Tabs/TabsTrigger.vue
@@ -7,7 +7,7 @@ export interface TabsTriggerProps extends PrimitiveProps {
   /** A unique value that associates the trigger with a content. */
   value: StringOrNumber
   /** When `true`, prevents the user from interacting with the tab. */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/TagsInput/TagsInputInput.vue
+++ b/packages/core/src/TagsInput/TagsInputInput.vue
@@ -4,11 +4,11 @@ import { useComposing, useForwardExpose } from '@/shared'
 
 export interface TagsInputInputProps extends PrimitiveProps {
   /** The placeholder character to use for empty tags input. */
-  placeholder?: string
+  placeholder?: string | undefined
   /** Focus on element when mounted. */
-  autoFocus?: boolean
+  autoFocus?: boolean | undefined
   /** Maximum number of character allowed. */
-  maxLength?: number
+  maxLength?: number | undefined
 }
 </script>
 

--- a/packages/core/src/TagsInput/TagsInputItem.vue
+++ b/packages/core/src/TagsInput/TagsInputItem.vue
@@ -10,14 +10,14 @@ export interface TagsInputItemProps extends PrimitiveProps {
   /** Value associated with the tags */
   value: AcceptableInputValue
   /** When `true`, prevents the user from interacting with the tags input. */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export interface TagsInputItemContext {
   value: Ref<AcceptableInputValue>
   displayValue: ComputedRef<string>
   isSelected: Ref<boolean>
-  disabled?: Ref<boolean>
+  disabled?: Ref<boolean> | undefined
   textId: string
 }
 

--- a/packages/core/src/TagsInput/TagsInputRoot.vue
+++ b/packages/core/src/TagsInput/TagsInputRoot.vue
@@ -9,30 +9,30 @@ export type AcceptableInputValue = string | number | bigint | Record<string, any
 
 export interface TagsInputRootProps<T = AcceptableInputValue> extends PrimitiveProps, FormFieldProps {
   /** The controlled value of the tags input. Can be bind as `v-model`. */
-  modelValue?: Array<T> | null
+  modelValue?: Array<T> | null | undefined
   /** The value of the tags that should be added. Use when you do not need to control the state of the tags input */
-  defaultValue?: Array<T>
+  defaultValue?: Array<T> | undefined
   /** When `true`, allow adding tags on paste. Work in conjunction with delimiter prop. */
-  addOnPaste?: boolean
+  addOnPaste?: boolean | undefined
   /** When `true` allow adding tags on tab keydown */
-  addOnTab?: boolean
+  addOnTab?: boolean | undefined
   /** When `true` allow adding tags blur input */
-  addOnBlur?: boolean
+  addOnBlur?: boolean | undefined
   /** When `true`, allow duplicated tags. */
-  duplicate?: boolean
+  duplicate?: boolean | undefined
   /** When `true`, prevents the user from interacting with the tags input. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** The character or regular expression to trigger the addition of a new tag. Also used to split tags for `@paste` event */
-  delimiter?: string | RegExp
+  delimiter?: string | RegExp | undefined
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** Maximum number of tags. */
-  max?: number
-  id?: string
+  max?: number | undefined
+  id?: string | undefined
   /** Convert the input value to the desired type. Mandatory when using objects as values and using `TagsInputInput` */
-  convertValue?: (value: string) => T
+  convertValue?: ((value: string) => T) | undefined
   /** Display the value of the tag. Useful when you want to apply modifications to the value like adding a suffix or when using object as values */
-  displayValue?: (value: T) => string
+  displayValue?: ((value: T) => string) | undefined
 }
 
 export type TagsInputRootEmits<T = AcceptableInputValue> = {
@@ -84,10 +84,10 @@ const props = withDefaults(defineProps<TagsInputRootProps<T>>(), {
 const emits = defineEmits<TagsInputRootEmits<T>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current input values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { addOnPaste, disabled, delimiter, max, id, dir: propDir, addOnBlur, addOnTab } = toRefs(props)

--- a/packages/core/src/Teleport/Teleport.vue
+++ b/packages/core/src/Teleport/Teleport.vue
@@ -5,25 +5,25 @@ export interface TeleportProps {
    *
    * {@link https://vuejs.org/guide/built-ins/teleport.html#basic-usage}
    */
-  to?: string | HTMLElement
+  to?: string | HTMLElement | undefined
   /**
    * Disable teleport and render the component inline
    *
    * {@link https://vuejs.org/guide/built-ins/teleport.html#disabling-teleport}
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Defer the resolving of a Teleport target until other parts of the
    * application have mounted (requires Vue 3.5.0+)
    *
    * {@link https://vuejs.org/guide/built-ins/teleport.html#deferred-teleport}
    */
-  defer?: boolean
+  defer?: boolean | undefined
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/TimeField/TimeFieldRoot.vue
+++ b/packages/core/src/TimeField/TimeFieldRoot.vue
@@ -102,11 +102,8 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<TimeFieldRootProps>(), {
-  defaultValue: undefined,
   disabled: false,
   readonly: false,
-  placeholder: undefined,
-  isDateUnavailable: undefined,
   stepSnapping: false,
 })
 const emits = defineEmits<TimeFieldRootEmits>()

--- a/packages/core/src/TimeField/TimeFieldRoot.vue
+++ b/packages/core/src/TimeField/TimeFieldRoot.vue
@@ -39,37 +39,37 @@ type TimeFieldRootContext = {
 
 export interface TimeFieldRootProps extends PrimitiveProps, FormFieldProps {
   /** The default value for the calendar */
-  defaultValue?: TimeValue
+  defaultValue?: TimeValue | undefined
   /** The default placeholder date */
-  defaultPlaceholder?: TimeValue
+  defaultPlaceholder?: TimeValue | undefined
   /** The placeholder date, which is used to determine what time to display when no time is selected. This updates as the user navigates the field */
-  placeholder?: TimeValue
+  placeholder?: TimeValue | undefined
   /** The controlled checked state of the field. Can be bound as `v-model`. */
-  modelValue?: TimeValue | null
+  modelValue?: TimeValue | null | undefined
   /** The hour cycle used for formatting times. Defaults to the local preference */
-  hourCycle?: HourCycle
+  hourCycle?: HourCycle | undefined
   /** The stepping interval for the time fields. Defaults to `1`. */
-  step?: DateStep
+  step?: DateStep | undefined
   /** Whether to enforce snapping the value to the nearest step increment after input. Defaults to `false`. */
-  stepSnapping?: boolean
+  stepSnapping?: boolean | undefined
   /** The granularity to use for formatting times. Defaults to minute if a Time is provided, otherwise defaults to minute. The field will render segments for each part of the date up to and including the specified granularity */
-  granularity?: 'hour' | 'minute' | 'second'
+  granularity?: 'hour' | 'minute' | 'second' | undefined
   /** Whether or not to hide the time zone segment of the field */
-  hideTimeZone?: boolean
+  hideTimeZone?: boolean | undefined
   /** The maximum date that can be selected */
-  maxValue?: TimeValue
+  maxValue?: TimeValue | undefined
   /** The minimum date that can be selected */
-  minValue?: TimeValue
+  minValue?: TimeValue | undefined
   /** The locale to use for formatting dates */
-  locale?: string
+  locale?: string | undefined
   /** Whether or not the time field is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether or not the time field is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** Id of the element */
-  id?: string
+  id?: string | undefined
   /** The reading direction of the time field when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
 }
 
 export type TimeFieldRootEmits = {
@@ -111,14 +111,14 @@ const props = withDefaults(defineProps<TimeFieldRootProps>(), {
 })
 const emits = defineEmits<TimeFieldRootEmits>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current time of the field */
     modelValue: TimeValue | undefined
     /** The time field segment contents */
     segments: { part: SegmentPart, value: string }[]
     /** Value if the input is invalid */
     isInvalid: boolean
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { disabled, readonly, granularity, defaultValue, minValue, maxValue, stepSnapping, dir: propDir, locale: propLocale } = toRefs(props)

--- a/packages/core/src/TimeRangeField/TimeRangeFieldRoot.vue
+++ b/packages/core/src/TimeRangeField/TimeRangeFieldRoot.vue
@@ -46,37 +46,37 @@ type TimeRangeFieldRootContext = {
 
 export interface TimeRangeFieldRootProps extends PrimitiveProps, FormFieldProps {
   /** The default value for the field */
-  defaultValue?: TimeRange
+  defaultValue?: TimeRange | undefined
   /** The default placeholder time */
-  defaultPlaceholder?: TimeValue
+  defaultPlaceholder?: TimeValue | undefined
   /** The placeholder time, which is used to determine what time to display when no time is selected. This updates as the user navigates the field */
-  placeholder?: TimeValue
+  placeholder?: TimeValue | undefined
   /** The controlled checked state of the field. Can be bound as `v-model`. */
-  modelValue?: TimeRange | null
+  modelValue?: TimeRange | null | undefined
   /** The hour cycle used for formatting times. Defaults to the local preference */
-  hourCycle?: HourCycle
+  hourCycle?: HourCycle | undefined
   /** The stepping interval for the time fields. Defaults to `1`. */
-  step?: DateStep
+  step?: DateStep | undefined
   /** The granularity to use for formatting times. Defaults to minute. The field will render segments for each part of the time up to and including the specified granularity */
-  granularity?: 'hour' | 'minute' | 'second'
+  granularity?: 'hour' | 'minute' | 'second' | undefined
   /** Whether or not to hide the time zone segment of the field */
-  hideTimeZone?: boolean
+  hideTimeZone?: boolean | undefined
   /** The maximum time that can be selected */
-  maxValue?: TimeValue
+  maxValue?: TimeValue | undefined
   /** The minimum time that can be selected */
-  minValue?: TimeValue
+  minValue?: TimeValue | undefined
   /** The locale to use for formatting times */
-  locale?: string
+  locale?: string | undefined
   /** Whether or not the time field is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether or not the time field is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** Id of the element */
-  id?: string
+  id?: string | undefined
   /** The reading direction of the time field when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** A function that returns whether or not a time is unavailable */
-  isTimeUnavailable?: Matcher
+  isTimeUnavailable?: Matcher | undefined
 }
 
 export type TimeRangeFieldRootEmits = {
@@ -117,14 +117,14 @@ const props = withDefaults(defineProps<TimeRangeFieldRootProps>(), {
 })
 const emits = defineEmits<TimeRangeFieldRootEmits>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current time of the field */
     modelValue: TimeRange | undefined
     /** The time field segment contents */
     segments: { start: { part: SegmentPart, value: string }[], end: { part: SegmentPart, value: string }[] }
     /** Value if the input is invalid */
     isInvalid: boolean
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { disabled, readonly, granularity, defaultValue, minValue, maxValue, dir: propDir, locale: propLocale, isTimeUnavailable: propsIsTimeUnavailable } = toRefs(props)

--- a/packages/core/src/TimeRangeField/TimeRangeFieldRoot.vue
+++ b/packages/core/src/TimeRangeField/TimeRangeFieldRoot.vue
@@ -109,11 +109,8 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<TimeRangeFieldRootProps>(), {
-  defaultValue: undefined,
   disabled: false,
   readonly: false,
-  placeholder: undefined,
-  isTimeUnavailable: undefined,
 })
 const emits = defineEmits<TimeRangeFieldRootEmits>()
 defineSlots<{

--- a/packages/core/src/Toast/ToastAnnounceExclude.vue
+++ b/packages/core/src/Toast/ToastAnnounceExclude.vue
@@ -2,7 +2,7 @@
 import type { PrimitiveProps } from '@/Primitive'
 
 export interface ToastAnnounceExcludeProps extends PrimitiveProps {
-  altText?: string
+  altText?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Toast/ToastProvider.vue
+++ b/packages/core/src/Toast/ToastProvider.vue
@@ -25,27 +25,27 @@ export interface ToastProviderProps {
    * associate the interruption with a toast.
    * @defaultValue 'Notification'
    */
-  label?: string
+  label?: string | undefined
   /**
    * Time in milliseconds that each toast should remain visible for.
    * @defaultValue 5000
    */
-  duration?: number
+  duration?: number | undefined
   /**
    * Whether to disable the ability to swipe to close the toast.
    * @defaultValue false
    */
-  disableSwipe?: boolean
+  disableSwipe?: boolean | undefined
   /**
    * Direction of pointer swipe that should close the toast.
    * @defaultValue 'right'
    */
-  swipeDirection?: SwipeDirection
+  swipeDirection?: SwipeDirection | undefined
   /**
    * Distance in pixels that the swipe must pass before a close is triggered.
    * @defaultValue 50
    */
-  swipeThreshold?: number
+  swipeThreshold?: number | undefined
 }
 
 export const [injectToastProviderContext, provideToastProviderContext]

--- a/packages/core/src/Toast/ToastRoot.vue
+++ b/packages/core/src/Toast/ToastRoot.vue
@@ -10,12 +10,12 @@ export type ToastRootEmits = Omit<ToastRootImplEmits, 'close'> & {
 
 export interface ToastRootProps extends ToastRootImplProps {
   /** The open state of the dialog when it is initially rendered. Use when you do not need to control its open state. */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
   /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 
@@ -34,14 +34,14 @@ const props = withDefaults(defineProps<ToastRootProps>(), {
 const emits = defineEmits<ToastRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
     /** Remaining time (in ms) */
     remaining: number
     /** Total time the toast will remain visible for (in ms) */
     duration: number
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { forwardRef } = useForwardExpose()

--- a/packages/core/src/Toast/ToastRoot.vue
+++ b/packages/core/src/Toast/ToastRoot.vue
@@ -22,11 +22,12 @@ export interface ToastRootProps extends ToastRootImplProps {
 <script setup lang="ts">
 import { useVModel } from '@vueuse/core'
 import { Presence } from '@/Presence'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import ToastRootImpl from './ToastRootImpl.vue'
 
 const props = withDefaults(defineProps<ToastRootProps>(), {
   type: 'foreground',
-  open: undefined,
+  open: UNDEFINED_DEFAULT,
   defaultOpen: true,
   as: 'li',
 })

--- a/packages/core/src/Toast/ToastRootImpl.vue
+++ b/packages/core/src/Toast/ToastRootImpl.vue
@@ -29,16 +29,16 @@ export interface ToastRootImplProps extends PrimitiveProps {
    *
    * For toasts that are the result of a user action, choose `foreground`. Toasts generated from background tasks should use `background`.
    */
-  type?: 'foreground' | 'background'
+  type?: 'foreground' | 'background' | undefined
   /**
    * The controlled open state of the dialog. Can be bind as `v-model:open`.
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Time in milliseconds that toast should remain visible for. Overrides value
    * given to `ToastProvider`.
    */
-  duration?: number
+  duration?: number | undefined
 }
 
 export const [injectToastRootContext, provideToastRootContext]

--- a/packages/core/src/Toast/ToastViewport.vue
+++ b/packages/core/src/Toast/ToastViewport.vue
@@ -9,14 +9,14 @@ export interface ToastViewportProps extends PrimitiveProps {
    * The keys to use as the keyboard shortcut that will move focus to the toast viewport.
    * @defaultValue ['F8']
    */
-  hotkey?: string[]
+  hotkey?: string[] | undefined
   /**
    * An author-localized label for the toast viewport to provide context for screen reader users
    * when navigating page landmarks. The available `{hotkey}` placeholder will be replaced for you.
    * Alternatively, you can pass in a custom function to generate the label.
    * @defaultValue 'Notifications ({hotkey})'
    */
-  label?: string | ((hotkey: string) => string)
+  label?: string | ((hotkey: string) => string) | undefined
 }
 </script>
 

--- a/packages/core/src/Toggle/Toggle.vue
+++ b/packages/core/src/Toggle/Toggle.vue
@@ -16,15 +16,15 @@ export interface ToggleProps extends PrimitiveProps, FormFieldProps {
   /**
    * The pressed state of the toggle when it is initially rendered. Use when you do not need to control its open state.
    */
-  defaultValue?: boolean
+  defaultValue?: boolean | undefined
   /**
    * The controlled pressed state of the toggle. Can be bind as `v-model`.
    */
-  modelValue?: boolean | null
+  modelValue?: boolean | null | undefined
   /**
    * When `true`, prevents the user from interacting with the toggle.
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 
@@ -47,7 +47,7 @@ const props = withDefaults(defineProps<ToggleProps>(), {
 const emits = defineEmits<ToggleEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current value */
     modelValue: typeof modelValue.value
     /** Current state */
@@ -56,7 +56,7 @@ defineSlots<{
     pressed: typeof modelValue.value
     /** Current disabled state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { forwardRef, currentElement } = useForwardExpose()

--- a/packages/core/src/Toggle/Toggle.vue
+++ b/packages/core/src/Toggle/Toggle.vue
@@ -33,13 +33,14 @@ import type { Ref } from 'vue'
 import { useVModel } from '@vueuse/core'
 import { computed } from 'vue'
 import { Primitive } from '@/Primitive'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 
 defineOptions({
   inheritAttrs: false,
 })
 
 const props = withDefaults(defineProps<ToggleProps>(), {
-  modelValue: undefined,
+  modelValue: UNDEFINED_DEFAULT,
   disabled: false,
   as: 'button',
 })

--- a/packages/core/src/ToggleGroup/ToggleGroupRoot.vue
+++ b/packages/core/src/ToggleGroup/ToggleGroupRoot.vue
@@ -8,15 +8,15 @@ import VisuallyHiddenInput from '@/VisuallyHidden/VisuallyHiddenInput.vue'
 export interface ToggleGroupRootProps<T = AcceptableValue | AcceptableValue[]>
   extends PrimitiveProps, FormFieldProps, SingleOrMultipleProps<T> {
   /** When `false`, navigating through the items using arrow keys will be disabled. */
-  rovingFocus?: boolean
+  rovingFocus?: boolean | undefined
   /** When `true`, prevents the user from interacting with the toggle group and all its items. */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** The orientation of the component, which determines how focus moves: `horizontal` for left/right arrows and `vertical` for up/down arrows. */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** When `loop` and `rovingFocus` is `true`, keyboard navigation will loop from last item to first, and vice versa. */
-  loop?: boolean
+  loop?: boolean | undefined
 }
 export type ToggleGroupRootEmits = {
   /** Event handler called when the value changes. */
@@ -27,11 +27,11 @@ interface ToggleGroupRootContext {
   isSingle: ComputedRef<boolean>
   modelValue: Ref<AcceptableValue | AcceptableValue[] | undefined>
   changeModelValue: (value: AcceptableValue) => void
-  dir?: Ref<Direction>
-  orientation?: DataOrientation
+  dir?: Ref<Direction> | undefined
+  orientation?: DataOrientation | undefined
   loop: Ref<boolean>
   rovingFocus: Ref<boolean>
-  disabled?: Ref<boolean>
+  disabled?: Ref<boolean> | undefined
 }
 
 export const [injectToggleGroupRootContext, provideToggleGroupRootContext]
@@ -52,10 +52,10 @@ const props = withDefaults(defineProps<ToggleGroupRootProps>(), {
 const emits = defineEmits<ToggleGroupRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current toggle values */
     modelValue: typeof modelValue.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { loop, rovingFocus, disabled, dir: propDir } = toRefs(props)

--- a/packages/core/src/Toolbar/ToolbarButton.vue
+++ b/packages/core/src/Toolbar/ToolbarButton.vue
@@ -3,7 +3,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import { useForwardExpose } from '@/shared'
 
 export interface ToolbarButtonProps extends PrimitiveProps {
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Toolbar/ToolbarRoot.vue
+++ b/packages/core/src/Toolbar/ToolbarRoot.vue
@@ -6,11 +6,11 @@ import { createContext, useDirection, useForwardExpose } from '@/shared'
 
 export interface ToolbarRootProps extends PrimitiveProps {
   /** The orientation of the toolbar */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
   /** The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** When `true`, keyboard navigation will loop from last tab to first, and vice versa. */
-  loop?: boolean
+  loop?: boolean | undefined
 }
 
 export interface ToolbarRootContext {

--- a/packages/core/src/Tooltip/TooltipArrow.vue
+++ b/packages/core/src/Tooltip/TooltipArrow.vue
@@ -8,14 +8,14 @@ export interface TooltipArrowProps extends PrimitiveProps {
    *
    * @defaultValue 10
    */
-  width?: number
+  width?: number | undefined
 
   /**
    * The height of the arrow in pixels.
    *
    * @defaultValue 5
    */
-  height?: number
+  height?: number | undefined
 }
 </script>
 

--- a/packages/core/src/Tooltip/TooltipContent.vue
+++ b/packages/core/src/Tooltip/TooltipContent.vue
@@ -8,7 +8,7 @@ export interface TooltipContentProps extends TooltipContentImplProps {
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
-  forceMount?: boolean
+  forceMount?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/Tooltip/TooltipContentImpl.vue
+++ b/packages/core/src/Tooltip/TooltipContentImpl.vue
@@ -37,7 +37,7 @@ export interface TooltipContentImplProps
    *
    * @defaultValue String
    */
-  ariaLabel?: string
+  ariaLabel?: string | undefined
 }
 </script>
 

--- a/packages/core/src/Tooltip/TooltipContentImpl.vue
+++ b/packages/core/src/Tooltip/TooltipContentImpl.vue
@@ -46,14 +46,15 @@ import { useEventListener } from '@vueuse/core'
 import { computed, onMounted } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { PopperContent } from '@/Popper'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import { VisuallyHidden } from '@/VisuallyHidden'
 import { injectTooltipRootContext } from './TooltipRoot.vue'
 import { TOOLTIP_OPEN } from './utils'
 
 const props = withDefaults(defineProps<TooltipContentImplProps>(), {
-  avoidCollisions: undefined,
-  asChild: undefined,
-  hideWhenDetached: undefined,
+  avoidCollisions: UNDEFINED_DEFAULT,
+  asChild: UNDEFINED_DEFAULT,
+  hideWhenDetached: UNDEFINED_DEFAULT,
 })
 const emits = defineEmits<TooltipContentImplEmits>()
 

--- a/packages/core/src/Tooltip/TooltipProvider.vue
+++ b/packages/core/src/Tooltip/TooltipProvider.vue
@@ -24,27 +24,27 @@ export interface TooltipProviderProps {
    * The duration from when the pointer enters the trigger until the tooltip gets opened.
    * @defaultValue 700
    */
-  delayDuration?: number
+  delayDuration?: number | undefined
   /**
    * How much time a user has to enter another trigger without incurring a delay again.
    * @defaultValue 300
    */
-  skipDelayDuration?: number
+  skipDelayDuration?: number | undefined
   /**
    * When `true`, trying to hover the content will result in the tooltip closing as the pointer leaves the trigger.
    * @defaultValue false
    */
-  disableHoverableContent?: boolean
+  disableHoverableContent?: boolean | undefined
   /**
    * When `true`, clicking on trigger will not close the content.
    * @defaultValue false
    */
-  disableClosingTrigger?: boolean
+  disableClosingTrigger?: boolean | undefined
   /**
    * When `true`, disable tooltip
    * @defaultValue false
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Prevent the tooltip from opening if the focus did not come from
    * the keyboard by matching against the `:focus-visible` selector.
@@ -52,11 +52,11 @@ export interface TooltipProviderProps {
    * browser tabs or closing a dialog.
    * @defaultValue false
    */
-  ignoreNonKeyboardFocus?: boolean
+  ignoreNonKeyboardFocus?: boolean | undefined
   /**
    * Default settings that will be used by all tooltip components.
    */
-  content?: TooltipContentProps
+  content?: TooltipContentProps | undefined
 }
 </script>
 

--- a/packages/core/src/Tooltip/TooltipRoot.vue
+++ b/packages/core/src/Tooltip/TooltipRoot.vue
@@ -7,34 +7,34 @@ export interface TooltipRootProps {
    * The open state of the tooltip when it is initially rendered.
    * Use when you do not need to control its open state.
    */
-  defaultOpen?: boolean
+  defaultOpen?: boolean | undefined
   /**
    * The controlled open state of the tooltip.
    */
-  open?: boolean
+  open?: boolean | undefined
   /**
    * Override the duration given to the `Provider` to customise
    * the open delay for a specific tooltip.
    *
    * @defaultValue 700
    */
-  delayDuration?: number
+  delayDuration?: number | undefined
   /**
    * Prevents Tooltip.Content from remaining open when hovering.
    * Disabling this has accessibility consequences. Inherits
    * from Tooltip.Provider.
    */
-  disableHoverableContent?: boolean
+  disableHoverableContent?: boolean | undefined
   /**
    * When `true`, clicking on trigger will not close the content.
    * @defaultValue false
    */
-  disableClosingTrigger?: boolean
+  disableClosingTrigger?: boolean | undefined
   /**
    * When `true`, disable tooltip
    * @defaultValue false
    */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /**
    * Prevent the tooltip from opening if the focus did not come from
    * the keyboard by matching against the `:focus-visible` selector.
@@ -42,7 +42,7 @@ export interface TooltipRootProps {
    * browser tabs or closing a dialog.
    * @defaultValue false
    */
-  ignoreNonKeyboardFocus?: boolean
+  ignoreNonKeyboardFocus?: boolean | undefined
 }
 
 export type TooltipRootEmits = {
@@ -90,10 +90,10 @@ const props = withDefaults(defineProps<TooltipRootProps>(), {
 const emit = defineEmits<TooltipRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current open state */
     open: typeof open.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 useForwardExpose()

--- a/packages/core/src/Tooltip/TooltipRoot.vue
+++ b/packages/core/src/Tooltip/TooltipRoot.vue
@@ -74,17 +74,17 @@ export const [injectTooltipRootContext, provideTooltipRootContext]
 import { useTimeoutFn, useVModel } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 import { PopperRoot } from '@/Popper'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import { injectTooltipProviderContext } from './TooltipProvider.vue'
 import { TOOLTIP_OPEN } from './utils'
 
 const props = withDefaults(defineProps<TooltipRootProps>(), {
   defaultOpen: false,
-  open: undefined,
-  delayDuration: undefined,
-  disableHoverableContent: undefined,
-  disableClosingTrigger: undefined,
-  disabled: undefined,
-  ignoreNonKeyboardFocus: undefined,
+  open: UNDEFINED_DEFAULT,
+  disableHoverableContent: UNDEFINED_DEFAULT,
+  disableClosingTrigger: UNDEFINED_DEFAULT,
+  disabled: UNDEFINED_DEFAULT,
+  ignoreNonKeyboardFocus: UNDEFINED_DEFAULT,
 })
 
 const emit = defineEmits<TooltipRootEmits>()

--- a/packages/core/src/Tree/TreeItem.vue
+++ b/packages/core/src/Tree/TreeItem.vue
@@ -5,11 +5,11 @@ export interface TreeItemProps<T> extends PrimitiveProps {
   /** Level of depth */
   level: number
   /** When `true`, prevents the user from interacting with the item. */
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
-export type SelectEvent<T> = CustomEvent<{ originalEvent: PointerEvent | KeyboardEvent, value?: T, isExpanded: boolean, isSelected: boolean }>
-export type ToggleEvent<T> = CustomEvent<{ originalEvent: PointerEvent | KeyboardEvent, value?: T, isExpanded: boolean, isSelected: boolean }>
+export type SelectEvent<T> = CustomEvent<{ originalEvent: PointerEvent | KeyboardEvent, value?: T | undefined, isExpanded: boolean, isSelected: boolean }>
+export type ToggleEvent<T> = CustomEvent<{ originalEvent: PointerEvent | KeyboardEvent, value?: T | undefined, isExpanded: boolean, isSelected: boolean }>
 
 export type TreeItemEmits<T> = {
   /** Event handler called when the selecting item. <br> It can be prevented by calling `event.preventDefault`. */
@@ -43,14 +43,14 @@ const props = withDefaults(defineProps<TreeItemProps<T>>(), {
 const emits = defineEmits<TreeItemEmits<T>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     isExpanded: boolean
     isSelected: boolean
     isIndeterminate: boolean | undefined
     isDisabled: boolean
     handleToggle: () => void
     handleSelect: () => void
-  }) => any
+  }) => any) | undefined
 }>()
 const rootContext = injectTreeRootContext()
 const { getItems } = useCollection()

--- a/packages/core/src/Tree/TreeRoot.vue
+++ b/packages/core/src/Tree/TreeRoot.vue
@@ -5,31 +5,31 @@ import { flatten } from './utils'
 
 export interface TreeRootProps<T = Record<string, any>, U extends Record<string, any> = Record<string, any>, M extends boolean = false> extends PrimitiveProps {
   /** The controlled value of the tree. Can be binded with `v-model`. */
-  modelValue?: M extends true ? U[] : U
+  modelValue?: (M extends true ? U[] : U) | undefined
   /** The value of the tree when initially rendered. Use when you do not need to control the state of the tree */
-  defaultValue?: M extends true ? U[] : U
+  defaultValue?: (M extends true ? U[] : U) | undefined
   /** List of items */
-  items?: T[]
+  items?: T[] | undefined
   /** The controlled value of the expanded item. Can be binded with `v-model`. */
-  expanded?: string[]
+  expanded?: string[] | undefined
   /** The value of the expanded tree when initially rendered. Use when you do not need to control the state of the expanded tree */
-  defaultExpanded?: string[]
+  defaultExpanded?: string[] | undefined
   /** This function is passed the index of each item and should return a unique key for that item */
   getKey: (val: T) => string
   /** This function is passed the index of each item and should return a list of children for that item */
-  getChildren?: (val: T) => T[] | undefined
+  getChildren?: ((val: T) => T[] | undefined) | undefined
   /** How multiple selection should behave in the collection. */
-  selectionBehavior?: 'toggle' | 'replace'
+  selectionBehavior?: 'toggle' | 'replace' | undefined
   /** Whether multiple options can be selected or not.  */
-  multiple?: M | boolean
+  multiple?: M | boolean | undefined
   /** The reading direction of the listbox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** When `true`, prevents the user from interacting with tree  */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** When `true`, selecting parent will select the descendants. Requires `multiple` to be `true`. */
-  propagateSelect?: boolean
+  propagateSelect?: boolean | undefined
   /** When `true`, selecting children will update the parent state. Requires `multiple` to be `true`. */
-  bubbleSelect?: boolean
+  bubbleSelect?: boolean | undefined
 }
 
 export type TreeRootEmits<T = Record<string, any>, M extends boolean = false> = {
@@ -64,7 +64,7 @@ export type FlattenedItem<T> = {
   value: T
   level: number
   hasChildren: boolean
-  parentItem?: T
+  parentItem?: T | undefined
   bind: {
     value: T
     level: number
@@ -93,11 +93,11 @@ const props = withDefaults(defineProps<TreeRootProps<T, U, M>>(), {
 const emits = defineEmits<TreeRootEmits<U, M>>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     flattenItems: FlattenedItem<T>[]
     modelValue: M extends true ? U[] : U
     expanded: typeof expanded.value
-  }) => any
+  }) => any) | undefined
 }>()
 
 const { items, multiple, disabled, propagateSelect, dir: propDir, bubbleSelect } = toRefs(props)

--- a/packages/core/src/Tree/TreeVirtualizer.vue
+++ b/packages/core/src/Tree/TreeVirtualizer.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
 export interface TreeVirtualizerProps {
   /** Number of items rendered outside the visible area */
-  overscan?: number
+  overscan?: number | undefined
   /** Estimated size (in px) of each item */
-  estimateSize?: number | ((index: number) => number)
+  estimateSize?: number | ((index: number) => number) | undefined
   /** Text content for each item to achieve type-ahead feature */
-  textContent?: (item: Record<string, any>) => string
+  textContent?: ((item: Record<string, any>) => string) | undefined
 }
 </script>
 
@@ -25,11 +25,11 @@ import { injectTreeRootContext } from './TreeRoot.vue'
 const props = defineProps<TreeVirtualizerProps>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     item: FlattenedItem<Record<string, any>>
     virtualizer: Virtualizer<Element | Window, Element>
     virtualItem: VirtualItem
-  }) => any
+  }) => any) | undefined
 }>()
 
 const slots = useSlots()

--- a/packages/core/src/Viewport/Viewport.vue
+++ b/packages/core/src/Viewport/Viewport.vue
@@ -8,7 +8,7 @@ export interface ViewportProps extends PrimitiveProps {
   /**
    * Will add `nonce` attribute to the style tag which can be used by Content Security Policy. <br> If omitted, inherits globally from `ConfigProvider`.
    */
-  nonce?: string
+  nonce?: string | undefined
 }
 </script>
 

--- a/packages/core/src/VisuallyHidden/VisuallyHidden.vue
+++ b/packages/core/src/VisuallyHidden/VisuallyHidden.vue
@@ -2,7 +2,7 @@
 import type { PrimitiveProps } from '@/Primitive'
 
 export interface VisuallyHiddenProps extends PrimitiveProps {
-  feature?: 'focusable' | 'fully-hidden'
+  feature?: 'focusable' | 'fully-hidden' | undefined
 }
 </script>
 

--- a/packages/core/src/VisuallyHidden/VisuallyHiddenInput.vue
+++ b/packages/core/src/VisuallyHidden/VisuallyHiddenInput.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts" generic="T">
 import type { VisuallyHiddenInputBubbleProps } from './VisuallyHiddenInputBubble.vue'
 import { computed } from 'vue'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import VisuallyHiddenInputBubble from './VisuallyHiddenInputBubble.vue'
 
 defineOptions({
@@ -9,7 +10,7 @@ defineOptions({
 
 const props = withDefaults(defineProps<VisuallyHiddenInputBubbleProps<T>>(), {
   feature: 'fully-hidden',
-  checked: undefined,
+  checked: UNDEFINED_DEFAULT,
 })
 
 const isFormArrayEmptyAndRequired = computed(() =>

--- a/packages/core/src/VisuallyHidden/VisuallyHiddenInputBubble.vue
+++ b/packages/core/src/VisuallyHidden/VisuallyHiddenInputBubble.vue
@@ -2,10 +2,10 @@
 export interface VisuallyHiddenInputBubbleProps<T> {
   name: string
   value: T
-  checked?: boolean
-  required?: boolean
-  disabled?: boolean
-  feature?: VisuallyHiddenProps['feature']
+  checked?: boolean | undefined
+  required?: boolean | undefined
+  disabled?: boolean | undefined
+  feature?: VisuallyHiddenProps['feature'] | undefined
 }
 </script>
 

--- a/packages/core/src/VisuallyHidden/VisuallyHiddenInputBubble.vue
+++ b/packages/core/src/VisuallyHidden/VisuallyHiddenInputBubble.vue
@@ -13,6 +13,7 @@ export interface VisuallyHiddenInputBubbleProps<T> {
 import type { VisuallyHiddenProps } from './VisuallyHidden.vue'
 import { computed, watch } from 'vue'
 import { usePrimitiveElement } from '@/Primitive'
+import { UNDEFINED_DEFAULT } from '@/shared/propDefaults'
 import VisuallyHidden from './VisuallyHidden.vue'
 
 defineOptions({
@@ -21,7 +22,7 @@ defineOptions({
 
 const props = withDefaults(defineProps<VisuallyHiddenInputBubbleProps<T>>(), {
   feature: 'fully-hidden',
-  checked: undefined,
+  checked: UNDEFINED_DEFAULT,
 })
 
 const { primitiveElement, currentElement } = usePrimitiveElement()

--- a/packages/core/src/YearPicker/YearPickerCellTrigger.vue
+++ b/packages/core/src/YearPicker/YearPickerCellTrigger.vue
@@ -12,7 +12,7 @@ export interface YearPickerCellTriggerProps extends PrimitiveProps {
 }
 
 export interface YearPickerCellTriggerSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current year value */
     yearValue: string
     /** Current disable state */
@@ -23,7 +23,7 @@ export interface YearPickerCellTriggerSlot {
     today: boolean
     /** Current unavailable state */
     unavailable: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/YearPicker/YearPickerHeading.vue
+++ b/packages/core/src/YearPicker/YearPickerHeading.vue
@@ -11,10 +11,10 @@ import { injectYearPickerRootContext } from './YearPickerRoot.vue'
 const props = withDefaults(defineProps<YearPickerHeadingProps>(), { as: 'div' })
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current year range heading */
     headingValue: string
-  }) => any
+  }) => any) | undefined
 }>()
 
 const rootContext = injectYearPickerRootContext()

--- a/packages/core/src/YearPicker/YearPickerNext.vue
+++ b/packages/core/src/YearPicker/YearPickerNext.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface YearPickerNextProps extends PrimitiveProps {
   /** The function to be used for the next page. Overwrites the `nextPage` function set on the `YearPickerRoot`. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface YearPickerNextSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/YearPicker/YearPickerPrev.vue
+++ b/packages/core/src/YearPicker/YearPickerPrev.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface YearPickerPrevProps extends PrimitiveProps {
   /** The function to be used for the prev page. Overwrites the `prevPage` function set on the `YearPickerRoot`. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface YearPickerPrevSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/YearPicker/YearPickerRoot.vue
+++ b/packages/core/src/YearPicker/YearPickerRoot.vue
@@ -29,7 +29,7 @@ type YearPickerRootContext = {
   isInvalid: Ref<boolean>
   isYearDisabled: Matcher
   isYearSelected: Matcher
-  isYearUnavailable?: Matcher
+  isYearUnavailable?: Matcher | undefined
   prevPage: (prevPageFunc?: (date: DateValue) => DateValue) => void
   nextPage: (nextPageFunc?: (date: DateValue) => DateValue) => void
   isNextButtonDisabled: (nextPageFunc?: (date: DateValue) => DateValue) => boolean
@@ -43,43 +43,43 @@ type YearPickerRootContext = {
 
 export interface YearPickerRootProps extends PrimitiveProps {
   /** The default value for the year picker */
-  defaultValue?: DateValue
+  defaultValue?: DateValue | undefined
   /** The default placeholder date */
-  defaultPlaceholder?: DateValue
+  defaultPlaceholder?: DateValue | undefined
   /** The placeholder date, which is used to determine what year range to display when no date is selected */
-  placeholder?: DateValue
+  placeholder?: DateValue | undefined
   /** Whether or not to prevent the user from deselecting a date without selecting another date first */
-  preventDeselect?: boolean
+  preventDeselect?: boolean | undefined
   /** The accessible label for the year picker */
-  calendarLabel?: string
+  calendarLabel?: string | undefined
   /** The maximum date that can be selected */
-  maxValue?: DateValue
+  maxValue?: DateValue | undefined
   /** The minimum date that can be selected */
-  minValue?: DateValue
+  minValue?: DateValue | undefined
   /** The locale to use for formatting dates */
-  locale?: string
+  locale?: string | undefined
   /** Whether the year picker is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether the year picker is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** If true, the year picker will focus the selected year, today, or the first year of the range on mount */
-  initialFocus?: boolean
+  initialFocus?: boolean | undefined
   /** A function that returns whether or not a year is disabled */
-  isYearDisabled?: Matcher
+  isYearDisabled?: Matcher | undefined
   /** A function that returns whether or not a year is unavailable */
-  isYearUnavailable?: Matcher
+  isYearUnavailable?: Matcher | undefined
   /** The reading direction of the calendar when applicable. If omitted, inherits globally from `ConfigProvider` or assumes LTR. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** A function that returns the next page of the year picker. Receives the current placeholder as an argument. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** A function that returns the previous page of the year picker. Receives the current placeholder as an argument. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** The controlled selected year value of the year picker. Can be bound as `v-model`. */
-  modelValue?: DateValue | DateValue[] | null
+  modelValue?: DateValue | DateValue[] | null | undefined
   /** Whether multiple years can be selected */
-  multiple?: boolean
+  multiple?: boolean | undefined
   /** Number of years to display per page */
-  yearsPerPage?: number
+  yearsPerPage?: number | undefined
 }
 
 export type YearPickerRootEmits = {
@@ -113,7 +113,7 @@ const props = withDefaults(defineProps<YearPickerRootProps>(), {
 })
 const emits = defineEmits<YearPickerRootEmits>()
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current date of the placeholder */
     date: DateValue
     /** The grid of years */
@@ -122,7 +122,7 @@ defineSlots<{
     locale: string
     /** The current selected value */
     modelValue: DateValue | DateValue[] | undefined
-  }) => any
+  }) => any) | undefined
 }>()
 
 const {

--- a/packages/core/src/YearPicker/YearPickerRoot.vue
+++ b/packages/core/src/YearPicker/YearPickerRoot.vue
@@ -99,16 +99,12 @@ import { onMounted, toRefs, watch } from 'vue'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
 
 const props = withDefaults(defineProps<YearPickerRootProps>(), {
-  defaultValue: undefined,
   as: 'div',
   preventDeselect: false,
   multiple: false,
   disabled: false,
   readonly: false,
   initialFocus: false,
-  placeholder: undefined,
-  isYearDisabled: undefined,
-  isYearUnavailable: undefined,
   yearsPerPage: 12,
 })
 const emits = defineEmits<YearPickerRootEmits>()

--- a/packages/core/src/YearPicker/useYearPicker.ts
+++ b/packages/core/src/YearPicker/useYearPicker.ts
@@ -14,8 +14,8 @@ export type UseYearPickerProps = {
   maxValue: Ref<DateValue | undefined>
   disabled: Ref<boolean>
   yearsPerPage: Ref<number>
-  isYearDisabled?: Matcher | Ref<Matcher | undefined>
-  isYearUnavailable?: Matcher | Ref<Matcher | undefined>
+  isYearDisabled?: Matcher | Ref<Matcher | undefined> | undefined
+  isYearUnavailable?: Matcher | Ref<Matcher | undefined> | undefined
   calendarLabel: Ref<string | undefined>
   nextPage: Ref<((placeholder: DateValue) => DateValue) | undefined>
   prevPage: Ref<((placeholder: DateValue) => DateValue) | undefined>

--- a/packages/core/src/YearRangePicker/YearRangePickerCellTrigger.vue
+++ b/packages/core/src/YearRangePicker/YearRangePickerCellTrigger.vue
@@ -12,7 +12,7 @@ export interface YearRangePickerCellTriggerProps extends PrimitiveProps {
 }
 
 export interface YearRangePickerCellTriggerSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current year value */
     yearValue: string
     /** Current disable state */
@@ -33,7 +33,7 @@ export interface YearRangePickerCellTriggerSlot {
     selectionStart: boolean
     /** Current selection end state */
     selectionEnd: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/YearRangePicker/YearRangePickerHeading.vue
+++ b/packages/core/src/YearRangePicker/YearRangePickerHeading.vue
@@ -11,10 +11,10 @@ import { injectYearRangePickerRootContext } from './YearRangePickerRoot.vue'
 const props = withDefaults(defineProps<YearRangePickerHeadingProps>(), { as: 'div' })
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** Current year range heading */
     headingValue: string
-  }) => any
+  }) => any) | undefined
 }>()
 
 const rootContext = injectYearRangePickerRootContext()

--- a/packages/core/src/YearRangePicker/YearRangePickerNext.vue
+++ b/packages/core/src/YearRangePicker/YearRangePickerNext.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface YearRangePickerNextProps extends PrimitiveProps {
   /** The function to be used for the next page. Overwrites the `nextPage` function set on the Root. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface YearRangePickerNextSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/YearRangePicker/YearRangePickerPrev.vue
+++ b/packages/core/src/YearRangePicker/YearRangePickerPrev.vue
@@ -4,14 +4,14 @@ import type { PrimitiveProps } from '@/Primitive'
 
 export interface YearRangePickerPrevProps extends PrimitiveProps {
   /** The function to be used for the prev page. Overwrites the `prevPage` function set on the Root. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
 }
 
 export interface YearRangePickerPrevSlot {
-  default?: (props: {
+  default?: ((props: {
     /** Current disable state */
     disabled: boolean
-  }) => any
+  }) => any) | undefined
 }
 </script>
 

--- a/packages/core/src/YearRangePicker/YearRangePickerRoot.vue
+++ b/packages/core/src/YearRangePicker/YearRangePickerRoot.vue
@@ -123,11 +123,7 @@ const props = withDefaults(defineProps<YearRangePickerRootProps>(), {
   disabled: false,
   readonly: false,
   initialFocus: false,
-  placeholder: undefined,
-  isYearDisabled: undefined,
-  isYearUnavailable: undefined,
   allowNonContiguousRanges: false,
-  maximumYears: undefined,
   yearsPerPage: 12,
 })
 const emits = defineEmits<YearRangePickerRootEmits>()

--- a/packages/core/src/YearRangePicker/YearRangePickerRoot.vue
+++ b/packages/core/src/YearRangePicker/YearRangePickerRoot.vue
@@ -30,7 +30,7 @@ type YearRangePickerRootContext = {
   headingId: string
   isInvalid: Ref<boolean>
   isYearDisabled: Matcher
-  isYearUnavailable?: Matcher
+  isYearUnavailable?: Matcher | undefined
   allowNonContiguousRanges: Ref<boolean>
   highlightedRange: Ref<{ start: DateValue, end: DateValue } | null>
   focusedValue: Ref<DateValue | undefined>
@@ -55,47 +55,47 @@ type YearRangePickerRootContext = {
 
 export interface YearRangePickerRootProps extends PrimitiveProps {
   /** The default placeholder date */
-  defaultPlaceholder?: DateValue
+  defaultPlaceholder?: DateValue | undefined
   /** The default value for the calendar */
-  defaultValue?: DateRange
+  defaultValue?: DateRange | undefined
   /** The controlled selected year range of the year range picker. Can be bound as `v-model`. */
-  modelValue?: DateRange | null
+  modelValue?: DateRange | null | undefined
   /** The placeholder date, which is used to determine what year range to display when no date is selected. */
-  placeholder?: DateValue
+  placeholder?: DateValue | undefined
   /** When combined with `isYearUnavailable`, determines whether non-contiguous ranges may be selected. */
-  allowNonContiguousRanges?: boolean
+  allowNonContiguousRanges?: boolean | undefined
   /** Whether or not to prevent the user from deselecting a date without selecting another date first */
-  preventDeselect?: boolean
+  preventDeselect?: boolean | undefined
   /** The maximum number of years that can be selected in a range */
-  maximumYears?: number
+  maximumYears?: number | undefined
   /** The accessible label for the calendar */
-  calendarLabel?: string
+  calendarLabel?: string | undefined
   /** The maximum date that can be selected */
-  maxValue?: DateValue
+  maxValue?: DateValue | undefined
   /** The minimum date that can be selected */
-  minValue?: DateValue
+  minValue?: DateValue | undefined
   /** The locale to use for formatting dates */
-  locale?: string
+  locale?: string | undefined
   /** Whether or not the calendar is disabled */
-  disabled?: boolean
+  disabled?: boolean | undefined
   /** Whether or not the calendar is readonly */
-  readonly?: boolean
+  readonly?: boolean | undefined
   /** If true, the calendar will focus the selected year on mount */
-  initialFocus?: boolean
+  initialFocus?: boolean | undefined
   /** A function that returns whether or not a year is disabled */
-  isYearDisabled?: Matcher
+  isYearDisabled?: Matcher | undefined
   /** A function that returns whether or not a year is unavailable */
-  isYearUnavailable?: Matcher
+  isYearUnavailable?: Matcher | undefined
   /** The reading direction of the calendar when applicable. */
-  dir?: Direction
+  dir?: Direction | undefined
   /** A function that returns the next page of the calendar. */
-  nextPage?: (placeholder: DateValue) => DateValue
+  nextPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** A function that returns the previous page of the calendar. */
-  prevPage?: (placeholder: DateValue) => DateValue
+  prevPage?: ((placeholder: DateValue) => DateValue) | undefined
   /** Which part of the range should be fixed */
-  fixedDate?: 'start' | 'end'
+  fixedDate?: 'start' | 'end' | undefined
   /** Number of years to display per page */
-  yearsPerPage?: number
+  yearsPerPage?: number | undefined
 }
 
 export type YearRangePickerRootEmits = {
@@ -133,7 +133,7 @@ const props = withDefaults(defineProps<YearRangePickerRootProps>(), {
 const emits = defineEmits<YearRangePickerRootEmits>()
 
 defineSlots<{
-  default?: (props: {
+  default?: ((props: {
     /** The current date of the placeholder */
     date: DateValue
     /** The grid of years */
@@ -142,7 +142,7 @@ defineSlots<{
     locale: string
     /** The current date range */
     modelValue: DateRange
-  }) => any
+  }) => any) | undefined
 }>()
 
 const {

--- a/packages/core/src/YearRangePicker/useRangeYearPicker.ts
+++ b/packages/core/src/YearRangePicker/useRangeYearPicker.ts
@@ -12,7 +12,7 @@ export type UseRangeYearPickerProps = {
   focusedValue: Ref<DateValue | undefined>
   allowNonContiguousRanges: Ref<boolean>
   fixedDate: Ref<'start' | 'end' | undefined>
-  maximumYears?: Ref<number | undefined>
+  maximumYears?: Ref<number | undefined> | undefined
 }
 
 export function useRangeYearPickerState(props: UseRangeYearPickerProps) {

--- a/packages/core/src/date/calendar.ts
+++ b/packages/core/src/date/calendar.ts
@@ -103,16 +103,16 @@ export function createMonth(props: CreateMonthProps): Grid<DateValue> {
 
 type SetMonthProps = CreateMonthProps & {
   numberOfMonths: number | undefined
-  currentMonths?: Grid<DateValue>[]
+  currentMonths?: Grid<DateValue>[] | undefined
 }
 
 type SetYearProps = CreateSelectProps & {
-  numberOfMonths?: number
-  pagedNavigation?: boolean
+  numberOfMonths?: number | undefined
+  pagedNavigation?: boolean | undefined
 }
 
 type SetDecadeProps = CreateSelectProps & {
-  startIndex?: number
+  startIndex?: number | undefined
   endIndex: number
 }
 
@@ -201,7 +201,7 @@ export function createMonthGrid(props: CreateSelectProps): Grid<DateValue> {
  * Creates a 3x4 grid of years (decade-aligned).
  * The grid starts from the decade that contains the given date.
  */
-export function createYearGrid(props: CreateSelectProps & { yearsPerPage?: number, decadeAligned?: boolean }): Grid<DateValue> {
+export function createYearGrid(props: CreateSelectProps & { yearsPerPage?: number | undefined, decadeAligned?: boolean | undefined }): Grid<DateValue> {
   const { dateObj, yearsPerPage = 12, decadeAligned = true } = props
 
   let startYear: number

--- a/packages/core/src/exactOptionalPropertyTypes.test-d.ts
+++ b/packages/core/src/exactOptionalPropertyTypes.test-d.ts
@@ -1,0 +1,76 @@
+/**
+ * Type-level regression guard for `exactOptionalPropertyTypes`.
+ *
+ * Consumers compiling with the flag on cannot pass an explicit `undefined` into
+ * an optional property whose type omits it, so
+ * `<AccordionRoot :model-value="maybeUndefined" />` stops type-checking as soon
+ * as one prop is declared `modelValue?: string` instead of
+ * `modelValue?: string | undefined`.
+ *
+ * The assertion below walks the props of every component exported from the
+ * package entry and fails `pnpm type-check` with the offending component/prop
+ * pairs, so a new component cannot silently regress the guarantee. Exports that
+ * are not components are covered by the `reka/add-undef-to-optional` ESLint
+ * rule, which requires the same of every optional property in the repository.
+ *
+ * This file is checked by `vue-tsc`; it is never executed and never published.
+ */
+import type { AllowedComponentProps, ComponentCustomProps, VNodeProps } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
+import type * as Reka from './index'
+
+/**
+ * Props that are not ours to fix:
+ * - `key`, `class`, `ref`, … come from `@vue/runtime-core` and are declared
+ *   there without `| undefined`.
+ * - `on*` props are generated from `defineEmits()` by Vue's `EmitsToProps`,
+ *   which likewise drops `undefined`; declaring the emits differently cannot
+ *   change it.
+ */
+type IgnoredProps = keyof VNodeProps | keyof AllowedComponentProps | keyof ComponentCustomProps | `on${string}`
+
+/** Keys of `T` that the caller may omit. */
+type OptionalKeys<T> = {
+  [K in keyof T]-?: object extends Pick<T, K> ? K : never
+}[keyof T]
+
+/**
+ * Optional keys of `T` that reject an explicit `undefined` — `never` for a type
+ * whose optional properties are all declared `prop?: T | undefined`.
+ */
+type PropsRejectingUndefined<T, Keys extends keyof T = Exclude<OptionalKeys<T>, IgnoredProps>> = {
+  [K in Keys]-?: { [P in K]: undefined } extends Pick<T, K> ? never : K
+}[Keys]
+
+/**
+ * Drops the `Record<string, any>` index signature `ComponentProps` adds for
+ * generic components, which would otherwise swallow every declared key.
+ */
+type KnownKeys<T> = {
+  [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K]
+}
+
+/**
+ * Props of every component exported from `src/index.ts`, keyed by export name.
+ * Components are the PascalCase exports; `injectFooContext` / `useFoo` helpers
+ * are filtered out.
+ */
+type ExportedComponentProps = {
+  [K in keyof typeof Reka as K extends Capitalize<K & string> ? K : never]:
+  KnownKeys<ComponentProps<(typeof Reka)[K]>>
+}
+
+/** The components that still declare an optional prop without `| undefined`. */
+type Offenders = {
+  [K in keyof ExportedComponentProps as PropsRejectingUndefined<ExportedComponentProps[K]> extends never
+    ? never
+    : K]: PropsRejectingUndefined<ExportedComponentProps[K]>
+}
+
+type Assert<T extends true> = T
+
+type NoOffenders<T> = keyof T extends never
+  ? true
+  : { 'optional props must be declared `prop?: T | undefined`': { [K in keyof T]: T[K] } }
+
+export type _OptionalPropsAcceptUndefined = Assert<NoOffenders<Offenders>>

--- a/packages/core/src/exactOptionalPropertyTypes.test-d.vue
+++ b/packages/core/src/exactOptionalPropertyTypes.test-d.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+/**
+ * Consumer-side regression guard for `exactOptionalPropertyTypes`.
+ *
+ * `exactOptionalPropertyTypes.test-d.ts` checks the exported prop types; this
+ * file checks what a downstream app actually writes — binding a value that may
+ * be `undefined` into a prop, and `v-model`-ing a ref that may hold
+ * `undefined`. Both fail to compile as soon as a prop stops accepting an
+ * explicit `undefined`, and templates exercise Vue's own prop resolution
+ * (`withDefaults`, generics, emits) rather than the declared interface alone.
+ *
+ * This file is checked by `vue-tsc`; it is never rendered and never published.
+ */
+import { ref } from 'vue'
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionRoot,
+  ComboboxRoot,
+  DialogContent,
+  DialogRoot,
+  Presence,
+  Primitive,
+  SliderRoot,
+  TooltipContent,
+  TooltipRoot,
+} from './index'
+
+const maybeBoolean = ref<boolean | undefined>()
+const maybeString = ref<string | undefined>()
+const maybeStrings = ref<string[] | undefined>()
+const maybeNumbers = ref<number[] | undefined>()
+const maybeElement = ref<HTMLElement | undefined>()
+</script>
+
+<template>
+  <AccordionRoot
+    v-model="maybeString"
+    :collapsible="maybeBoolean"
+    :disabled="maybeBoolean"
+    :default-value="maybeString"
+  >
+    <AccordionItem
+      value="item"
+      :disabled="maybeBoolean"
+    >
+      <AccordionContent :force-mount="maybeBoolean" />
+    </AccordionItem>
+  </AccordionRoot>
+
+  <ComboboxRoot
+    v-model="maybeStrings"
+    :open="maybeBoolean"
+    :disabled="maybeBoolean"
+  />
+
+  <DialogRoot
+    v-model:open="maybeBoolean"
+    :modal="maybeBoolean"
+  >
+    <DialogContent
+      :force-mount="maybeBoolean"
+      :trap-focus="maybeBoolean"
+    />
+  </DialogRoot>
+
+  <SliderRoot
+    v-model="maybeNumbers"
+    :disabled="maybeBoolean"
+    :min="undefined"
+  />
+
+  <TooltipRoot
+    :open="maybeBoolean"
+    :disabled="maybeBoolean"
+  >
+    <TooltipContent
+      :force-mount="maybeBoolean"
+      :collision-boundary="maybeElement"
+    />
+  </TooltipRoot>
+
+  <Presence
+    :present="true"
+    :force-mount="maybeBoolean"
+  />
+
+  <Primitive
+    :as-child="maybeBoolean"
+    :as="maybeString"
+  />
+</template>

--- a/packages/core/src/shared/component/Arrow.vue
+++ b/packages/core/src/shared/component/Arrow.vue
@@ -8,19 +8,19 @@ export interface ArrowProps extends PrimitiveProps {
    *
    * @defaultValue 10
    */
-  width?: number
+  width?: number | undefined
   /**
    * The height of the arrow in pixels.
    *
    * @defaultValue 5
    */
-  height?: number
+  height?: number | undefined
   /**
    * When `true`, render the rounded version of arrow. Do not work with `as`/`asChild`
    *
    * @defaultValue false
    */
-  rounded?: boolean
+  rounded?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/shared/component/BaseSeparator.vue
+++ b/packages/core/src/shared/component/BaseSeparator.vue
@@ -8,12 +8,12 @@ export interface BaseSeparatorProps extends PrimitiveProps {
    *
    * Either `vertical` or `horizontal`. Defaults to `horizontal`.
    */
-  orientation?: DataOrientation
+  orientation?: DataOrientation | undefined
   /**
    * Whether or not the component is purely decorative. <br>When `true`, accessibility-related attributes
    * are updated so that that the rendered element is removed from the accessibility tree.
    */
-  decorative?: boolean
+  decorative?: boolean | undefined
 }
 </script>
 

--- a/packages/core/src/shared/date/comparators.ts
+++ b/packages/core/src/shared/date/comparators.ts
@@ -13,8 +13,8 @@ export type TimeGranularity = 'hour' | 'minute' | 'second'
 type GetDefaultDateProps = {
   defaultValue?: DateValue | DateValue[] | undefined
   defaultPlaceholder?: DateValue | undefined
-  granularity?: Granularity
-  locale?: string
+  granularity?: Granularity | undefined
+  locale?: string | undefined
 }
 
 /**

--- a/packages/core/src/shared/date/parser.ts
+++ b/packages/core/src/shared/date/parser.ts
@@ -85,7 +85,7 @@ type SharedContentProps = {
   formatter: Formatter
   hideTimeZone: boolean
   hourCycle: HourCycle
-  isTimeValue?: boolean
+  isTimeValue?: boolean | undefined
 }
 
 type CreateContentObjProps = SharedContentProps & {

--- a/packages/core/src/shared/date/types.ts
+++ b/packages/core/src/shared/date/types.ts
@@ -15,13 +15,13 @@ export type DayOfWeek = {
 }
 
 export type DateStep = {
-  year?: number
-  month?: number
-  day?: number
-  hour?: number
-  minute?: number
-  second?: number
-  millisecond?: number
+  year?: number | undefined
+  month?: number | undefined
+  day?: number | undefined
+  hour?: number | undefined
+  minute?: number | undefined
+  second?: number | undefined
+  millisecond?: number | undefined
 }
 
 export type DateRange = {

--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -52,7 +52,7 @@ function daySegmentAttrs(props: SegmentAttrProps) {
   const isEmpty = segmentValues.day === null
 
   // Include month from segmentValues to ensure correct max days calculation
-  const dateFields: { day?: number, month?: number } = {}
+  const dateFields: { day?: number | undefined, month?: number | undefined } = {}
   if (segmentValues.day)
     dateFields.day = segmentValues.day
   if (segmentValues.month)
@@ -286,7 +286,7 @@ export type UseDateFieldProps = {
   placeholder: Ref<DateValue>
   hourCycle: HourCycle
   step: Ref<DateStep>
-  stepSnapping?: Ref<boolean>
+  stepSnapping?: Ref<boolean> | undefined
   formatter: Formatter
   segmentValues: Ref<SegmentValueObj>
   disabled: Ref<boolean>

--- a/packages/core/src/shared/date/useDateField.ts
+++ b/packages/core/src/shared/date/useDateField.ts
@@ -52,11 +52,12 @@ function daySegmentAttrs(props: SegmentAttrProps) {
   const isEmpty = segmentValues.day === null
 
   // Include month from segmentValues to ensure correct max days calculation
-  const dateFields: { day?: number | undefined, month?: number | undefined } = {}
-  if (segmentValues.day)
-    dateFields.day = segmentValues.day
-  if (segmentValues.month)
-    dateFields.month = segmentValues.month
+  // Built by spreading rather than assigning so that unset fields stay absent
+  // instead of present-and-undefined, which `set()` does not accept.
+  const dateFields = {
+    ...(segmentValues.day ? { day: segmentValues.day } : {}),
+    ...(segmentValues.month ? { month: segmentValues.month } : {}),
+  }
 
   const date = Object.keys(dateFields).length > 0 ? placeholder.set(dateFields) : placeholder
 

--- a/packages/core/src/shared/date/utils.ts
+++ b/packages/core/src/shared/date/utils.ts
@@ -38,7 +38,7 @@ export function getOptsByGranularity(granularity: Granularity, hourCycle: HourCy
 }
 
 type GetDefaultDateStepProps = {
-  step?: DateStep
+  step?: DateStep | undefined
 }
 
 export function normalizeDateStep(props?: GetDefaultDateStepProps): DateStep {

--- a/packages/core/src/shared/propDefaults.test.ts
+++ b/packages/core/src/shared/propDefaults.test.ts
@@ -1,0 +1,70 @@
+import type { ComponentOptions } from 'vue'
+import { describe, expect, it } from 'vitest'
+
+const sources = import.meta.glob<string>('../**/*.vue', { eager: true, query: '?raw', import: 'default' })
+const loaders = import.meta.glob<ComponentOptions>('../**/*.vue', { import: 'default' })
+
+/**
+ * Every `key: UNDEFINED_DEFAULT` entry found in a `withDefaults()` call, as
+ * `[file, propName]` pairs.
+ */
+const entries = Object.entries(sources).flatMap(([file, source]) =>
+  Array.from(source.matchAll(/(\w+): UNDEFINED_DEFAULT\b/g), match => [file, match[1]] as const),
+)
+
+describe('undefined prop defaults', () => {
+  // Pinned so that dropping an entry — which would silently let Vue cast the
+  // prop to `false` when it is absent — has to be an explicit, reviewed change
+  // rather than a passing "cleanup".
+  it('is used by exactly these props', () => {
+    expect(entries.map(([file, prop]) => `${file.replace('../', '')} ${prop}`).sort()).toMatchInlineSnapshot(`
+      [
+        "Accordion/AccordionItem.vue unmountOnHide",
+        "AlertDialog/AlertDialogContent.vue disableOutsidePointerEvents",
+        "Autocomplete/AutocompleteRoot.vue open",
+        "Collapsible/CollapsibleRoot.vue open",
+        "Combobox/ComboboxRoot.vue open",
+        "ConfigProvider/_ConfigProvider.vue scrollBody",
+        "ContextMenu/ContextMenuSub.vue open",
+        "DatePicker/DatePickerRoot.vue open",
+        "DateRangePicker/DateRangePickerRoot.vue open",
+        "Dialog/DialogContent.vue disableOutsidePointerEvents",
+        "Dialog/DialogRoot.vue open",
+        "Drawer/DrawerRoot.vue open",
+        "DropdownMenu/DropdownMenuRoot.vue open",
+        "DropdownMenu/DropdownMenuSub.vue open",
+        "HoverCard/HoverCardRoot.vue open",
+        "Menu/MenuSub.vue open",
+        "Menubar/MenubarSub.vue open",
+        "Popover/PopoverRoot.vue open",
+        "RadioGroup/Radio.vue checked",
+        "Select/SelectRoot.vue open",
+        "Toast/ToastRoot.vue open",
+        "Toggle/Toggle.vue modelValue",
+        "Tooltip/TooltipContentImpl.vue asChild",
+        "Tooltip/TooltipContentImpl.vue avoidCollisions",
+        "Tooltip/TooltipContentImpl.vue hideWhenDetached",
+        "Tooltip/TooltipRoot.vue disableClosingTrigger",
+        "Tooltip/TooltipRoot.vue disableHoverableContent",
+        "Tooltip/TooltipRoot.vue disabled",
+        "Tooltip/TooltipRoot.vue ignoreNonKeyboardFocus",
+        "Tooltip/TooltipRoot.vue open",
+        "VisuallyHidden/VisuallyHiddenInput.vue checked",
+        "VisuallyHidden/VisuallyHiddenInputBubble.vue checked",
+      ]
+    `)
+  })
+
+  // Vue casts an absent `Boolean` prop to `false` unless the prop declaration
+  // owns a `default` key (`resolvePropValue`: `isAbsent && !hasDefault`).
+  // Components using UNDEFINED_DEFAULT rely on the prop staying `undefined`, so
+  // the compiled declaration must keep that key and resolve it to `undefined`.
+  it.each(entries)('%s keeps %s absent instead of casting it to false', async (file, propName) => {
+    const component = await loaders[file]!()
+    const declaration = (component.props as Record<string, object>)[propName]
+
+    expect(declaration, `${propName} is not a declared prop`).toBeDefined()
+    expect(Object.hasOwn(declaration, 'default')).toBe(true)
+    expect((declaration as { default: unknown }).default).toBeUndefined()
+  })
+})

--- a/packages/core/src/shared/propDefaults.ts
+++ b/packages/core/src/shared/propDefaults.ts
@@ -1,0 +1,23 @@
+/**
+ * Sentinel default for props that must stay `undefined` when the consumer does
+ * not pass them.
+ *
+ * Vue resolves an absent `Boolean` prop to `false` unless the prop declares a
+ * `default` (see `resolvePropValue`: the cast is skipped when
+ * `hasOwn(opt, 'default')`). Components that distinguish "not set" from `false`
+ * — controlled vs. uncontrolled `open`, `unmountOnHide` inherited from a root,
+ * … — therefore have to declare an explicit `undefined` default.
+ *
+ * A literal `undefined` cannot be used there under `exactOptionalPropertyTypes`,
+ * because Vue types the defaults object as `InferDefaults<T>`, whose values are
+ * stripped of `undefined`. This sentinel is `undefined` at runtime and
+ * assignable to any default type, so it keeps both the compiler and the Boolean
+ * cast opt-out happy.
+ *
+ * ```ts
+ * withDefaults(defineProps<CollapsibleRootProps>(), {
+ *   open: UNDEFINED_DEFAULT,
+ * })
+ * ```
+ */
+export const UNDEFINED_DEFAULT = undefined as unknown as never

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -8,21 +8,21 @@ interface SingleOrMultipleProps<T = AcceptableValue | AcceptableValue[]> {
    *
    * This prop will overwrite the inferred type from `modelValue` and `defaultValue`.
    */
-  type?: SingleOrMultipleType
+  type?: SingleOrMultipleType | undefined
 
   /**
    * The controlled value of the active item(s).
    *
    * Use this when you need to control the state of the items. Can be binded with `v-model`
    */
-  modelValue?: T
+  modelValue?: T | undefined
 
   /**
    * The default active value of the item(s).
    *
    * Use when you do not need to control the state of the item(s).
    */
-  defaultValue?: T
+  defaultValue?: T | undefined
 }
 
 /**
@@ -31,8 +31,8 @@ interface SingleOrMultipleProps<T = AcceptableValue | AcceptableValue[]> {
  * otherwise, it will be passed string
  */
 type ScrollBodyOption = {
-  padding?: boolean | number | string
-  margin?: boolean | number | string
+  padding?: boolean | number | string | undefined
+  margin?: boolean | number | string | undefined
 }
 
 // Exclude `boolean` type to prevent type casting
@@ -47,7 +47,7 @@ import type { DefineComponent } from 'vue'
 type GenericComponentInstance<T> = T extends new (...args: any[]) => infer R
   ? R
   : T extends (...args: any[]) => infer R
-    ? R extends { __ctx?: infer K }
+    ? R extends { __ctx?: (infer K) | undefined }
       ? Exclude<K, void> extends { expose: (...args: infer Y) => void }
         ? Y[0] & InstanceType<DefineComponent>
         : any
@@ -56,9 +56,9 @@ type GenericComponentInstance<T> = T extends new (...args: any[]) => infer R
 
 interface FormFieldProps {
   /** The name of the field. Submitted with its owning form as part of a name/value pair. */
-  name?: string
+  name?: string | undefined
   /** When `true`, indicates that the user must set the value before the owning form can be submitted. */
-  required?: boolean
+  required?: boolean | undefined
 }
 
 export type { AcceptableValue, ArrayOrWrapped, DataOrientation, Direction, FormFieldProps, GenericComponentInstance, ScrollBodyOption, SingleOrMultipleProps, SingleOrMultipleType, StringOrNumber }

--- a/packages/core/src/shared/useArrowNavigation.ts
+++ b/packages/core/src/shared/useArrowNavigation.ts
@@ -8,14 +8,14 @@ interface ArrowNavigationOptions {
    *
    * @defaultValue "both"
    */
-  arrowKeyOptions?: ArrowKeyOptions
+  arrowKeyOptions?: ArrowKeyOptions | undefined
 
   /**
    * The attribute name to find the collection items in the parent element.
    *
    * @defaultValue "data-reka-collection-item"
    */
-  attributeName?: string
+  attributeName?: string | undefined
 
   /**
    * The parent element where contains all the collection items, this will collect every item to be used when nav
@@ -23,21 +23,21 @@ interface ArrowNavigationOptions {
    *
    * @defaultValue []
    */
-  itemsArray?: HTMLElement[]
+  itemsArray?: HTMLElement[] | undefined
 
   /**
    * Allow loop navigation. If false, it will stop at the first and last element
    *
    * @defaultValue true
    */
-  loop?: boolean
+  loop?: boolean | undefined
 
   /**
    * The orientation of the collection
    *
    * @defaultValue "ltr"
    */
-  dir?: Direction
+  dir?: Direction | undefined
 
   /**
    * Prevent the scroll when navigating. This happens when the direction of the
@@ -45,21 +45,21 @@ interface ArrowNavigationOptions {
    *
    * @defaultValue true
    */
-  preventScroll?: boolean
+  preventScroll?: boolean | undefined
 
   /**
    * By default all currentElement would trigger navigation. If `true`, currentElement nodeName in the ignore list will return null
    *
    * @defaultValue false
    */
-  enableIgnoredElement?: boolean
+  enableIgnoredElement?: boolean | undefined
 
   /**
    * Focus the element after navigation
    *
    * @defaultValue false
    */
-  focus?: boolean
+  focus?: boolean | undefined
 }
 
 const ignoredElement = ['INPUT', 'TEXTAREA']
@@ -154,7 +154,7 @@ interface FindNextFocusableElementOptions {
    *
    * @default true
    */
-  loop?: boolean
+  loop?: boolean | undefined
 }
 
 /**

--- a/packages/core/src/shared/useDateFormatter.ts
+++ b/packages/core/src/shared/useDateFormatter.ts
@@ -8,7 +8,7 @@ import { ref } from 'vue'
 import { hasTime, isZonedDateTime, toDate } from '@/date'
 
 export interface DateFormatterOptions extends Intl.DateTimeFormatOptions {
-  calendar?: string
+  calendar?: string | undefined
 }
 
 export type Formatter = {

--- a/packages/core/src/shared/useForwardProps.ts
+++ b/packages/core/src/shared/useForwardProps.ts
@@ -3,7 +3,7 @@ import { camelize, computed, getCurrentInstance, toRef } from 'vue'
 
 interface PropOptions {
   type?: any
-  required?: boolean
+  required?: boolean | undefined
   default?: any
 }
 

--- a/packages/core/src/shared/useForwardScopeId.ts
+++ b/packages/core/src/shared/useForwardScopeId.ts
@@ -21,6 +21,6 @@ export function useForwardScopeId(): Record<string, string> {
   // `vnode.scopeId` is the scope id the parent set on this component's placeholder
   // vnode for scoped-CSS fallthrough. It is populated during the parent's render,
   // so it is already available by the time `setup()` runs.
-  const scopeId = (getCurrentInstance()?.vnode as { scopeId?: string } | undefined)?.scopeId
+  const scopeId = (getCurrentInstance()?.vnode as { scopeId?: string | undefined } | undefined)?.scopeId
   return scopeId ? { [scopeId]: '' } : {}
 }

--- a/packages/core/src/shared/useSelectionBehavior.ts
+++ b/packages/core/src/shared/useSelectionBehavior.ts
@@ -4,7 +4,7 @@ import { findValuesBetween } from './arrays'
 
 export function useSelectionBehavior<T>(
   modelValue: Ref<T | T[]>,
-  props: UnwrapNestedRefs<{ multiple?: boolean, selectionBehavior?: 'toggle' | 'replace' }>,
+  props: UnwrapNestedRefs<{ multiple?: boolean | undefined, selectionBehavior?: 'toggle' | 'replace' | undefined }>,
 ) {
   const firstValue = ref()
 

--- a/packages/core/src/shared/withDefault.ts
+++ b/packages/core/src/shared/withDefault.ts
@@ -9,9 +9,9 @@ import { useForwardExpose } from './useForwardExpose'
 // https://github.com/vuejs/core/blob/1f2a652a9d2e3bec472fb1786a4c16d6ccfa1fb1/packages/runtime-core/src/h.ts#L53-L58
 type RawProps = VNodeProps & {
   // used to differ from a single VNode object as children
-  __v_isVNode?: never
+  __v_isVNode?: never | undefined
   // used to differ from Array children
-  [Symbol.iterator]?: never
+  [Symbol.iterator]?: never | undefined
 } & Record<string, any>
 
 // types inspired from vue-test-utils
@@ -20,18 +20,18 @@ interface MountingOptions<Props> {
   /**
    * Default props for the component
    */
-  props?: (RawProps & Props) | ({} extends Props ? null : never) | ((attrs: Record<string, any>) => (RawProps & Props))
+  props?: (RawProps & Props) | ({} extends Props ? null : never) | ((attrs: Record<string, any>) => (RawProps & Props)) | undefined
   /**
    * Pass attributes into the component
    */
-  attrs?: Record<string, unknown>
+  attrs?: Record<string, unknown> | undefined
 }
 
 export function withDefault<
   T,
   C = T extends ((...args: any) => any) | (new (...args: any) => any)
     ? T
-    : T extends { props?: infer Props }
+    : T extends { props?: (infer Props) | undefined }
       ? DefineComponent<
         Props extends Readonly<(infer PropNames)[]> | (infer PropNames)[]
           ? { [key in PropNames extends string ? PropNames : string]?: any }

--- a/packages/core/tsconfig.app.json
+++ b/packages/core/tsconfig.app.json
@@ -9,6 +9,8 @@
       "@/*": ["./src/*"],
       "@iconify/vue": ["../../.histoire/node_modules/@iconify/vue"]
     },
+
+    "exactOptionalPropertyTypes": true,
     // TODO: set skipLibCheck to false (#2043)
     // Ideally we should set this to false, but histoire and vueuse are being difficult...
     // For now, keep it disabled...

--- a/packages/plugins/src/resolver/index.ts
+++ b/packages/plugins/src/resolver/index.ts
@@ -8,7 +8,7 @@ export interface ResolverOptions {
    *
    * @defaultValue ""
    */
-  prefix?: string
+  prefix?: string | undefined
 }
 
 export default function (options: ResolverOptions = {}): ComponentResolver {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^21.0.2
         version: 21.0.2
+      '@typescript-eslint/utils':
+        specifier: ^8.58.0
+        version: 8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.8.3)
       bumpp:
         specifier: ^12.1.1
         version: 12.1.1
@@ -2811,9 +2814,6 @@ packages:
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
@@ -5080,10 +5080,6 @@ packages:
     resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6100,11 +6096,6 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7528,7 +7519,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.25.9
       '@babel/types': 7.29.7
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7654,7 +7645,7 @@ snapshots:
   '@commitlint/is-ignored@21.0.2':
     dependencies:
       '@commitlint/types': 21.0.1
-      semver: 7.8.1
+      semver: 7.8.5
 
   '@commitlint/lint@21.0.2':
     dependencies:
@@ -7815,7 +7806,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.84.0':
     dependencies:
       '@types/estree': 1.0.9
-      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/types': 8.58.0
       comment-parser: 1.4.5
       esquery: 1.7.0
       jsdoc-type-pratt-parser: 7.1.1
@@ -9619,10 +9610,6 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
-    dependencies:
-      balanced-match: 1.0.2
-
   brace-expansion@2.1.1:
     dependencies:
       balanced-match: 1.0.2
@@ -10346,7 +10333,7 @@ snapshots:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
       minimatch: 9.0.1
-      semver: 7.8.1
+      semver: 7.8.5
 
   ee-first@1.1.1: {}
 
@@ -11132,7 +11119,7 @@ snapshots:
     dependencies:
       foreground-child: 3.2.1
       jackspeak: 3.4.0
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       minipass: 7.1.2
       package-json-from-dist: 1.0.0
       path-scurry: 1.11.1
@@ -12419,10 +12406,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.1
 
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.1
@@ -12480,7 +12463,7 @@ snapshots:
       pkg-types: 2.3.0
       postcss: 8.5.15
       postcss-nested: 7.0.2(postcss@8.5.15)
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.17
     optionalDependencies:
       typescript: 5.8.3
@@ -13524,8 +13507,6 @@ snapshots:
   semver@7.7.2: {}
 
   semver@7.7.4: {}
-
-  semver@7.8.1: {}
 
   semver@7.8.5: {}
 


### PR DESCRIPTION
## Description

Closes #1404.

Enables [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) for `packages/core`, and makes the public prop types usable by consumers who enable it too.

Without this, an optional prop whose type omits `undefined` cannot receive an explicit `undefined`, which breaks ordinary Vue bindings against reka-ui:

```vue
<!-- `maybeUndefined: boolean | undefined` -->
<AccordionRoot :disabled="maybeUndefined" />
<!-- Type 'boolean | undefined' is not assignable to type 'boolean'
     with 'exactOptionalPropertyTypes: true' -->
```

Four commits: the first widens the types, the second turns the flag on and fixes the fallout, the third fixes two components the flag could not reach, and the fourth adds regression guards.

## 1. `| undefined` on every optional property

- **`eslint-rules/add-undef-to-optional.mjs`** — new local rule (adapted from [MUI's rule](https://github.com/mui/mui-public/blob/master/packages/code-infra/src/eslint/mui/rules/add-undef-to-optional.mjs), React-specific handling stripped). Reports optional `TSPropertySignature` nodes whose type doesn't already accept `undefined`, and autofixes them. The fixer only parenthesises when precedence requires it — function, constructor, conditional and infer types — so simple types stay readable:

  ```ts
  disabled?: boolean | undefined
  dir?: Direction | undefined
  default?: ((props: { modelValue: string }) => any) | undefined  // parens needed
  ```

- **`eslint.config.mjs`** — registers it as `reka/add-undef-to-optional: 'error'`, scoped to the shipped source (`packages/*/src`) and excluding `*.test.ts`, `*.test-d.*`, `*.story.vue` and `story/` / `stories/` directories. Tests and stories are not part of the published contract, so widening their local helper types would only add noise.
- **`package.json` / `pnpm-lock.yaml`** — declares `@typescript-eslint/utils`, already present transitively via `@antfu/eslint-config`, because the rule imports it directly.
- **223 files** of autofix output (191 `.vue`, 32 `.ts`). Every hunk is a one-line type widening; no runtime code changed.

## 2. Enabling the flag

`exactOptionalPropertyTypes: true` in `packages/core/tsconfig.app.json`, plus the fixes it forces.

### `withDefaults` entries — the interesting part

Vue resolves an absent `Boolean` prop to `false` unless the prop declaration owns a `default` key:

```js
// runtime-core, resolvePropValue
const hasDefault = hasOwn(opt, 'default')
...
if (opt[BooleanFlags.shouldCast]) {
  if (isAbsent && !hasDefault) value = false
}
```

So components that distinguish "not set" from `false` — controlled vs. uncontrolled `open`, `unmountOnHide` inherited from the root, … — pass an explicit `undefined` default on purpose. `InferDefaults` strips `undefined` from its value types, so a literal `undefined` stops type-checking once the flag is on.

Classified all 89 `default: undefined` entries by the **compiled runtime type**, not by intent:

| | count | action |
|---|---:|---|
| compiles to `type: Boolean` / `[Boolean, …]` — cast-sensitive | 32 | keep, via a sentinel |
| compiles to `type: null` — never cast | 57 | dropped, behaviour unchanged |

The 32 now use `UNDEFINED_DEFAULT` (`packages/core/src/shared/propDefaults.ts`), which is `undefined` at runtime and assignable to any default type:

```ts
withDefaults(defineProps<CollapsibleRootProps>(), {
  open: UNDEFINED_DEFAULT,
})
```

`propDefaults.test.ts` pins that list in an inline snapshot and asserts each compiled declaration still owns a `default` key resolving to `undefined` — so a future "cleanup" that drops one fails CI rather than silently turning `open` into `false`.

`CheckboxRoot` / `SwitchRoot` keep their `trueValue` / `falseValue` factory defaults, re-cast through `never` instead of `undefined`.

### Dead defaults the flag surfaced

`ColorSwatchPickerRoot.loop` and `TimeFieldRoot.isDateUnavailable` were defaults for props that do not exist. Removed.

### Remaining call sites

- **`PopperContent`** — `limiter` built by conditional spread instead of being passed as `undefined`.
- **`useDateField`** — the `set()` argument is spread together so unset fields stay absent instead of present-and-undefined.
- **`NumberField/utils`, `BubbleSelect`, `SelectRoot`** — casts where a third-party or Vue-provided type declares optional properties without `| undefined`: `@internationalized/number` declares `numberingSystem?: string` against the lib's `string | undefined`, and Vue's DOM attribute interfaces (`SelectHTMLAttributes`, `OptionHTMLAttributes`) are not `exactOptionalPropertyTypes`-safe.
- **`Primitive`** — `as` typed as `PropType<AsTag | Component | undefined>`.

## 3. Props the ESLint rule could not reach

`Primitive` and `Presence` declare their props with a runtime options object, not `defineProps<T>()`, so their public prop types come from `type: Boolean` and not from `PrimitiveProps` / `PresenceProps`. Vue infers `asChild?: boolean` and `forceMount?: boolean` from that, which a consumer with the flag on cannot satisfy with a maybe-undefined value:

```vue
<Primitive :as-child="maybeBoolean" />
<Presence :present="true" :force-mount="maybeBoolean" />
```

Both constructors are now cast through `PropType<boolean | undefined>`. Runtime behaviour is untouched — `Boolean` is still the declared type, so the absent-prop cast still applies where it did before.

## 4. Regression guards

Nothing stopped a new component from declaring `prop?: T` again. Two type-level guards close that, both running under `pnpm --filter reka-ui type-check`, which the Build workflow already executes. Neither file is bundled or published (`!src/**/*.test-d.*` added to `files`).

- **`src/exactOptionalPropertyTypes.test-d.ts`** — walks every component exported from `src/index.ts`, 398 of them, generic components included, and reports the offending component/prop pairs:

  ```
  Type '{ '…': { AccordionRoot: "disabled" } }' does not satisfy the constraint 'true'.
  ```

  Vue-generated props are excluded: `key` / `class` / `ref` from `VNodeProps`, and the `on*` props `EmitsToProps` derives from `defineEmits()`, are declared without `undefined` upstream and cannot be widened from here.

- **`src/exactOptionalPropertyTypes.test-d.vue`** — the same guarantee from the consumer side, binding possibly-undefined values and `v-model` refs into a representative set of components, so Vue's own prop resolution (`withDefaults`, generics, emits) is exercised rather than the declared interfaces alone.

Both were verified against deliberate regressions: removing `| undefined` from `AccordionRootProps.disabled`, and reverting the `Presence` fix above, each fail `type-check` with the component named.

Non-component exports (context types, composable options, `date` utilities, the plugins resolver options) stay covered by the ESLint rule.

## Verification

Rebased onto `v2` (`c23e0ed8`).

- `pnpm --filter reka-ui type-check` — clean, with the flag on
- `pnpm --filter reka-ui exec vitest run` — 98 files, 2045 tests passed (33 of them new)
- `pnpm --filter reka-ui build` — succeeds (vue-tsc + tsdown)
- `pnpm lint` — no errors introduced by this PR. One error remains, `DropdownMenu.test.ts` import order, which reproduces unchanged on `v2`.
- The published surface was checked end-to-end: the guard from §4 was re-run against the built `dist/index.d.ts` from a consumer `tsconfig` with `strict` + `exactOptionalPropertyTypes` on — 398 components, zero offenders. The optional properties remaining in the emitted `.d.ts` without `| undefined` are Vue's `on*` emit props, `SlotsType` slots, and optional *function parameters*, none of which the flag affects.

## Notes for reviewers

- **The flag is enabled for `packages/core` only.** `packages/plugins/tsconfig.json` sets neither `strict` nor `strictNullChecks`, so TypeScript rejects `exactOptionalPropertyTypes` there outright (`TS5052`). Turning `strict` on for that package surfaces 45 mostly-unrelated errors (missing `webpack`/`bun` type packages, `moduleResolution: node` against `vite`/`rollup`) — a separate cleanup, happy to do it in its own PR. Its public types are still covered by the ESLint rule; there is exactly one optional property in `packages/plugins/src` and it carries `| undefined`.
- **`docs/content/meta/*.md` is not regenerated.** `pnpm docs:gen` currently fails on `v2` independently of this PR — `TypeError: traverse is not a function` in `docs/scripts/autogen.ts:309`, fallout of the `@babel/traverse` v8 bump in #2817 (v8 changed the default-export interop). Still reproduces on `v2` at `c23e0ed8`. Happy to fix that separately and regenerate here afterwards.
- Whether the generated prop tables should render `boolean | undefined` or keep showing `boolean` is a maintainer call; if the latter, `autogen.ts` should strip the `undefined` member.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript compatibility for optional props, callbacks, matchers, and slots across components.
  * Explicitly supports `undefined` values with `exactOptionalPropertyTypes`.
  * Preserved omitted Boolean props as `undefined` instead of converting them to `false`.
  * Prevented test-only declaration files from being included in published packages.

* **Developer Experience**
  * Added automated checks for incompatible optional prop declarations.
  * Added type-level regression coverage for common component usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->