### PR TITLE
feat(Combobox): add unmountOnHide prop

### DIFF
--- a/docs/content/meta/ComboboxRoot.md
+++ b/docs/content/meta/ComboboxRoot.md
@@ -122,6 +122,13 @@
     'type': 'boolean',
     'required': false,
     'default': 'true'
+  },
+  {
+    'name': 'unmountOnHide',
+    'description': '<p>When set to <code>false</code>, the Combobox content will not be unmounted when closed, but instead hidden with CSS. &lt;br&gt;\nUseful when you want to improve performance by not remounting the content on every open.</p>\n',
+    'type': 'boolean',
+    'required': false,
+    'default': 'true'
   }
 ]" />
 
@@ -182,6 +189,7 @@
 | `resetModelValueOnClear` | When true the modelValue will be reset to null (or [] if multiple) | `boolean` | No | `false` |
 | `resetSearchTermOnBlur` | Whether to reset the searchTerm when the Combobox input blurred | `boolean` | No | `true` |
 | `resetSearchTermOnSelect` | Whether to reset the searchTerm when the Combobox value is selected | `boolean` | No | `true` |
+| `unmountOnHide` | When set to false, the Combobox content will not be unmounted when closed, but instead hidden with CSS. <br> Useful when you want to improve performance by not remounting the content on every open. | `boolean` | No | `true` |
 
 **Events**
 

--- a/packages/core/src/Autocomplete/AutocompleteRoot.vue
+++ b/packages/core/src/Autocomplete/AutocompleteRoot.vue
@@ -237,6 +237,7 @@ provideComboboxRootContext({
   openOnFocus,
   openOnClick,
   resetModelValueOnClear: ref(true),
+  unmountOnHide: ref(true),
 })
 
 // Provide autocomplete-specific context

