### PR TITLE
refactor(shared): extract segment focus navigation shared by date/time fields

### DIFF
--- a/packages/core/src/DateField/DateFieldRoot.vue
+++ b/packages/core/src/DateField/DateFieldRoot.vue
@@ -20,6 +20,7 @@ import {
   normalizeInputValue,
   syncSegmentValues,
 } from '@/shared/date'
+import { useSegmentNavigation } from '@/shared/date/useSegmentNavigation'
 
 type DateFieldRootContext = {
   locale: Ref<string>
@@ -223,28 +224,11 @@ watch([modelValue, locale], ([_modelValue]) => {
 
 const currentFocusedElement = ref<HTMLElement | null>(null)
 
-const currentSegmentIndex = computed(() =>
-  Array.from(segmentElements.value).findIndex(el =>
-    el.getAttribute('data-reka-date-field-segment')
-    === currentFocusedElement.value?.getAttribute('data-reka-date-field-segment')))
-
-const nextFocusableSegment = computed(() => {
-  const sign = dir.value === 'rtl' ? -1 : 1
-  const nextCondition = sign < 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
-  if (nextCondition)
-    return null
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value + sign]
-  return segmentToFocus
-})
-
-const prevFocusableSegment = computed(() => {
-  const sign = dir.value === 'rtl' ? -1 : 1
-  const prevCondition = sign > 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
-  if (prevCondition)
-    return null
-
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value - sign]
-  return segmentToFocus
+const { currentSegmentIndex, nextFocusableSegment, prevFocusableSegment, focusNext } = useSegmentNavigation({
+  segmentElements,
+  currentFocusedElement,
+  dir,
+  segmentAttributes: ['data-reka-date-field-segment'],
 })
 
 const inputType = computed(() => getInputType(inferredGranularity.value))
@@ -286,12 +270,7 @@ provideDateFieldRootContext({
   segmentContents: editableSegmentContents,
   elements: segmentElements,
   setFocusedElement,
-  focusNext() {
-    // Auto-advance follows the segments' DOM order (the locale's format
-    // order) regardless of writing direction; only arrow-key navigation is
-    // direction-aware via nextFocusableSegment/prevFocusableSegment.
-    Array.from(segmentElements.value)[currentSegmentIndex.value + 1]?.focus()
-  },
+  focusNext,
 })
 
 defineExpose({

--- a/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
+++ b/packages/core/src/DateRangeField/DateRangeFieldRoot.vue
@@ -25,6 +25,7 @@ import {
 
   syncSegmentValues,
 } from '@/shared/date'
+import { useSegmentNavigation } from '@/shared/date/useSegmentNavigation'
 
 export type DateRangeType = 'start' | 'end'
 
@@ -311,27 +312,11 @@ watch([endValue, locale], ([_endValue]) => {
 
 const currentFocusedElement = ref<HTMLElement | null>(null)
 
-const currentSegmentIndex = computed(() => Array.from(segmentElements.value).findIndex(el =>
-  el.getAttribute('data-reka-date-field-segment') === currentFocusedElement.value?.getAttribute('data-reka-date-field-segment')
-  && el.getAttribute('data-reka-date-range-field-segment-type') === currentFocusedElement.value?.getAttribute('data-reka-date-range-field-segment-type')))
-
-const nextFocusableSegment = computed(() => {
-  const sign = dir.value === 'rtl' ? -1 : 1
-  const nextCondition = sign < 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
-  if (nextCondition)
-    return null
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value + sign]
-  return segmentToFocus
-})
-
-const prevFocusableSegment = computed(() => {
-  const sign = dir.value === 'rtl' ? -1 : 1
-  const prevCondition = sign > 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
-  if (prevCondition)
-    return null
-
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value - sign]
-  return segmentToFocus
+const { currentSegmentIndex, nextFocusableSegment, prevFocusableSegment, focusNext } = useSegmentNavigation({
+  segmentElements,
+  currentFocusedElement,
+  dir,
+  segmentAttributes: ['data-reka-date-field-segment', 'data-reka-date-range-field-segment-type'],
 })
 
 const kbd = useKbd()
@@ -368,12 +353,7 @@ provideDateRangeFieldRootContext({
   segmentContents: editableSegmentContents,
   elements: segmentElements,
   setFocusedElement,
-  focusNext() {
-    // Auto-advance follows the segments' DOM order (the locale's format
-    // order) regardless of writing direction; only arrow-key navigation is
-    // direction-aware via nextFocusableSegment/prevFocusableSegment.
-    Array.from(segmentElements.value)[currentSegmentIndex.value + 1]?.focus()
-  },
+  focusNext,
 })
 
 defineExpose({

--- a/packages/core/src/TimeField/TimeFieldRoot.vue
+++ b/packages/core/src/TimeField/TimeFieldRoot.vue
@@ -18,6 +18,7 @@ import {
   normalizeHourCycle,
   syncTimeSegmentValues,
 } from '@/shared/date'
+import { useSegmentNavigation } from '@/shared/date/useSegmentNavigation'
 
 type TimeFieldRootContext = {
   locale: Ref<string>
@@ -270,28 +271,11 @@ watch([convertedModelValue, locale], ([_modelValue]) => {
 
 const currentFocusedElement = ref<HTMLElement | null>(null)
 
-const currentSegmentIndex = computed(() =>
-  Array.from(segmentElements.value).findIndex(el =>
-    el.getAttribute('data-reka-time-field-segment')
-    === currentFocusedElement.value?.getAttribute('data-reka-time-field-segment')))
-
-const nextFocusableSegment = computed(() => {
-  const sign = dir.value === 'rtl' ? -1 : 1
-  const nextCondition = sign < 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
-  if (nextCondition)
-    return null
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value + sign]
-  return segmentToFocus
-})
-
-const prevFocusableSegment = computed(() => {
-  const sign = dir.value === 'rtl' ? -1 : 1
-  const prevCondition = sign > 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
-  if (prevCondition)
-    return null
-
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value - sign]
-  return segmentToFocus
+const { currentSegmentIndex, nextFocusableSegment, prevFocusableSegment, focusNext } = useSegmentNavigation({
+  segmentElements,
+  currentFocusedElement,
+  dir,
+  segmentAttributes: ['data-reka-time-field-segment'],
 })
 
 const kbd = useKbd()
@@ -327,12 +311,7 @@ provideTimeFieldRootContext({
   segmentContents: editableSegmentContents,
   elements: segmentElements,
   setFocusedElement,
-  focusNext() {
-    // Auto-advance follows the segments' DOM order (the locale's format
-    // order) regardless of writing direction; only arrow-key navigation is
-    // direction-aware via nextFocusableSegment/prevFocusableSegment.
-    Array.from(segmentElements.value)[currentSegmentIndex.value + 1]?.focus()
-  },
+  focusNext,
 })
 
 defineExpose({

--- a/packages/core/src/TimeRangeField/TimeRangeFieldRoot.vue
+++ b/packages/core/src/TimeRangeField/TimeRangeFieldRoot.vue
@@ -25,6 +25,7 @@ import {
   syncTimeSegmentValues,
 
 } from '@/shared/date'
+import { useSegmentNavigation } from '@/shared/date/useSegmentNavigation'
 
 type TimeRangeFieldRootContext = {
   locale: Ref<string>
@@ -376,27 +377,11 @@ watch([convertedEndValue, locale], ([_endValue]) => {
 
 const currentFocusedElement = ref<HTMLElement | null>(null)
 
-const currentSegmentIndex = computed(() => Array.from(segmentElements.value).findIndex(el =>
-  el.getAttribute('data-reka-time-field-segment') === currentFocusedElement.value?.getAttribute('data-reka-time-field-segment')
-  && el.getAttribute('data-reka-time-range-field-segment-type') === currentFocusedElement.value?.getAttribute('data-reka-time-range-field-segment-type')))
-
-const nextFocusableSegment = computed(() => {
-  const sign = dir.value === 'rtl' ? -1 : 1
-  const nextCondition = sign < 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
-  if (nextCondition)
-    return null
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value + sign]
-  return segmentToFocus
-})
-
-const prevFocusableSegment = computed(() => {
-  const sign = dir.value === 'rtl' ? -1 : 1
-  const prevCondition = sign > 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
-  if (prevCondition)
-    return null
-
-  const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value - sign]
-  return segmentToFocus
+const { currentSegmentIndex, nextFocusableSegment, prevFocusableSegment, focusNext } = useSegmentNavigation({
+  segmentElements,
+  currentFocusedElement,
+  dir,
+  segmentAttributes: ['data-reka-time-field-segment', 'data-reka-time-range-field-segment-type'],
 })
 
 const kbd = useKbd()
@@ -432,12 +417,7 @@ provideTimeRangeFieldRootContext({
   segmentContents: editableSegmentContents,
   elements: segmentElements,
   setFocusedElement,
-  focusNext() {
-    // Auto-advance follows the segments' DOM order (the locale's format
-    // order) regardless of writing direction; only arrow-key navigation is
-    // direction-aware via nextFocusableSegment/prevFocusableSegment.
-    Array.from(segmentElements.value)[currentSegmentIndex.value + 1]?.focus()
-  },
+  focusNext,
 })
 
 defineExpose({

--- a/packages/core/src/shared/date/index.ts
+++ b/packages/core/src/shared/date/index.ts
@@ -40,4 +40,5 @@ export type {
   TimeSegmentPart,
 } from './types'
 export { useDateField } from './useDateField'
+export { useSegmentNavigation } from './useSegmentNavigation'
 export * from './utils'

--- a/packages/core/src/shared/date/useSegmentNavigation.ts
+++ b/packages/core/src/shared/date/useSegmentNavigation.ts
@@ -1,0 +1,54 @@
+import type { Ref } from 'vue'
+import type { Direction } from '@/shared/types'
+import { computed } from 'vue'
+
+export interface UseSegmentNavigationProps {
+  /** The editable segment elements of the field, in DOM order */
+  segmentElements: Ref<Set<HTMLElement>>
+  /** The segment element that currently holds focus, if any */
+  currentFocusedElement: Ref<HTMLElement | null>
+  /** The writing direction of the field */
+  dir: Ref<Direction>
+  /** The data attributes that together identify a segment element within the field */
+  segmentAttributes: string[]
+}
+
+export function useSegmentNavigation({ segmentElements, currentFocusedElement, dir, segmentAttributes }: UseSegmentNavigationProps) {
+  const currentSegmentIndex = computed(() =>
+    Array.from(segmentElements.value).findIndex(el =>
+      segmentAttributes.every(attribute =>
+        el.getAttribute(attribute) === currentFocusedElement.value?.getAttribute(attribute))))
+
+  const nextFocusableSegment = computed(() => {
+    const sign = dir.value === 'rtl' ? -1 : 1
+    const nextCondition = sign < 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
+    if (nextCondition)
+      return null
+    const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value + sign]
+    return segmentToFocus
+  })
+
+  const prevFocusableSegment = computed(() => {
+    const sign = dir.value === 'rtl' ? -1 : 1
+    const prevCondition = sign > 0 ? currentSegmentIndex.value < 0 : currentSegmentIndex.value > segmentElements.value.size - 1
+    if (prevCondition)
+      return null
+
+    const segmentToFocus = Array.from(segmentElements.value)[currentSegmentIndex.value - sign]
+    return segmentToFocus
+  })
+
+  function focusNext() {
+    // Auto-advance follows the segments' DOM order (the locale's format
+    // order) regardless of writing direction; only arrow-key navigation is
+    // direction-aware via nextFocusableSegment/prevFocusableSegment.
+    Array.from(segmentElements.value)[currentSegmentIndex.value + 1]?.focus()
+  }
+
+  return {
+    currentSegmentIndex,
+    nextFocusableSegment,
+    prevFocusableSegment,
+    focusNext,
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #2813 — implements the non-blocking suggestion from the review:

> this block (and the `currentSegmentIndex` / `next` / `prevFocusableSegment` trio) is now duplicated across four roots — the fact that this bug lived in four places is a decent argument for extracting a shared composable in `shared/date/`, but that's a follow-up, not this PR.

### 📚 Description

Extracts the segment focus-navigation block that was copy-pasted across `DateFieldRoot`, `DateRangeFieldRoot`, `TimeFieldRoot` and `TimeRangeFieldRoot` into a `useSegmentNavigation` composable in `shared/date/`.

The composable takes `segmentElements`, `currentFocusedElement`, `dir`, and the list of data attributes that identify a segment within the field. The single-value roots pass their `data-reka-{date,time}-field-segment` attribute; the range roots additionally pass their `*-segment-type` attribute, which preserves the start/end disambiguation their inline versions had. It returns the `currentSegmentIndex` / `nextFocusableSegment` / `prevFocusableSegment` trio plus the DOM-order `focusNext` used for auto-advance.

The logic is moved verbatim — no behavior change intended. Net −81 lines across the four roots.

Verified locally:

- All four field suites green: 164 tests, including the RTL auto-advance and range-boundary-hop regressions added in #2813 (they exercise exactly this code).
- `vue-tsc --noEmit -p tsconfig.check.json` clean, eslint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated segment navigation logic across date, date range, time, and time range field components. A centralized segment navigation handler now manages focus tracking, directional navigation, and segment advancement for all date and time field types based on DOM order and writing direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->