### PR TITLE
fix(useForwardExpose): correct `currentElement` resolution and type

### DIFF
--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -84,7 +84,8 @@ provideComboboxContentContext({ position })
 const isInputWithinContent = ref(false)
 onMounted(() => {
   if (rootContext.inputElement.value) {
-    isInputWithinContent.value = currentElement.value.contains(rootContext.inputElement.value)
+    // TODO(currentElement): verify nullability; should probably be (?? false)
+    isInputWithinContent.value = currentElement.value!.contains(rootContext.inputElement.value)
     if (isInputWithinContent.value) {
       rootContext.inputElement.value.focus()
     }

--- a/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
@@ -14,10 +14,10 @@ const props = defineProps<DismissableLayerBranchProps>()
 
 const { forwardRef, currentElement } = useForwardExpose()
 onMounted(() => {
-  context.branches.add(currentElement.value)
+  context.branches.add(currentElement.value!)
 })
 onUnmounted(() => {
-  context.branches.delete(currentElement.value)
+  context.branches.delete(currentElement.value!)
 })
 </script>
 

--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -148,7 +148,8 @@ watchEffect((cleanupFn) => {
       return
     }
 
-    const isLastFocusedElementExist = container.contains(lastFocusedElement)
+    // container is non-null here: `MutationObserver` observes only inside `if (container)`
+    const isLastFocusedElementExist = container!.contains(lastFocusedElement)
     if (!isLastFocusedElementExist)
       focus(container)
   }

--- a/packages/core/src/Listbox/ListboxItem.vue
+++ b/packages/core/src/Listbox/ListboxItem.vue
@@ -44,7 +44,7 @@ const { CollectionItem } = useCollection()
 const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectListboxRootContext()
 
-const isHighlighted = computed(() => currentElement.value != null && currentElement.value === rootContext.highlightedElement.value)
+const isHighlighted = computed(() => currentElement.value !== undefined && currentElement.value === rootContext.highlightedElement.value)
 const isSelected = computed(() => valueComparator(rootContext.modelValue.value, props.value, rootContext.by))
 
 const disabled = computed(() => rootContext.disabled.value || props.disabled)
@@ -56,7 +56,7 @@ async function handleSelect(ev: SelectEvent<T>) {
 
   if (!disabled.value && ev) {
     rootContext.onValueChange(props.value)
-    rootContext.changeHighlight(currentElement.value)
+    rootContext.changeHighlight(currentElement.value!)
   }
 }
 
@@ -93,7 +93,7 @@ provideListboxItemContext({
           return
 
         if (rootContext.highlightOnHover.value)
-          rootContext.changeHighlight(currentElement, false, false)
+          rootContext.changeHighlight(currentElement!, false, false)
       }"
     >
       <slot />

--- a/packages/core/src/Slider/SliderThumbImpl.vue
+++ b/packages/core/src/Slider/SliderThumbImpl.vue
@@ -43,7 +43,7 @@ const thumbInBoundsOffset = computed(() => {
 
 const isMounted = useMounted()
 onMounted(() => {
-  rootContext.thumbElements.value.push(thumbElement.value)
+  rootContext.thumbElements.value.push(thumbElement.value!)
 })
 onUnmounted(() => {
   const i = rootContext.thumbElements.value.findIndex(i => i === thumbElement.value) ?? -1

--- a/packages/core/src/Splitter/SplitterGroup.vue
+++ b/packages/core/src/Splitter/SplitterGroup.vue
@@ -57,7 +57,7 @@ export type PanelGroupContext = {
   startDragging: (dragHandleId: string, event: ResizeEvent) => void
   stopDragging: () => void
   unregisterPanel: (panelData: PanelData) => void
-  panelGroupElement: Ref<ParentNode | null>
+  panelGroupElement: Ref<ParentNode | null | undefined>
 
   // Exposed function for child component
   collapsePanel: (panelData: PanelData) => void

--- a/packages/core/src/Splitter/utils/composables/useWindowSplitterBehavior.ts
+++ b/packages/core/src/Splitter/utils/composables/useWindowSplitterBehavior.ts
@@ -19,7 +19,7 @@ export function useWindowSplitterResizeHandlerBehavior({
 }): void {
   watchEffect((onCleanup) => {
     const _panelGroupElement = panelGroupElement.value
-    if (disabled.value || resizeHandler.value === null || _panelGroupElement === null)
+    if (disabled.value || resizeHandler.value === null || !_panelGroupElement)
       return
 
     const handleElement = getResizeHandleElement(handleId, _panelGroupElement)

--- a/packages/core/src/Splitter/utils/composables/useWindowSplitterBehavior.ts
+++ b/packages/core/src/Splitter/utils/composables/useWindowSplitterBehavior.ts
@@ -15,7 +15,7 @@ export function useWindowSplitterResizeHandlerBehavior({
   disabled: Ref<boolean>
   handleId: string
   resizeHandler: Ref<ResizeHandler | null>
-  panelGroupElement: Ref<ParentNode | null>
+  panelGroupElement: Ref<ParentNode | null | undefined>
 }): void {
   watchEffect((onCleanup) => {
     const _panelGroupElement = panelGroupElement.value

--- a/packages/core/src/Splitter/utils/composables/useWindowSplitterPanelGroupBehavior.ts
+++ b/packages/core/src/Splitter/utils/composables/useWindowSplitterPanelGroupBehavior.ts
@@ -25,7 +25,7 @@ export function useWindowSplitterPanelGroupBehavior({
   groupId: string
   layout: Ref<number[]>
   panelDataArray: PanelData[]
-  panelGroupElement: Ref<ParentNode | null>
+  panelGroupElement: Ref<ParentNode | null | undefined>
   setLayout: (sizes: number[]) => void
   getPanelDataWithPercentConstraints: (groupSizeOverride?: number | null) => PanelData[] | null
 }): void {

--- a/packages/core/src/Stepper/StepperTrigger.vue
+++ b/packages/core/src/Stepper/StepperTrigger.vue
@@ -66,7 +66,7 @@ function handleKeyDown(event: KeyboardEvent) {
 
 const { forwardRef, currentElement } = useForwardExpose()
 
-let registeredElement: HTMLElement | null = null
+let registeredElement: HTMLElement | undefined
 
 onMounted(() => {
   registeredElement = currentElement.value
@@ -77,7 +77,7 @@ onMounted(() => {
 onUnmounted(() => {
   if (registeredElement) {
     rootContext.totalStepperItems.value.delete(registeredElement)
-    registeredElement = null
+    registeredElement = undefined
   }
 })
 </script>

--- a/packages/core/src/TagsInput/TagsInputInput.vue
+++ b/packages/core/src/TagsInput/TagsInputInput.vue
@@ -129,9 +129,9 @@ function handlePaste(event: ClipboardEvent) {
 }
 
 onMounted(() => {
-  const inputEl = currentElement.value.nodeName === 'INPUT'
+  const inputEl = currentElement.value?.nodeName === 'INPUT'
     ? currentElement.value
-    : currentElement.value.querySelector('input')
+    : currentElement.value?.querySelector('input')
 
   if (!inputEl)
     return

--- a/packages/core/src/Toast/ToastViewport.vue
+++ b/packages/core/src/Toast/ToastViewport.vue
@@ -53,11 +53,12 @@ const DIGIT_RE = /Digit/g
 const hotkeyMessage = computed(() => hotkey.value.join('+').replace(KEY_RE, '').replace(DIGIT_RE, ''))
 
 onKeyStroke(hotkey.value, () => {
-  currentElement.value.focus()
+  // TODO(currentElement): fires on a global hotkey at arbitrary times; should probably a no-op (currentElement.value?) rather than throw
+  currentElement.value!.focus()
 })
 
 onMounted(() => {
-  providerContext.onViewportChange(currentElement.value)
+  providerContext.onViewportChange(currentElement.value!)
 })
 
 watchEffect((cleanupFn) => {

--- a/packages/core/src/shared/useForwardExpose.test.ts
+++ b/packages/core/src/shared/useForwardExpose.test.ts
@@ -322,4 +322,136 @@ describe('useForwardRef', async () => {
     await flushPromises()
     expect(renderNode).toBe('span')
   })
+
+  it('should resolve undefined for a #text-root that renders no element', async () => {
+    const comp = defineComponent({
+      setup() {
+        const { forwardRef, currentElement } = useForwardExpose()
+        return { forwardRef, currentElement }
+      },
+      template: `just text, no element root`,
+    })
+    const el = ref()
+    let resolved
+    mount(
+      defineComponent(() => {
+        return () => h(comp, { ref: el })
+      }),
+    )
+    watchPostEffect(() => {
+      resolved = el.value?.currentElement
+    })
+    await flushPromises()
+    expect(resolved).toBeUndefined()
+  })
+
+  it('should resolve undefined for a #comment-root that renders no element', async () => {
+    const comp = defineComponent({
+      setup() {
+        const { forwardRef, currentElement } = useForwardExpose()
+        return { forwardRef, currentElement }
+      },
+      template: `<div v-if="false" />`,
+    })
+    const el = ref()
+    let resolved
+    mount(
+      defineComponent(() => {
+        return () => h(comp, { ref: el })
+      }),
+    )
+    watchPostEffect(() => {
+      resolved = el.value?.currentElement
+    })
+    await flushPromises()
+    expect(resolved).toBeUndefined()
+  })
+
+  it('should not resolve to an element outside a #comment-root component', async () => {
+    const Child = defineComponent({ template: `<div v-if="false" />` })
+
+    const comp = defineComponent({
+      components: { Child },
+      setup(_, { expose }) {
+        const { forwardRef, currentElement } = useForwardExpose()
+        expose({ currentElement })
+        return { forwardRef }
+      },
+      render() {
+        return [h(Child, { ref: this.forwardRef }), h('div', { id: 'outsider' })]
+      },
+    })
+
+    const parentRef = ref<any>()
+    mount(defineComponent(() => () => h(comp, { ref: parentRef })))
+    await flushPromises()
+
+    expect(parentRef.value?.currentElement).toBeUndefined()
+  })
+
+  it('should not resolve to an element outside a #text-root component', async () => {
+    const Child = defineComponent({ template: `just text` })
+
+    const comp = defineComponent({
+      components: { Child },
+      setup(_, { expose }) {
+        const { forwardRef, currentElement } = useForwardExpose()
+        expose({ currentElement })
+        return { forwardRef }
+      },
+      render() {
+        return [h(Child, { ref: this.forwardRef }), h('div', { id: 'outsider' })]
+      },
+    })
+
+    const parentRef = ref<any>()
+    mount(defineComponent(() => () => h(comp, { ref: parentRef })))
+    await flushPromises()
+
+    expect(parentRef.value?.currentElement).toBeUndefined()
+  })
+
+  it('should be undefined for a #comment-root component with no sibling', async () => {
+    const Child = defineComponent({ template: `<div v-if="false" />` })
+
+    const comp = defineComponent({
+      components: { Child },
+      setup(_, { expose }) {
+        const { forwardRef, currentElement } = useForwardExpose()
+        expose({ currentElement })
+        return { forwardRef }
+      },
+      render() {
+        return [h(Child, { ref: this.forwardRef })]
+      },
+    })
+
+    const parentRef = ref<any>()
+    mount(defineComponent(() => () => h(comp, { ref: parentRef })))
+    await flushPromises()
+
+    expect(parentRef.value?.currentElement).toBeUndefined()
+  })
+
+  it('should be undefined for a #text-root component with no sibling', async () => {
+    const Child = defineComponent({ template: `just text` })
+
+    const comp = defineComponent({
+      components: { Child },
+      setup(_, { expose }) {
+        const { forwardRef, currentElement } = useForwardExpose()
+        expose({ currentElement })
+        return { forwardRef }
+      },
+      render() {
+        return [h(Child, { ref: this.forwardRef })]
+      },
+    })
+
+    const parentRef = ref<any>()
+    mount(defineComponent(() => () => h(comp, { ref: parentRef })))
+    await flushPromises()
+
+    expect(parentRef.value?.currentElement).toBeUndefined()
+  })
 })

--- a/packages/core/src/shared/useForwardExpose.test.ts
+++ b/packages/core/src/shared/useForwardExpose.test.ts
@@ -454,4 +454,49 @@ describe('useForwardRef', async () => {
 
     expect(parentRef.value?.currentElement).toBeUndefined()
   })
+
+  it('should resolve the first element root of a multi-root fragment', async () => {
+    const Child = defineComponent({ template: `leading text <button id="own">ok</button>` })
+
+    const comp = defineComponent({
+      components: { Child },
+      setup(_, { expose }) {
+        const { forwardRef, currentElement } = useForwardExpose()
+        expose({ currentElement })
+        return { forwardRef }
+      },
+      render() {
+        return [h(Child, { ref: this.forwardRef }), h('div', { id: 'outsider' })]
+      },
+    })
+
+    const parentRef = ref<any>()
+    mount(defineComponent(() => () => h(comp, { ref: parentRef })))
+    await flushPromises()
+
+    expect(parentRef.value?.currentElement).toBeInstanceOf(HTMLButtonElement)
+    expect(parentRef.value?.currentElement?.id).toBe('own')
+  })
+
+  it('should not resolve outside element when the fragment has no proper element', async () => {
+    const Child = defineComponent({ template: `<!-- a --><!-- b -->` })
+
+    const comp = defineComponent({
+      components: { Child },
+      setup(_, { expose }) {
+        const { forwardRef, currentElement } = useForwardExpose()
+        expose({ currentElement })
+        return { forwardRef }
+      },
+      render() {
+        return [h(Child, { ref: this.forwardRef }), h('div', { id: 'outsider' })]
+      },
+    })
+
+    const parentRef = ref<any>()
+    mount(defineComponent(() => () => h(comp, { ref: parentRef })))
+    await flushPromises()
+
+    expect(parentRef.value?.currentElement).toBeUndefined()
+  })
 })

--- a/packages/core/src/shared/useForwardExpose.ts
+++ b/packages/core/src/shared/useForwardExpose.ts
@@ -20,12 +20,33 @@ export function useForwardExpose<T extends ComponentPublicInstance>() {
   })
 
   function resolveCurrentElement() {
-    // $el could be text/comment for non-single root normal or text root, thus we retrieve the nextElementSibling
-    return currentRef.value
-      && '$el' in currentRef.value
-      && ['#text', '#comment'].includes(currentRef.value.$el.nodeName)
-      ? currentRef.value.$el.nextElementSibling as HTMLElement
-      : unrefElement(currentRef as unknown as MaybeElement) as HTMLElement
+    // $el could be #text/#comment for non-single root normal or text root, thus we
+    // try to retrieve the `nextElementSibling`
+    const el = currentRef.value
+    if (el
+      && '$el' in el
+      && ['#text', '#comment'].includes(el.$el.nodeName)) {
+      // no end anchor, means that it is a singular #text or #comment -> no proper element,
+      // so early-return.
+      const anchor = el.$?.subTree?.anchor as Node | null
+      if (!anchor)
+        return undefined
+
+      // accept the next sibling ONLY if it is a part of the component;
+      // sibling positioned AFTER the anchor belongs to something else,
+      // and should not be returned.
+      const nextSibling = el.$el.nextElementSibling as HTMLElement | null
+      if (
+        nextSibling
+        && (nextSibling.compareDocumentPosition(anchor) & Node.DOCUMENT_POSITION_FOLLOWING)
+      ) {
+        return nextSibling
+      }
+
+      return undefined
+    }
+
+    return unrefElement(currentRef as unknown as MaybeElement) as HTMLElement | undefined
   }
 
   // Do give us credit if you reference our code :D


### PR DESCRIPTION
### 🔗 Linked issue

[#2804](https://github.com/unovue/reka-ui/issues/2804)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves [#2804](https://github.com/unovue/reka-ui/issues/2804).

Walking `nextElementSibling` from a fragment's start anchor without a bound meant a component rendering no element (#text/#comment/empty-fragment root) resolved to an unrelated following element. The result was also typed `HTMLElement` while it could be nullish, so consumers crashed calling `.contains()` on it. Tests that verify it were added.

As for the Breaking Change, many components already guarded against the lying type, but outside uses may need minor fixes. None of the existing behaviours was changed: the 2nd commit just satisfies the type checker, and there are some questionable spots that would require further discussion.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of components rendered without standard HTML elements, preventing incorrect element detection.
  - Improved focus, autofocus, highlighting, toast hotkeys, slider, stepper, and dismissible-layer behavior when elements are unavailable during setup or cleanup.
  - Improved splitter behavior when its panel group is temporarily unavailable.

- **Tests**
  - Added coverage for text-only and comment-only component roots, including cases where no valid sibling element exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->