--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -79,8 +79,10 @@ describe('given a Combobox with unmountOnHide=false', () => {
     await nextTick()
     expect(content.style.display).not.toBe('none')
 
+    statefulInput.focus()
     statefulInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
     await vi.waitFor(() => expect(content.style.display).toBe('none'))
+    expect(document.activeElement).toBe(trigger.element)
 
     await trigger.trigger('click')
     await nextTick()
@@ -108,6 +110,14 @@ describe('given a Combobox with unmountOnHide=false', () => {
 
     expect(document.body.style.overflow).not.toBe('hidden')
     await trigger.trigger('click')
+    await nextTick()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    await wrapper.setProps({ bodyLock: false })
+    await nextTick()
+    expect(document.body.style.overflow).not.toBe('hidden')
+
+    await wrapper.setProps({ bodyLock: true })
     await nextTick()
     expect(document.body.style.overflow).toBe('hidden')
 

--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -1,13 +1,201 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { handleSubmit, sleep } from '@/test'
-import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxRoot, ComboboxTrigger, ComboboxViewport, ComboboxVirtualizer } from '.'
+import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot, ComboboxTrigger, ComboboxViewport, ComboboxVirtualizer } from '.'
 import Combobox from './story/_Combobox.vue'
 import ComboboxObject from './story/_ComboboxObject.vue'
 import ComboboxTagsInput from './story/_ComboboxTagsInput.vue'
+
+const PersistentCombobox = defineComponent({
+  components: { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot, ComboboxTrigger, ComboboxViewport },
+  props: {
+    bodyLock: Boolean,
+    onEscapeKeyDown: Function,
+    onInteractOutside: Function,
+  },
+  template: `<ComboboxRoot :unmount-on-hide="false">
+  <ComboboxAnchor>
+    <ComboboxInput data-testid="persistent-input" />
+    <ComboboxTrigger data-testid="persistent-trigger">Open</ComboboxTrigger>
+  </ComboboxAnchor>
+  <ComboboxPortal>
+    <ComboboxContent
+      data-testid="persistent-content"
+      :body-lock="bodyLock"
+      @escape-key-down="onEscapeKeyDown"
+      @interact-outside="onInteractOutside"
+    >
+      <ComboboxViewport>
+        <ComboboxItem value="Apple">Apple</ComboboxItem>
+      </ComboboxViewport>
+      <input data-testid="option-state" aria-label="Option state">
+    </ComboboxContent>
+  </ComboboxPortal>
+</ComboboxRoot>`,
+})
+
+const PersistentComboboxWithInputInside = defineComponent({
+  components: { ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot, ComboboxTrigger, ComboboxViewport },
+  template: `<ComboboxRoot :unmount-on-hide="false">
+  <ComboboxTrigger data-testid="inside-trigger">Open</ComboboxTrigger>
+  <ComboboxPortal>
+    <ComboboxContent data-testid="inside-content">
+      <ComboboxInput data-testid="inside-input" />
+      <ComboboxViewport>
+        <ComboboxItem value="Apple">Apple</ComboboxItem>
+      </ComboboxViewport>
+    </ComboboxContent>
+  </ComboboxPortal>
+</ComboboxRoot>`,
+})
+
+describe('given a Combobox with unmountOnHide=false', () => {
+  let wrapper: VueWrapper<InstanceType<typeof PersistentCombobox>>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(PersistentCombobox, { attachTo: document.body })
+  })
+
+  afterEach(async () => {
+    wrapper?.unmount()
+    await nextTick()
+  })
+
+  it('keeps the same hidden content node and subtree state across close and reopen', async () => {
+    const trigger = wrapper.find('[data-testid="persistent-trigger"]')
+    const content = document.querySelector('[data-testid="persistent-content"]') as HTMLElement
+    const statefulInput = document.querySelector('[data-testid="option-state"]') as HTMLInputElement
+
+    expect(content.style.display).toBe('none')
+    expect(content.dataset.state).toBe('closed')
+    expect(document.querySelector('[role="combobox"]')?.getAttribute('aria-expanded')).toBe('false')
+    statefulInput.value = 'preserved'
+
+    await trigger.trigger('click')
+    await nextTick()
+    expect(content.style.display).not.toBe('none')
+
+    statefulInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await vi.waitFor(() => expect(content.style.display).toBe('none'))
+
+    await trigger.trigger('click')
+    await nextTick()
+    expect(document.querySelector('[data-testid="persistent-content"]')).toBe(content)
+    expect((document.querySelector('[data-testid="option-state"]') as HTMLInputElement).value).toBe('preserved')
+  })
+
+  it('does not activate focus or dismissal behavior while closed', async () => {
+    const onEscapeKeyDown = vi.fn()
+    const onInteractOutside = vi.fn()
+    await wrapper.setProps({ onEscapeKeyDown, onInteractOutside })
+
+    expect(document.activeElement).toBe(document.body)
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    await sleep(1)
+
+    expect(onEscapeKeyDown).not.toHaveBeenCalled()
+    expect(onInteractOutside).not.toHaveBeenCalled()
+  })
+
+  it('releases body scroll lock when hidden', async () => {
+    await wrapper.setProps({ bodyLock: true })
+    const trigger = wrapper.find('[data-testid="persistent-trigger"]')
+
+    expect(document.body.style.overflow).not.toBe('hidden')
+    await trigger.trigger('click')
+    await nextTick()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    document.activeElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await vi.waitFor(() => expect(document.body.style.overflow).not.toBe('hidden'))
+  })
+
+  it('removes persistent portal content when the root unmounts', () => {
+    const content = document.querySelector('[data-testid="persistent-content"]') as HTMLElement
+    wrapper.unmount()
+    expect(document.body.contains(content)).toBe(false)
+  })
+})
+
+describe('given a persistent Combobox with its input inside content', () => {
+  let wrapper: VueWrapper<InstanceType<typeof PersistentComboboxWithInputInside>>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(PersistentComboboxWithInputInside, { attachTo: document.body })
+  })
+
+  afterEach(() => wrapper?.unmount())
+
+  it('does not focus hidden content on mount and restores the trigger on close', async () => {
+    const trigger = wrapper.find('[data-testid="inside-trigger"]')
+    expect(document.activeElement).toBe(document.body)
+
+    await trigger.trigger('click')
+    await vi.waitFor(() => expect(document.activeElement?.getAttribute('data-testid')).toBe('inside-input'))
+
+    await document.activeElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await vi.waitFor(() => expect(document.activeElement).toBe(trigger.element))
+  })
+})
+
+describe('given two persistent Comboboxes', () => {
+  const TwoPersistentComboboxes = defineComponent({
+    components: { PersistentCombobox },
+    props: { onSecondEscapeKeyDown: Function },
+    template: `<div>
+  <PersistentCombobox data-testid="first" />
+  <PersistentCombobox data-testid="second" :on-escape-key-down="onSecondEscapeKeyDown" />
+</div>`,
+  })
+
+  let wrapper: VueWrapper<InstanceType<typeof TwoPersistentComboboxes>>
+
+  afterEach(async () => {
+    wrapper?.unmount()
+    await nextTick()
+  })
+
+  it('lets the open Combobox handle Escape when a hidden one mounted after it', async () => {
+    document.body.innerHTML = ''
+    const onSecondEscapeKeyDown = vi.fn()
+    wrapper = mount(TwoPersistentComboboxes, { attachTo: document.body, props: { onSecondEscapeKeyDown } })
+    await nextTick()
+    const triggers = wrapper.findAll('[data-testid="persistent-trigger"]')
+    const contents = document.querySelectorAll<HTMLElement>('[data-testid="persistent-content"]')
+
+    await triggers[0].trigger('click')
+    await nextTick()
+    expect(contents[0].style.display).not.toBe('none')
+    expect(contents[1].style.display).toBe('none')
+
+    document.activeElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await vi.waitFor(() => expect(contents[0].style.display).toBe('none'))
+
+    expect(onSecondEscapeKeyDown).not.toHaveBeenCalled()
+  })
+})
+
+describe('given a default Combobox mount policy', () => {
+  it('continues to unmount content when closed', async () => {
+    document.body.innerHTML = ''
+    const wrapper = mount(Combobox, { attachTo: document.body })
+    expect(document.querySelector('[role="listbox"]')).toBeNull()
+
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+    expect(document.querySelector('[role="listbox"]')).not.toBeNull()
+
+    document.activeElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await vi.waitFor(() => expect(document.querySelector('[role="listbox"]')).toBeNull())
+    wrapper.unmount()
+  })
+})
 
 describe('given default Combobox', () => {
   let wrapper: VueWrapper<InstanceType<typeof Combobox>>

--- a/packages/core/src/Combobox/ComboboxContent.vue
+++ b/packages/core/src/Combobox/ComboboxContent.vue
@@ -28,10 +28,16 @@ rootContext.contentId ||= useId(undefined, 'reka-combobox-content')
 </script>
 
 <template>
-  <Presence :present="forceMount || rootContext.open.value">
+  <Presence
+    v-slot="{ present }"
+    :present="forceMount || rootContext.open.value"
+    :force-mount="forceMount || !rootContext.unmountOnHide.value"
+  >
     <ComboboxContentImpl
+      v-show="rootContext.unmountOnHide.value || present"
       v-bind="{ ...forwarded, ...$attrs }"
       :ref="forwardRef"
+      :present="rootContext.unmountOnHide.value || present"
     >
       <slot />
     </ComboboxContentImpl>

--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -55,7 +55,7 @@ const isEmpty = computed(() => rootContext.ignoreFilter.value
 
 const { forwardRef, currentElement } = useForwardExpose()
 const scrollLocked = useBodyScrollLock(props.present && props.bodyLock)
-watch(() => props.present, present => scrollLocked.value = present && props.bodyLock)
+watch([() => props.present, () => props.bodyLock], ([present, bodyLock]) => scrollLocked.value = present && bodyLock)
 useFocusGuards()
 const ariaHiddenTarget = computed(() => props.present ? rootContext.parentElement.value : undefined)
 useHideOthers(ariaHiddenTarget)
@@ -99,13 +99,15 @@ onMounted(() => {
 })
 
 watch(() => props.present, async (isPresent, wasPresent) => {
-  if (isPresent || !wasPresent || !isInputWithinContent.value)
+  if (isPresent || !wasPresent)
+    return
+
+  const activeElement = getActiveElement()
+  if (!activeElement || !currentElement.value.contains(activeElement))
     return
 
   await nextTick()
-  const activeElement = getActiveElement()
-  if (!activeElement || activeElement === document.body || currentElement.value.contains(activeElement))
-    rootContext.triggerElement.value?.focus()
+  rootContext.triggerElement.value?.focus()
 })
 
 onUnmounted(() => {

--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -31,7 +31,7 @@ export const [injectComboboxContentContext, provideComboboxContentContext]
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, toRefs } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, toRefs, watch } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { FocusScope } from '@/FocusScope'
 import { ListboxContent } from '@/Listbox'
@@ -39,8 +39,9 @@ import { PopperContent } from '@/Popper'
 import { Primitive } from '@/Primitive'
 import { injectComboboxRootContext } from './ComboboxRoot.vue'
 
-const props = withDefaults(defineProps<ComboboxContentImplProps>(), {
+const props = withDefaults(defineProps<ComboboxContentImplProps & { present?: boolean }>(), {
   position: 'inline',
+  present: true,
 })
 const emits = defineEmits<ComboboxContentImplEmits>()
 
@@ -53,14 +54,20 @@ const isEmpty = computed(() => rootContext.ignoreFilter.value
 )
 
 const { forwardRef, currentElement } = useForwardExpose()
-useBodyScrollLock(props.bodyLock)
+const scrollLocked = useBodyScrollLock(props.present && props.bodyLock)
+watch(() => props.present, present => scrollLocked.value = present && props.bodyLock)
 useFocusGuards()
-useHideOthers(rootContext.parentElement)
+const ariaHiddenTarget = computed(() => props.present ? rootContext.parentElement.value : undefined)
+useHideOthers(ariaHiddenTarget)
 
 const pickedProps = computed(() => {
-  if (props.position === 'popper')
-    return props
-  else return {}
+  if (props.position === 'popper') {
+    const { present: _, ...forwardedProps } = props
+    return forwardedProps
+  }
+  else {
+    return {}
+  }
 })
 
 const forwardedProps = useForwardProps(pickedProps.value)
@@ -85,10 +92,20 @@ const isInputWithinContent = ref(false)
 onMounted(() => {
   if (rootContext.inputElement.value) {
     isInputWithinContent.value = currentElement.value.contains(rootContext.inputElement.value)
-    if (isInputWithinContent.value) {
+    if (props.present && isInputWithinContent.value) {
       rootContext.inputElement.value.focus()
     }
   }
+})
+
+watch(() => props.present, async (isPresent, wasPresent) => {
+  if (isPresent || !wasPresent || !isInputWithinContent.value)
+    return
+
+  await nextTick()
+  const activeElement = getActiveElement()
+  if (!activeElement || activeElement === document.body || currentElement.value.contains(activeElement))
+    rootContext.triggerElement.value?.focus()
 })
 
 onUnmounted(() => {
@@ -116,11 +133,13 @@ function isEventTargetWithinCombobox(target: EventTarget | null) {
   <ListboxContent as-child>
     <FocusScope
       as-child
+      :present="props.present"
       @mount-auto-focus.prevent
       @unmount-auto-focus.prevent
     >
       <DismissableLayer
         as-child
+        :present="props.present"
         :disable-outside-pointer-events="disableOutsidePointerEvents"
         @dismiss="rootContext.onOpenChange(false)"
         @focus-outside="(ev) => {

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -30,6 +30,7 @@ type ComboboxRootContext<T> = {
   openOnFocus: Ref<boolean>
   openOnClick: Ref<boolean>
   resetModelValueOnClear: Ref<boolean>
+  unmountOnHide: Ref<boolean>
 }
 
 export const [injectComboboxRootContext, provideComboboxRootContext]
@@ -77,6 +78,12 @@ export interface ComboboxRootProps<T = AcceptableValue> extends Omit<ListboxRoot
    * When `true` the `modelValue` will be reset to `null` (or `[]` if `multiple`)
    */
   resetModelValueOnClear?: boolean
+  /**
+   * When set to `false`, the Combobox content will not be unmounted when closed, but instead hidden with CSS. <br>
+   * Useful when you want to improve performance by not remounting the content on every open.
+   * @defaultValue true
+   */
+  unmountOnHide?: boolean
 }
 </script>
 
@@ -95,6 +102,7 @@ const props = withDefaults(defineProps<ComboboxRootProps<T>>(), {
   openOnClick: false,
   resetModelValueOnClear: false,
   highlightOnHover: true,
+  unmountOnHide: true,
 })
 const emits = defineEmits<ComboboxRootEmits<T>>()
 
@@ -108,7 +116,7 @@ defineSlots<{
 }>()
 
 const { primitiveElement, currentElement: parentElement } = usePrimitiveElement<GenericComponentInstance<typeof ListboxRoot>>()
-const { multiple, disabled, ignoreFilter, resetSearchTermOnSelect, openOnFocus, openOnClick, dir: propDir, resetModelValueOnClear, highlightOnHover } = toRefs(props)
+const { multiple, disabled, ignoreFilter, resetSearchTermOnSelect, openOnFocus, openOnClick, dir: propDir, resetModelValueOnClear, highlightOnHover, unmountOnHide } = toRefs(props)
 
 const dir = useDirection(propDir)
 
@@ -243,6 +251,7 @@ provideComboboxRootContext({
   openOnFocus,
   openOnClick,
   resetModelValueOnClear,
+  unmountOnHide,
 })
 </script>
 

--- a/packages/core/src/Combobox/story/_ComboboxManualFilter.vue
+++ b/packages/core/src/Combobox/story/_ComboboxManualFilter.vue
@@ -5,7 +5,9 @@ import { computed, ref } from 'vue'
 import { useFilter } from '@/shared'
 import { ComboboxAnchor, ComboboxContent, ComboboxGroup, ComboboxInput, ComboboxItem, ComboboxItemIndicator, ComboboxLabel, ComboboxRoot, ComboboxTrigger, ComboboxViewport } from '..'
 
-const props = defineProps<ComboboxRootProps & { input?: ComboboxInputProps }>()
+const props = withDefaults(defineProps<ComboboxRootProps & { input?: ComboboxInputProps }>(), {
+  unmountOnHide: true,
+})
 const people = [
   { id: 1, name: 'Durward Reynolds' },
   { id: 2, name: 'Kenton Towne' },

--- a/packages/core/src/Combobox/story/_ComboboxObject.vue
+++ b/packages/core/src/Combobox/story/_ComboboxObject.vue
@@ -4,7 +4,9 @@ import { Icon } from '@iconify/vue'
 import { ref } from 'vue'
 import { ComboboxAnchor, ComboboxContent, ComboboxGroup, ComboboxInput, ComboboxItem, ComboboxItemIndicator, ComboboxLabel, ComboboxRoot, ComboboxTrigger, ComboboxViewport } from '..'
 
-const props = defineProps<ComboboxRootProps & { input?: ComboboxInputProps }>()
+const props = withDefaults(defineProps<ComboboxRootProps & { input?: ComboboxInputProps }>(), {
+  unmountOnHide: true,
+})
 const people = [
   { id: 1, name: 'Durward Reynolds' },
   { id: 2, name: 'Kenton Towne' },


### PR DESCRIPTION
### 🔗 Linked issue

Follows the Dialog precedent in [#2662](https://github.com/unovue/reka-ui/pull/2662).

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds `unmountOnHide` to `ComboboxRoot`, defaulting to `true`. When `false`, content stays mounted but hidden while closed, preserving expensive option subtrees and internal state across open cycles.

Closed persistent content is excluded from focus, dismissal, body-scroll-lock, and surrounding-content ARIA behavior. `ComboboxContent.forceMount` keeps its existing low-level semantics. Tests cover persistence, unchanged defaults, event safety, body-lock changes, multiple instances, and cleanup.

### 📸 Screenshots (if appropriate)

Not applicable.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `unmountOnHide` option to Combobox, defaulting to `true`.
  * Combobox content can remain mounted and visually hidden when closed by setting `unmountOnHide` to `false`.
  * Autocomplete retains its default unmounting behavior.

* **Bug Fixes**
  * Improved focus restoration, scrolling, dismissal, portal cleanup, and Escape-key handling for persistent Combobox content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
