### PR TITLE
perf(Presence): skip work for bubbled animation events

### DIFF
--- a/packages/core/src/Presence/Presence.test.ts
+++ b/packages/core/src/Presence/Presence.test.ts
@@ -147,22 +147,23 @@ describe('given a Presence with animated content', () => {
 describe('given a Presence with an animated descendant', () => {
   it('should ignore bubbled animation events before reading styles', async () => {
     const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle')
-    const wrapper = mount(defineComponent({
-      components: { Presence },
-      template: `<Presence :present="true">
-        <div data-testid="presence">
-          <span data-testid="animated-child">Child</span>
-        </div>
-      </Presence>`,
-    }))
-
     const createAnimationEndEvent = () => {
       const event = new Event('animationend', { bubbles: true })
       Object.defineProperty(event, 'animationName', { value: 'child-animation' })
       return event
     }
+    let wrapper: ReturnType<typeof mount> | undefined
 
     try {
+      wrapper = mount(defineComponent({
+        components: { Presence },
+        template: `<Presence :present="true">
+          <div data-testid="presence">
+            <span data-testid="animated-child">Child</span>
+          </div>
+        </Presence>`,
+      }))
+
       await nextTick()
       const presenceElement = wrapper.find('[data-testid="presence"]').element
       const animatedChild = wrapper.find('[data-testid="animated-child"]').element
@@ -176,7 +177,7 @@ describe('given a Presence with an animated descendant', () => {
       expect(getComputedStyleSpy).not.toHaveBeenCalledWith(presenceElement)
     }
     finally {
-      wrapper.unmount()
+      wrapper?.unmount()
       getComputedStyleSpy.mockRestore()
     }
   })

--- a/packages/core/src/Presence/Presence.test.ts
+++ b/packages/core/src/Presence/Presence.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
-import { defineComponent, onMounted, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, onMounted, ref } from 'vue'
 import { Presence } from '.'
 
 const CONTENT = 'Content'
@@ -141,5 +141,43 @@ describe('given a Presence with animated content', () => {
         expect(wrapper.html()).not.toContain(CONTENT)
       })
     })
+  })
+})
+
+describe('given a Presence with an animated descendant', () => {
+  it('should ignore bubbled animation events before reading styles', async () => {
+    const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle')
+    const wrapper = mount(defineComponent({
+      components: { Presence },
+      template: `<Presence :present="true">
+        <div data-testid="presence">
+          <span data-testid="animated-child">Child</span>
+        </div>
+      </Presence>`,
+    }))
+
+    const createAnimationEndEvent = () => {
+      const event = new Event('animationend', { bubbles: true })
+      Object.defineProperty(event, 'animationName', { value: 'child-animation' })
+      return event
+    }
+
+    try {
+      await nextTick()
+      const presenceElement = wrapper.find('[data-testid="presence"]').element
+      const animatedChild = wrapper.find('[data-testid="animated-child"]').element
+      getComputedStyleSpy.mockClear()
+
+      presenceElement.dispatchEvent(createAnimationEndEvent())
+      expect(getComputedStyleSpy).toHaveBeenCalledWith(presenceElement)
+      getComputedStyleSpy.mockClear()
+
+      animatedChild.dispatchEvent(createAnimationEndEvent())
+      expect(getComputedStyleSpy).not.toHaveBeenCalledWith(presenceElement)
+    }
+    finally {
+      wrapper.unmount()
+      getComputedStyleSpy.mockRestore()
+    }
   })
 })

--- a/packages/core/src/Presence/usePresence.ts
+++ b/packages/core/src/Presence/usePresence.ts
@@ -91,12 +91,15 @@ export function usePresence(
    * make sure we only trigger ANIMATION_END for the currently active animation.
    */
   const handleAnimationEnd = (event: AnimationEvent) => {
+    if (event.target !== node.value)
+      return
+
     const currentAnimationName = getAnimationName(node.value)
     const isCurrentAnimation = currentAnimationName.includes(
       CSS.escape(event.animationName),
     )
     const directionName = state.value === 'mounted' ? 'enter' : 'leave'
-    if (event.target === node.value && isCurrentAnimation) {
+    if (isCurrentAnimation) {
       dispatchCustomEvent(`after-${directionName}`)
       dispatch('ANIMATION_END')
 
@@ -115,7 +118,7 @@ export function usePresence(
       }
     }
     // if no animation, immediately trigger 'ANIMATION_END'
-    if (event.target === node.value && currentAnimationName === 'none')
+    if (currentAnimationName === 'none')
       dispatch('ANIMATION_END')
   }
   const handleAnimationStart = (event: AnimationEvent) => {


### PR DESCRIPTION
### Linked issue

Closes #2838

### Type of change

- [ ] Documentation
- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Chore
- [ ] Breaking change

### Description

`animationend` and `animationcancel` bubble from descendants. Presence was
calling `getAnimationName(node.value)`, and therefore `getComputedStyle`,
before checking whether the event originated from its own host element. The
result was discarded for descendant events because both behavior branches
already required `event.target === node.value`.

I moved that target check to an early return. Events from the Presence host
retain the same behavior, while descendant events no longer trigger
unnecessary style reads. This also aligns `handleAnimationEnd` with the
existing target guard in `handleAnimationStart`.

I added a regression test with a direct-event positive control before
asserting that a bubbled descendant event does not read the Presence host
styles.

### Screenshots

Not applicable.

### Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. Not applicable: this is an
  internal, behavior-preserving performance change with no public API changes.

### Validation

- `pnpm --filter reka-ui exec vitest run src/Presence/Presence.test.ts`
- `pnpm exec eslint packages/core/src/Presence/usePresence.ts packages/core/src/Presence/Presence.test.ts`
- `pnpm --filter reka-ui type-check`
- `pnpm --filter reka-ui build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed presence animations completing incorrectly when animation events bubble up from descendant elements.
  * Ensured only animation events from the tracked element determine animation completion, improving transition reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->