### PR TITLE
perf(Presence): avoid repeated style recalculations

### DIFF
--- a/packages/core/src/Presence/Presence.test.ts
+++ b/packages/core/src/Presence/Presence.test.ts
@@ -145,7 +145,7 @@ describe('given a Presence with animated content', () => {
 })
 
 describe('given a Presence with an animated descendant', () => {
-  it('should ignore bubbled animation events before reading styles', async () => {
+  it('should handle animation events from cached styles and ignore bubbled events', async () => {
     const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle')
     const createAnimationEndEvent = () => {
       const event = new Event('animationend', { bubbles: true })
@@ -170,11 +170,10 @@ describe('given a Presence with an animated descendant', () => {
       getComputedStyleSpy.mockClear()
 
       presenceElement.dispatchEvent(createAnimationEndEvent())
-      expect(getComputedStyleSpy).toHaveBeenCalledWith(presenceElement)
-      getComputedStyleSpy.mockClear()
+      expect(getComputedStyleSpy).not.toHaveBeenCalled()
 
       animatedChild.dispatchEvent(createAnimationEndEvent())
-      expect(getComputedStyleSpy).not.toHaveBeenCalledWith(presenceElement)
+      expect(getComputedStyleSpy).not.toHaveBeenCalled()
     }
     finally {
       wrapper?.unmount()
@@ -182,3 +181,249 @@ describe('given a Presence with an animated descendant', () => {
     }
   })
 })
+
+describe('given batched Presence updates', () => {
+  it('waits for the batch to mount before reading initial animation names', async () => {
+    const present = ref(false)
+    const animationReadNodeCounts: number[] = []
+    const deferredAnimationReads: boolean[] = []
+    const styles = new WeakMap<Element, CSSStyleDeclaration>()
+    const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle').mockImplementation((element) => {
+      let style = styles.get(element)
+      if (!style) {
+        let canReadAnimation = false
+        queueMicrotask(() => canReadAnimation = true)
+        style = {
+          get animationName() {
+            animationReadNodeCounts.push(document.querySelectorAll('[data-batch-presence]').length)
+            deferredAnimationReads.push(canReadAnimation)
+            return 'none'
+          },
+          get display() {
+            return 'block'
+          },
+        } as CSSStyleDeclaration
+        styles.set(element, style)
+      }
+      return style
+    })
+    const host = document.createElement('div')
+    document.body.append(host)
+    const wrapper = mount(defineComponent({
+      components: { Presence },
+      setup: () => ({ present }),
+      template: `<div>
+        <Presence v-for="index in 6" :key="index" :present="present">
+          <span data-batch-presence />
+        </Presence>
+      </div>`,
+    }), { attachTo: host })
+
+    try {
+      await flushPresence()
+      animationReadNodeCounts.length = 0
+
+      present.value = true
+      await flushPresence()
+
+      expect(wrapper.findAll('[data-batch-presence]')).toHaveLength(6)
+      expect(animationReadNodeCounts.length).toBeGreaterThan(0)
+      expect(animationReadNodeCounts.every(count => count === 6)).toBe(true)
+      expect(deferredAnimationReads.every(Boolean)).toBe(true)
+    }
+    finally {
+      wrapper.unmount()
+      host.remove()
+      getComputedStyleSpy.mockRestore()
+    }
+  })
+
+  it('does not read computed styles while unmounting non-animated nodes', async () => {
+    const present = ref(true)
+    const getComputedStyleSpy = vi.spyOn(globalThis, 'getComputedStyle')
+    const wrapper = mount(defineComponent({
+      components: { Presence },
+      setup: () => ({ present }),
+      template: `<div>
+        <Presence v-for="index in 6" :key="index" :present="present">
+          <span :data-index="index" />
+        </Presence>
+      </div>`,
+    }))
+
+    try {
+      await flushPresence()
+      getComputedStyleSpy.mockClear()
+
+      present.value = false
+      await flushPresence()
+
+      expect(wrapper.findAll('span')).toHaveLength(0)
+      expect(getComputedStyleSpy).not.toHaveBeenCalled()
+    }
+    finally {
+      wrapper.unmount()
+      getComputedStyleSpy.mockRestore()
+    }
+  })
+
+  it('keeps animated content mounted until its exit animation ends', async () => {
+    const open = ref(true)
+    const events: string[] = []
+    const getComputedStyleSpy = mockLiveAnimationStyles()
+    const wrapper = mount(defineComponent({
+      components: { Presence },
+      setup: () => ({ events, open }),
+      template: `<Presence :present="open">
+        <div
+          data-testid="animated"
+          :data-state="open ? 'open' : 'closed'"
+          @leave="events.push('leave')"
+          @after-leave="events.push('after-leave')"
+        />
+      </Presence>`,
+    }))
+
+    try {
+      await flushPresence()
+      events.length = 0
+
+      open.value = false
+      await flushPresence()
+
+      const element = wrapper.find('[data-testid="animated"]')
+      expect(element.exists()).toBe(true)
+      expect(events).toEqual(['leave'])
+
+      element.element.dispatchEvent(createAnimationEvent('animationend', 'fadeOut'))
+      await flushPresence()
+
+      expect(wrapper.find('[data-testid="animated"]').exists()).toBe(false)
+      expect(events).toEqual(['leave', 'after-leave'])
+    }
+    finally {
+      wrapper.unmount()
+      getComputedStyleSpy.mockRestore()
+    }
+  })
+
+  it('does not let a stale exit animation unmount a quickly remounted node', async () => {
+    const open = ref(true)
+    const getComputedStyleSpy = mockLiveAnimationStyles()
+    const wrapper = mount(defineComponent({
+      components: { Presence },
+      setup: () => ({ open }),
+      template: `<Presence :present="open">
+        <div data-testid="animated" :data-state="open ? 'open' : 'closed'" />
+      </Presence>`,
+    }))
+
+    try {
+      await flushPresence()
+
+      open.value = false
+      await flushPresence()
+      const element = wrapper.find('[data-testid="animated"]')
+
+      open.value = true
+      await flushPresence()
+      element.element.dispatchEvent(createAnimationEvent('animationend', 'fadeOut'))
+      await flushPresence()
+
+      expect(wrapper.find('[data-testid="animated"]').exists()).toBe(true)
+    }
+    finally {
+      wrapper.unmount()
+      getComputedStyleSpy.mockRestore()
+    }
+  })
+
+  it('caches the initial animation name when the node mounts', async () => {
+    const open = ref(true)
+    const getComputedStyleSpy = mockLiveAnimationStyles(() => 'stableAnimation')
+    const wrapper = mount(defineComponent({
+      components: { Presence },
+      setup: () => ({ open }),
+      template: `<Presence :present="open">
+        <div data-testid="animated" />
+      </Presence>`,
+    }))
+
+    try {
+      await flushPresence()
+      expect(getComputedStyleSpy).toHaveBeenCalledTimes(1)
+
+      open.value = false
+      await flushPresence()
+
+      expect(wrapper.find('[data-testid="animated"]').exists()).toBe(false)
+    }
+    finally {
+      wrapper.unmount()
+      getComputedStyleSpy.mockRestore()
+    }
+  })
+
+  it('preserves enter and leave event order without animations', async () => {
+    const open = ref(false)
+    const events: string[] = []
+    const wrapper = mount(defineComponent({
+      components: { Presence },
+      setup: () => ({ events, open }),
+      template: `<Presence :present="open">
+        <div
+          @enter="events.push('enter')"
+          @after-enter="events.push('after-enter')"
+          @leave="events.push('leave')"
+          @after-leave="events.push('after-leave')"
+        />
+      </Presence>`,
+    }))
+
+    try {
+      open.value = true
+      await flushPresence()
+      open.value = false
+      await flushPresence()
+
+      expect(events).toEqual(['enter', 'after-enter', 'leave', 'after-leave'])
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+})
+
+async function flushPresence() {
+  await nextTick()
+  await nextTick()
+  await nextTick()
+}
+
+function mockLiveAnimationStyles(
+  getAnimationName: (element: HTMLElement) => string = element =>
+    element.dataset.state === 'closed' ? 'fadeOut' : 'fadeIn',
+) {
+  const styles = new WeakMap<Element, CSSStyleDeclaration>()
+  return vi.spyOn(globalThis, 'getComputedStyle').mockImplementation((element) => {
+    let style = styles.get(element)
+    if (!style) {
+      style = {
+        get animationName() {
+          return getAnimationName(element as HTMLElement)
+        },
+        get display() {
+          return 'block'
+        },
+      } as CSSStyleDeclaration
+      styles.set(element, style)
+    }
+    return style
+  })
+}
+
+function createAnimationEvent(type: 'animationend' | 'animationcancel', animationName: string) {
+  const event = new Event(type)
+  Object.defineProperty(event, 'animationName', { value: animationName })
+  return event
+}

--- a/packages/core/src/Presence/Presence.test.ts
+++ b/packages/core/src/Presence/Presence.test.ts
@@ -222,6 +222,7 @@ describe('given batched Presence updates', () => {
     try {
       await flushPresence()
       animationReadNodeCounts.length = 0
+      deferredAnimationReads.length = 0
 
       present.value = true
       await flushPresence()

--- a/packages/core/src/Presence/usePresence.ts
+++ b/packages/core/src/Presence/usePresence.ts
@@ -163,10 +163,7 @@ export function usePresence(
           // Vue attaches sibling nodes one by one. Reading animationName here
           // synchronously would force a full style calculation after every
           // insertion, so wait until the batch has finished mounting.
-          const mountAnimationName = getAnimationName(styles)
-          mountAnimationNameRef.value = mountAnimationName
-          prevAnimationNameRef.value = mountAnimationName
-          mountAnimationNameRef.value = undefined
+          prevAnimationNameRef.value = getAnimationName(styles)
         })
 
         newNode.addEventListener('animationstart', handleAnimationStart)

--- a/packages/core/src/Presence/usePresence.ts
+++ b/packages/core/src/Presence/usePresence.ts
@@ -8,12 +8,14 @@ export function usePresence(
   present: Ref<boolean>,
   node: Ref<HTMLElement | undefined>,
 ) {
-  const stylesRef = ref<CSSStyleDeclaration>({} as any)
+  const stylesRef = ref<CSSStyleDeclaration | null>(null)
   const prevAnimationNameRef = ref<string>('none')
-  const prevPresentRef = ref(present)
+  const mountAnimationNameRef = ref<string>()
+  const prevPresentRef = ref(present.value)
   const initialState = present.value ? 'mounted' : 'unmounted'
   let timeoutId: number | undefined
-  const ownerWindow = node.value?.ownerDocument.defaultView ?? defaultWindow
+  let attachedNode: HTMLElement | undefined
+  let ownerWindow = node.value?.ownerDocument.defaultView ?? defaultWindow
 
   const { state, dispatch } = useStateMachine(initialState, {
     mounted: {
@@ -42,12 +44,14 @@ export function usePresence(
     present,
     async (currentPresent, prevPresent) => {
       const hasPresentChanged = prevPresent !== currentPresent
+      prevPresentRef.value = currentPresent
       await nextTick()
       if (hasPresentChanged) {
         const prevAnimationName = prevAnimationNameRef.value
-        const currentAnimationName = getAnimationName(node.value)
+        const currentAnimationName = getAnimationName(stylesRef.value)
 
         if (currentPresent) {
+          mountAnimationNameRef.value = currentAnimationName
           dispatch('MOUNT')
           dispatchCustomEvent('enter')
           if (currentAnimationName === 'none')
@@ -91,10 +95,11 @@ export function usePresence(
    * make sure we only trigger ANIMATION_END for the currently active animation.
    */
   const handleAnimationEnd = (event: AnimationEvent) => {
-    if (event.target !== node.value)
+    const currentNode = node.value
+    if (event.target !== currentNode)
       return
 
-    const currentAnimationName = getAnimationName(node.value)
+    const currentAnimationName = getAnimationName(stylesRef.value)
     const isCurrentAnimation = currentAnimationName.includes(
       CSS.escape(event.animationName),
     )
@@ -104,15 +109,15 @@ export function usePresence(
       dispatch('ANIMATION_END')
 
       if (!prevPresentRef.value) {
-        const currentFillMode = node.value.style.animationFillMode
-        node.value.style.animationFillMode = 'forwards'
+        const currentFillMode = currentNode.style.animationFillMode
+        currentNode.style.animationFillMode = 'forwards'
         // Reset the style after the node had time to unmount (for cases
         // where the component chooses not to unmount). Doing this any
         // sooner than `setTimeout` (e.g. with `requestAnimationFrame`)
         // still causes a flash.
         timeoutId = ownerWindow?.setTimeout(() => {
-          if (node.value?.style.animationFillMode === 'forwards') {
-            node.value.style.animationFillMode = currentFillMode
+          if (currentNode.style.animationFillMode === 'forwards') {
+            currentNode.style.animationFillMode = currentFillMode
           }
         })
       }
@@ -124,50 +129,88 @@ export function usePresence(
   const handleAnimationStart = (event: AnimationEvent) => {
     if (event.target === node.value) {
       // if animation occurred, store its name as the previous animation.
-      prevAnimationNameRef.value = getAnimationName(node.value)
+      prevAnimationNameRef.value = getAnimationName(stylesRef.value)
     }
   }
 
   const watcher = watch(
     node,
-    (newNode, oldNode) => {
+    (newNode) => {
+      if (timeoutId !== undefined) {
+        ownerWindow?.clearTimeout(timeoutId)
+        timeoutId = undefined
+      }
+
+      attachedNode?.removeEventListener('animationstart', handleAnimationStart)
+      attachedNode?.removeEventListener('animationcancel', handleAnimationEnd)
+      attachedNode?.removeEventListener('animationend', handleAnimationEnd)
+      attachedNode = newNode
+
       if (newNode) {
-        stylesRef.value = getComputedStyle(newNode)
+        ownerWindow = newNode.ownerDocument.defaultView ?? defaultWindow
+        const styles = getComputedStyle(newNode)
+        stylesRef.value = styles
+        mountAnimationNameRef.value = undefined
+
+        queueMicrotask(() => {
+          if (
+            attachedNode !== newNode
+            || state.value !== 'mounted'
+          ) {
+            return
+          }
+
+          // Vue attaches sibling nodes one by one. Reading animationName here
+          // synchronously would force a full style calculation after every
+          // insertion, so wait until the batch has finished mounting.
+          const mountAnimationName = getAnimationName(styles)
+          mountAnimationNameRef.value = mountAnimationName
+          prevAnimationNameRef.value = mountAnimationName
+          mountAnimationNameRef.value = undefined
+        })
+
         newNode.addEventListener('animationstart', handleAnimationStart)
         newNode.addEventListener('animationcancel', handleAnimationEnd)
         newNode.addEventListener('animationend', handleAnimationEnd)
       }
       else {
+        stylesRef.value = null
+        mountAnimationNameRef.value = undefined
+        prevAnimationNameRef.value = 'none'
+
         // Transition to the unmounted state if the node is removed prematurely.
         // We avoid doing so during cleanup as the node may change but still exist.
         dispatch('ANIMATION_END')
-
-        if (timeoutId !== undefined)
-          ownerWindow?.clearTimeout(timeoutId)
-        oldNode?.removeEventListener('animationstart', handleAnimationStart)
-        oldNode?.removeEventListener('animationcancel', handleAnimationEnd)
-        oldNode?.removeEventListener('animationend', handleAnimationEnd)
       }
     },
     { immediate: true },
   )
 
   const stateWatcher = watch(state, () => {
-    const currentAnimationName = getAnimationName(node.value)
-    prevAnimationNameRef.value
-      = state.value === 'mounted' ? currentAnimationName : 'none'
+    if (state.value === 'mounted') {
+      prevAnimationNameRef.value
+        = mountAnimationNameRef.value ?? getAnimationName(stylesRef.value)
+      mountAnimationNameRef.value = undefined
+    }
+    else {
+      prevAnimationNameRef.value = 'none'
+    }
   })
 
   onUnmounted(() => {
     watcher()
     stateWatcher()
-    if (node.value) {
-      node.value.removeEventListener('animationstart', handleAnimationStart)
-      node.value.removeEventListener('animationcancel', handleAnimationEnd)
-      node.value.removeEventListener('animationend', handleAnimationEnd)
+    if (attachedNode) {
+      attachedNode.removeEventListener('animationstart', handleAnimationStart)
+      attachedNode.removeEventListener('animationcancel', handleAnimationEnd)
+      attachedNode.removeEventListener('animationend', handleAnimationEnd)
+      attachedNode = undefined
     }
     if (timeoutId !== undefined)
       ownerWindow?.clearTimeout(timeoutId)
+    stylesRef.value = null
+    mountAnimationNameRef.value = undefined
+    prevAnimationNameRef.value = 'none'
   })
 
   const isPresent = computed(() =>
@@ -179,6 +222,6 @@ export function usePresence(
   }
 }
 
-function getAnimationName(node?: HTMLElement) {
-  return node ? getComputedStyle(node).animationName || 'none' : 'none'
+function getAnimationName(styles: CSSStyleDeclaration | null) {
+  return styles?.animationName || 'none'
 }


### PR DESCRIPTION
Bulk deselecting rows in the shadcn-vue Data Table example caused every `CheckboxIndicator` Presence instance to repeatedly read computed animation styles. On the full documentation page, these reads forced expensive style recalculations and produced the delay reported in [shadcn-vue#1918](https://github.com/unovue/shadcn-vue/issues/1918).

This change caching strategy: `getComputedStyle` runs once when a node is attached, and the cached `CSSStyleDeclaration` is reused by state watchers and animation events. The initial `animationName` read is deferred until Vue finishes mounting the current batch, preventing each inserted indicator from independently recalculating the page styles. Exit animation behavior, rapid `false → true` reversals, node replacement, cleanup, and the existing event order remain unchanged.

The benchmark used the original five-row shadcn-vue Data Table example inside a captured copy of the surrounding documentation page with its production stylesheet. Chrome 150 on Windows x64 ran one warm-up followed by five measured runs per action.

| Action | Before median | After median | Improvement | Median `getComputedStyle` calls |
| --- | ---: | ---: | ---: | ---: |
| Select all | 83.7 ms | 83.6 ms | 0.1% | 18 → 6 |
| Deselect all | 417.1 ms | 149.9 ms | 64.1% | 12 → 0 |
| Deselect/select ratio | 4.983 | 1.793 | 64.0% lower | — |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of enter and exit animations during mounting, unmounting, and node replacement.
  * Prevented stale or bubbled animation events from affecting current transitions.
  * Reduced unnecessary style calculations for non-animated elements.
  * Preserved animation state more reliably when elements are remounted or replaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->