### PR TITLE
fix(Splitter): validate empty group silently

### DIFF
--- a/packages/core/src/Splitter/utils/validation.test.ts
+++ b/packages/core/src/Splitter/utils/validation.test.ts
@@ -1,0 +1,15 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { validatePanelGroupLayout } from './validation'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('validatePanelGroupLayout', () => {
+  it('should validate an empty group silently', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = validatePanelGroupLayout({ layout: [], panelConstraints: [] })
+    expect(result).toEqual([])
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/Splitter/utils/validation.test.ts
+++ b/packages/core/src/Splitter/utils/validation.test.ts
@@ -12,4 +12,10 @@ describe('validatePanelGroupLayout', () => {
     expect(result).toEqual([])
     expect(warn).not.toHaveBeenCalled()
   })
+
+  it('should throw when the layout length does not match the panel constraints', () => {
+    expect(() =>
+      validatePanelGroupLayout({ layout: [50, 50], panelConstraints: [] }),
+    ).toThrow('Invalid 0 panel layout')
+  })
 })

--- a/packages/core/src/Splitter/utils/validation.ts
+++ b/packages/core/src/Splitter/utils/validation.ts
@@ -14,7 +14,7 @@ export function validatePanelGroupLayout({
   const nextLayout = [...prevLayout]
 
   // An empty group has no sizes to total, so 0 !== 100 here is not a misconfiguration
-  if (panelConstraints.length === 0)
+  if (nextLayout.length === 0 && panelConstraints.length === 0)
     return nextLayout
 
   const nextLayoutTotalSize = nextLayout.reduce(

--- a/packages/core/src/Splitter/utils/validation.ts
+++ b/packages/core/src/Splitter/utils/validation.ts
@@ -12,6 +12,11 @@ export function validatePanelGroupLayout({
   panelConstraints: PanelConstraints[]
 }): number[] {
   const nextLayout = [...prevLayout]
+
+  // An empty group has no sizes to total, so 0 !== 100 here is not a misconfiguration
+  if (panelConstraints.length === 0)
+    return nextLayout
+
   const nextLayoutTotalSize = nextLayout.reduce(
     (accumulated, current) => accumulated + current,
     0,


### PR DESCRIPTION
When a `SplitterGroup` outlives its panels, say the last one sits behind a `v-if` that gets toggled off, the registration watcher still validates a group that now has zero registered panels. `validatePanelGroupLayout` compares the empty layout's total of 0 against 100 and logs `Invalid layout total size: .`, even though an empty group has no sizes to total and nothing to normalize. The fix returns early when there are no panel constraints, so an empty group validates silently.

Fixes #2834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty panel groups by bypassing unnecessary layout validation and normalization.
  * Prevented irrelevant warnings when panel constraints are unavailable.
  * Added clearer validation for mismatched layout and panel-constraint lengths.

* **Tests**
  * Expanded coverage for empty panel groups and layout validation behavior.
  * Improved test isolation by restoring mocks after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->