### PR TITLE
fix(NumberField): allow deleting through formatted literals

### DIFF
--- a/packages/core/src/NumberField/NumberField.test.ts
+++ b/packages/core/src/NumberField/NumberField.test.ts
@@ -237,6 +237,43 @@ describe('numberField', () => {
       expect(input.value).toBe('5 inches')
     })
 
+    it('should allow backspacing through the unit suffix', async () => {
+      const { input, user } = setup({
+        defaultValue: 13,
+        formatOptions: {
+          style: 'unit',
+          unit: 'minute',
+          unitDisplay: 'short',
+        },
+      })
+      expect(input.value).toBe('13 min')
+
+      await user.click(input)
+      input.setSelectionRange(input.value.length, input.value.length)
+      const initialLength = input.value.length
+      for (let i = 0; i < initialLength; i++)
+        await user.keyboard('{Backspace}')
+
+      expect(input.value).toBe('')
+    })
+
+    it('should still reject invalid insertions while showing units', async () => {
+      const { input, user } = setup({
+        defaultValue: 13,
+        formatOptions: {
+          style: 'unit',
+          unit: 'minute',
+          unitDisplay: 'short',
+        },
+      })
+
+      await user.click(input)
+      input.setSelectionRange(2, 2)
+      await user.keyboard('x')
+
+      expect(input.value).toBe('13 min')
+    })
+
     it('should change format based on reactive options', async () => {
       const { input, rerender } = setup({
         defaultValue: 5,

--- a/packages/core/src/NumberField/NumberFieldInput.vue
+++ b/packages/core/src/NumberField/NumberFieldInput.vue
@@ -122,9 +122,10 @@ function handleChange() {
     @beforeinput="(event: InputEvent) => {
       if (event.isComposing) return
       // Deletions are exempt: partially deleted literals ('13 mi' while
-      // backspacing through '13 min') never pass partial validation, and
-      // blur/enter re-parse whatever remains.
-      if (event.inputType.startsWith('delete')) return
+      // backspacing through '13 min') never pass partial validation, so
+      // validating them would trap the caret mid-literal. Deletions only
+      // ever remove characters, so they cannot introduce invalid input.
+      if (event.inputType?.startsWith('delete')) return
       const target = event.target as HTMLInputElement
       let nextValue
         = target.value.slice(0, target.selectionStart ?? undefined)

--- a/packages/core/src/NumberField/NumberFieldInput.vue
+++ b/packages/core/src/NumberField/NumberFieldInput.vue
@@ -121,6 +121,10 @@ function handleChange() {
     @wheel="handleWheelEvent"
     @beforeinput="(event: InputEvent) => {
       if (event.isComposing) return
+      // Deletions are exempt: partially deleted literals ('13 mi' while
+      // backspacing through '13 min') never pass partial validation, and
+      // blur/enter re-parse whatever remains.
+      if (event.inputType.startsWith('delete')) return
       const target = event.target as HTMLInputElement
       let nextValue
         = target.value.slice(0, target.selectionStart ?? undefined)


### PR DESCRIPTION
Fixes #2850

With `formatOptions: { style: 'unit', unit: 'minute', unitDisplay: 'short' }`, backspacing `13 min` stops dead at `13 mi`. Any format whose text contains literals (currency codes, unit names) can wedge the same way once a deletion lands inside the literal.

Two layers stack up to cause it:

1. `NumberParser.isValidPartialNumber` strips only complete literals. Its regex is built from full formatted parts (`min` and the space), so `13 mi` leaves `mi` behind and fails; every state between `13 min` and `13 ` is invalid.
2. The `beforeinput` guard's `slice(selectionStart) + data + slice(selectionEnd)` models insertions. A collapsed-cursor backspace removes nothing from that computation, so the guard validates the pre-edit string: it approves `13 min`, the browser deletes to `13 mi`, and the next backspace gets rejected for the state the previous one created.

Which means the deletion gate never prevented invalid intermediate states; it only trapped the caret in them one keystroke late.

The fix exempts deletions (`inputType` starting with `delete`) from the guard. They can only remove characters, and blur/enter still run the remaining text through `parse` exactly as before. Insertions keep the existing validation. I considered mirroring React Aria's per-inputType `nextValue` computation instead (the same slice math appears in their `useFormattedTextField`), but theirs computes the true post-delete string and rejects it, so it blocks the very first backspace rather than the second and makes the suffix fully undeletable. Their NumberField wedges the same way; I didn't find it on their tracker.

Tests: red/green on backspacing `13 min` down to empty (v2 wedges at `13 mi`), plus a test pinning that invalid insertions still get rejected — the `beforeinput` guard had no coverage before these. Full core suite 2006/2006, vue-tsc and eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deletion behavior in unit-formatted number fields.
  - Backspacing through a unit suffix now correctly clears the associated value.
  - Invalid characters remain blocked while the unit suffix stays visible.
  - Partial values are supported during editing and validated when the field loses focus or is submitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->