### PR TITLE
fix(NumberField): allow backspacing through a formatted unit suffix

### DIFF
--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -237,6 +237,26 @@ describe('numberField', () => {
       expect(input.value).toBe('5 inches')
     })
 
+    it('should allow backspacing through the unit suffix', async () => {
+      const { input, user } = setup({
+        defaultValue: 13,
+        formatOptions: {
+          style: 'unit',
+          unit: 'minute',
+          unitDisplay: 'short',
+        },
+      })
+      expect(input.value).toBe('13 min')
+
+      input.focus()
+      await user.keyboard('{Backspace}')
+      expect(input.value).toBe('13 mi')
+
+      await user.keyboard('{Backspace}')
+      await user.keyboard('{Backspace}')
+      expect(input.value).toBe('13 ')
+    })
+
     it('should change format based on reactive options', async () => {
       const { input, rerender } = setup({
         defaultValue: 5,

--- a/packages/core/src/NumberField/NumberFieldInput.vue
+++ b/packages/core/src/NumberField/NumberFieldInput.vue
@@ -121,6 +121,9 @@ function handleChange() {
     @wheel="handleWheelEvent"
     @beforeinput="(event: InputEvent) => {
       if (event.isComposing) return
+      // A collapsed deletion carries no data, so nextValue would repeat the current value; undo and redo read the same
+      // Every deletion is skipped so they stay consistent, and applyInputValue reformats on blur
+      if (event.inputType.startsWith('delete') || event.inputType.startsWith('history')) return
       const target = event.target as HTMLInputElement
       let nextValue
         = target.value.slice(0, target.selectionStart ?? undefined)


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2850

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With `formatOptions: { style: 'unit', unit: 'minute', unitDisplay: 'short' }` the field shows `13 min`, and backspacing stops at `13 mi`. A deletion leaves the caret collapsed and carries no data, so the `beforeinput` handler ends up building `nextValue` out of the text that is already in the input. `13 mi` is not a valid partial number, so the keystroke is prevented and the value can never shrink any further.

Validating the pre-delete value that way is meaningless, so the handler now skips deletions, plus undo and redo, which read the same. Whatever text is left gets reformatted or cleared by `applyInputValue` on blur.

Worth flagging: react-aria, which this handler is ported from, computes the real post-delete value and still validates it, so backspacing there stops one keystroke earlier at `13 min`. That behaviour has been reported since 2022 in adobe/react-spectrum#2806 without a resolution. Glad to scope this differently if you would rather stay in step with them.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backspacing now correctly removes unit suffix characters from numeric fields while preserving the entered value and spacing.
  * Other number input validation behavior remains unchanged.

* **Tests**
  * Added coverage for deleting short unit suffixes from number fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
