### PR TITLE
fix(DismissableLayer): keep body pointer-events locked when the last scroll lock releases

### DIFF
--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -138,6 +138,10 @@ describe('sibling layers with disableOutsidePointerEvents', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
     document.body.style.pointerEvents = ''
+    // Module-level layer registry: make this suite order-independent even if
+    // a failing test skipped its unmounts.
+    context.layersRoot.clear()
+    context.layersWithOutsidePointerEventsDisabled.clear()
   })
 
   // The mirrored direction of the #2674 tests above: the OLDER disabling

--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -3,8 +3,10 @@ import { fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
+import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 import { sleep } from '@/test'
 import { DismissableLayer as DismissableLayerPrimitive } from '.'
+import { context } from './context'
 import DismissableLayer from './story/_DismissableLayer.vue'
 import { isLayerExist } from './utils'
 
@@ -125,6 +127,173 @@ describe('nested layers with disableOutsidePointerEvents (#2674)', () => {
     expect(document.body.style.pointerEvents).toBe('none')
 
     outerOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    wrapper.unmount()
+  })
+})
+
+describe('sibling layers with disableOutsidePointerEvents', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.body.style.pointerEvents = ''
+  })
+
+  // The mirrored direction of the #2674 tests above: the OLDER disabling
+  // layer leaves the set while a NEWER sibling is still present. This is the
+  // layer-registry half of the #2784 scenario (a closing animated Popover
+  // whose layer unmounts after a Dialog has already opened).
+  function mountSiblings() {
+    const popoverOpen = ref(true)
+    const dialogOpen = ref(false)
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => h('div', [
+          popoverOpen.value
+            ? h(DismissableLayerPrimitive, { 'disableOutsidePointerEvents': true, 'data-testid': 'popover' }, () => 'Popover')
+            : null,
+          dialogOpen.value
+            ? h(DismissableLayerPrimitive, { 'disableOutsidePointerEvents': true, 'data-testid': 'dialog' }, () => 'Dialog')
+            : null,
+        ])
+      },
+    }), { attachTo: document.body })
+
+    return { wrapper, popoverOpen, dialogOpen }
+  }
+
+  it('should keep body pointer-events none after the older layer unmounts while a newer one is open', async () => {
+    const { wrapper, popoverOpen, dialogOpen } = mountSiblings()
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Dialog mounts while the popover is still animating out (still mounted)
+    dialogOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Popover's exit animation ends -> its layer unmounts; dialog still open
+    popoverOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Closing the dialog restores the body
+    dialogOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('should keep body pointer-events none when the handoff happens in the same tick', async () => {
+    const { wrapper, popoverOpen, dialogOpen } = mountSiblings()
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // "Pick" action: close the popover and open the dialog in the same tick
+    popoverOpen.value = false
+    dialogOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    dialogOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    wrapper.unmount()
+  })
+})
+
+describe('scroll-lock handoff to a modal layer without its own scroll lock (#2784)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.body.style.pointerEvents = ''
+    // Module-level layer registry: make this suite order-independent even if
+    // a failing test skipped its unmounts.
+    context.layersRoot.clear()
+    context.layersWithOutsidePointerEventsDisabled.clear()
+  })
+
+  // Mimics `PopoverContentModal`: a modal layer that also holds a body scroll
+  // lock, released when the content unmounts (for an animated popover that is
+  // the end of the exit animation).
+  const ModalLayerWithScrollLock = defineComponent({
+    setup() {
+      useBodyScrollLock(true)
+      return () => h(DismissableLayerPrimitive, { disableOutsidePointerEvents: true }, () => 'popover')
+    },
+  })
+
+  // Mimics an overlay-less modal `DialogContent`: disables outside pointer
+  // events but registers no scroll lock (that lives on `DialogOverlayImpl`).
+  function mountHandoff() {
+    const popoverOpen = ref(false)
+    const dialogOpen = ref(false)
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => h('div', [
+          popoverOpen.value ? h(ModalLayerWithScrollLock) : null,
+          dialogOpen.value
+            ? h(DismissableLayerPrimitive, { disableOutsidePointerEvents: true }, () => 'dialog')
+            : null,
+        ])
+      },
+    }), { attachTo: document.body })
+
+    return { wrapper, popoverOpen, dialogOpen }
+  }
+
+  it('should keep body pointer-events none when the scroll-lock holder unmounts while a modal layer remains open', async () => {
+    const { wrapper, popoverOpen, dialogOpen } = mountHandoff()
+
+    // Modal popover opens: dismissable layer + scroll lock
+    popoverOpen.value = true
+    await nextTick() // scroll lock applies its own pointer-events on next tick
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Modal dialog (no overlay -> no scroll lock) opens while the popover
+    // is still mounted (e.g. animating out)
+    dialogOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Popover unmounts: the last scroll lock releases and must not clear the
+    // body pointer-events still owned by the dialog's dismissable layer
+    popoverOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Closing the dialog restores the body
+    dialogOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('should keep body pointer-events none when a scroll-locking layer opens and closes over a modal layer', async () => {
+    const { wrapper, popoverOpen, dialogOpen } = mountHandoff()
+
+    // Overlay-less modal dialog open first
+    dialogOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // A modal popover (scroll-lock holder) opens on top, then closes
+    popoverOpen.value = true
+    await nextTick()
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    popoverOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    dialogOpen.value = false
     await sleep(1)
     expect(document.body.style.pointerEvents).toBe('')
 

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -8,11 +8,11 @@ import type { PrimitiveProps } from '@/Primitive'
 import {
   computed,
   nextTick,
-  reactive,
   watch,
   watchEffect,
 } from 'vue'
 import { isNullish, useForwardExpose } from '@/shared'
+import { context } from './context'
 
 export interface DismissableLayerProps extends PrimitiveProps {
   /**
@@ -54,12 +54,7 @@ export type DismissableLayerPrivateEmits = DismissableLayerEmits & {
   dismiss: []
 }
 
-export const context = reactive({
-  layersRoot: new Set<HTMLElement>(),
-  layersWithOutsidePointerEventsDisabled: new Set<HTMLElement>(),
-  originalBodyPointerEvents: undefined as string | undefined,
-  branches: new Set<HTMLElement>(),
-})
+export { context }
 </script>
 
 <script setup lang="ts">

--- a/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
@@ -8,7 +8,7 @@ export interface DismissableLayerBranchProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { onMounted, onUnmounted } from 'vue'
 import { Primitive } from '@/Primitive'
-import { context } from './DismissableLayer.vue'
+import { context } from './context'
 
 const props = defineProps<DismissableLayerBranchProps>()
 

--- a/packages/core/src/DismissableLayer/context.ts
+++ b/packages/core/src/DismissableLayer/context.ts
@@ -1,0 +1,11 @@
+import { reactive } from 'vue'
+
+// Module-level registry shared by every `DismissableLayer` in the app, and
+// consulted by `useBodyScrollLock` before it releases the body
+// `pointer-events` style both own (#2784).
+export const context = reactive({
+  layersRoot: new Set<HTMLElement>(),
+  layersWithOutsidePointerEventsDisabled: new Set<HTMLElement>(),
+  originalBodyPointerEvents: undefined as string | undefined,
+  branches: new Set<HTMLElement>(),
+})

--- a/packages/core/src/shared/useBodyScrollLock.ts
+++ b/packages/core/src/shared/useBodyScrollLock.ts
@@ -7,6 +7,7 @@ import { isClient, isIOS, tryOnBeforeUnmount } from '@vueuse/shared'
 import { defu } from 'defu'
 import { computed, nextTick, ref, watch } from 'vue'
 import { injectConfigProviderContext } from '@/ConfigProvider/ConfigProvider.vue'
+import { context as dismissableLayerContext } from '@/DismissableLayer/context'
 
 const useBodyLockStackCount = createSharedComposable(() => {
   const map = ref<Map<string, boolean>>(new Map())
@@ -29,7 +30,13 @@ const useBodyLockStackCount = createSharedComposable(() => {
   const resetBodyStyle = () => {
     document.body.style.paddingRight = ''
     document.body.style.marginRight = ''
-    document.body.style.pointerEvents = ''
+    // A mounted `DismissableLayer` with `disableOutsidePointerEvents` may
+    // still own the body pointer-events lock (e.g. a modal Dialog rendered
+    // without the Overlay that would hold a scroll lock). Clearing it here
+    // would make everything behind that layer clickable again (#2784); the
+    // layer restores it once its last disabling layer is gone.
+    if (dismissableLayerContext.layersWithOutsidePointerEventsDisabled.size === 0)
+      document.body.style.pointerEvents = ''
     document.documentElement.style.removeProperty('--scrollbar-width')
     document.body.style.overflow = initialOverflow.value ?? ''
     isIOS && stopTouchMoveListener?.()


### PR DESCRIPTION
Fixes #2784

### What happens

`useBodyScrollLock` and `DismissableLayer` both write `document.body.style.pointerEvents` without consulting each other, and the scroll lock's `resetBodyStyle()` — which runs when the last scroll-lock holder releases — cleared it unconditionally.

In the repro, the last scroll-lock holder is the closing popover itself: `PopoverContentModal` holds `useBodyScrollLock(true)` until its content unmounts, i.e. until the exit animation finishes. The dialog that opened mid-animation disables outside pointer events through its `DismissableLayer`, but holds no scroll lock of its own — a dialog's lock lives on `DialogOverlayImpl`, and the repro (legitimately) renders no overlay. So when the popover's exit animation ends, its scroll lock is the last one out and wipes the body lock the dialog still depends on.

Instrumented trace of one handoff on `v2` HEAD (temporary logs in both writers):

```
+840ms   DismissableLayer apply: size 0→1, saved original "" → body 'none'   (popover layer)
+848ms   useBodyScrollLock nextTick apply: body 'none'                        (popover lock)
+1075ms  DismissableLayer add: size 1→2                                       (dialog layer)
+1484ms  useBodyScrollLock resetBodyStyle: body ''      ← popover unmounts: the stomp
+1486ms  DismissableLayer delete: size 2→1 → correctly no restore             (damage done)
```

`DismissableLayer`'s own bookkeeping is correct throughout — the dialog's layer is registered, and the departing layer doesn't restore because it isn't the last one. Nothing re-applies the style afterwards because no layer-registry state changes again.

### Relationship to the issue's analysis

The `watchEffect` re-trigger mechanism described in #2784 matches the pre-2.9.10 `DismissableLayer` and was fixed by #2678 (the repro pins `2.9.6`, which predates it). The leak itself is not stale, though — running the repro's own Auto-run ×20 (headless Chromium, its "exit animation played" self-check green):

| build | result |
|---|---|
| 2.9.6 (repro's pin) | 20/20 leaks |
| 2.9.9 | 20/20 |
| 2.9.10 (first release with #2678) | 20/20 |
| 2.10.1 (latest) | 20/20 |
| `v2` HEAD | 20/20 |
| `v2` HEAD + this PR | **0/20** |

The exit animation isn't essential either: the same stomp happens with no animation at all when a modal popover opens and closes over an overlay-less modal dialog (covered by the second regression test).

### The fix

`resetBodyStyle()` now leaves `pointerEvents` alone while any `DismissableLayer` still has `disableOutsidePointerEvents` active; that layer's cleanup restores it once the last disabling layer is gone. The scroll lock's other resets (overflow, padding/margin, `--scrollbar-width`) are unchanged.

To let `useBodyScrollLock` (in `shared/`) read the layer registry without importing the component — `DismissableLayer.vue` imports from the `shared` barrel, so that would be a cycle — the module-level `context` moves verbatim to `DismissableLayer/context.ts`. The `.vue` re-exports it, so the existing import surface is unchanged (`context` isn't in the package's public exports; the only other consumer, `DismissableLayerBranch.vue`, is updated).

### Tests

- Two red→green regressions for this bug: a scroll-lock-holding modal layer unmounting while an overlay-less modal layer is open — in both open orders (popover first / dialog first).
- Two more pinning the layer-registry half: the *older* sibling layer leaving while a newer one is open — the mirrored direction of the #2674 suite, which only covered inner-closes-first.
- Full core suite: 95 files / 1974 tests green; `vue-tsc` and lint clean.

### Out of scope (happy to follow up)

The underlying shape — two owners writing one property — has two more edges this PR deliberately doesn't touch:

1. `DismissableLayer` can capture the scroll lock's `'none'` as `originalBodyPointerEvents` (when a layer mounts while a `bodyLock` is already active) and write it back on final restore, leaving the body at `pointer-events: none` with nothing open. Pre-existing, reachable both before and after this PR.
2. The reverse stomp: `DismissableLayer`'s restore doesn't consult still-active scroll locks.

A shared, refcounted owner for body `pointer-events` (first acquirer saves the original, last release restores it) would close the whole class, and seems to line up with where #2822 wants v3 to go. Glad to do that as a follow-up if you'd take it — kept this one minimal since the guarded path is the one #2784 actually hits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal and dismissible-layer handoffs to keep background interaction blocked while another layer remains active.
  * Ensured body interaction styles are restored correctly only after all active layers are closed.
  * Added regression coverage for scroll-lock transitions and sibling modal layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->