### PR TITLE
docs: note core build is required before docs:dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,13 +73,12 @@ All commands run from the repo root.
 | Docs API regen | `pnpm docs:gen` (regenerates `docs/content/meta/*.md`) |
 | Bundle size | `pnpm --filter reka-ui size` |
 
-> `pnpm test` is **watch mode**. For a one-shot run (CI-style) use
-> `pnpm --filter reka-ui exec vitest run`.
-
-> The docs site needs `packages/core/dist` to exist — `docs/.vitepress/config.ts`
-> imports `reka-ui/dist/constant.js` through the workspace link. On a fresh
-> checkout run `pnpm --filter reka-ui build` first, or `pnpm docs:dev` fails with
-> `Cannot find module … /dist/constant.js`.
+> - `pnpm test` is **watch mode**. For a one-shot run (CI-style) use
+>   `pnpm --filter reka-ui exec vitest run`.
+> - The docs site needs `packages/core/dist` to exist — `docs/.vitepress/config.ts`
+>   imports `reka-ui/dist/constant.js` through the workspace link. On a fresh
+>   checkout run `pnpm --filter reka-ui build` first, or `pnpm docs:dev` fails
+>   with `Cannot find module … /dist/constant.js`.
 
 ## Component architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,12 +69,17 @@ All commands run from the repo root.
 | Test coverage | `pnpm --filter reka-ui test:coverage` |
 | Lint / auto-fix | `pnpm lint` / `pnpm lint:fix` |
 | Stories | `pnpm story:dev` |
-| Docs dev | `pnpm docs:install && pnpm docs:dev` |
+| Docs dev | `pnpm --filter reka-ui build && pnpm docs:install && pnpm docs:dev` |
 | Docs API regen | `pnpm docs:gen` (regenerates `docs/content/meta/*.md`) |
 | Bundle size | `pnpm --filter reka-ui size` |
 
 > `pnpm test` is **watch mode**. For a one-shot run (CI-style) use
 > `pnpm --filter reka-ui exec vitest run`.
+
+> The docs site needs `packages/core/dist` to exist — `docs/.vitepress/config.ts`
+> imports `reka-ui/dist/constant.js` through the workspace link. On a fresh
+> checkout run `pnpm --filter reka-ui build` first, or `pnpm docs:dev` fails with
+> `Cannot find module … /dist/constant.js`.
 
 ## Component architecture
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- TODO: replace with your issue number, e.g. Resolves #1337 -->
N/A — small docs-only correction. Happy to open an issue first if maintainers prefer.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

failed to load config from docs/.vitepress/config.ts
Cannot find module '<repo>/docs/node_modules/reka-ui/dist/constant.js'
Error [ERR_MODULE_NOT_FOUND]

`docs/node_modules/reka-ui` is a workspace symlink to `packages/core`, and
`docs/.vitepress/config.ts` imports `reka-ui/dist/constant.js`. Nothing in the
install step produces that file — `packages/core` has no `prepare`/`postinstall`
hook, only a manual `build` script — so `packages/core/dist/` does not exist
until `pnpm --filter reka-ui build` has been run at least once.

This is a docs-only fix; no source or config changes. It updates
`CONTRIBUTING.md` to:

- include the build step in the "Docs dev" command row
- add a short note explaining why it is needed, quoting the error message so the
  failure is searchable

Verified locally: with `packages/core/dist/` removed, `pnpm docs:dev` reproduces
the error above; after `pnpm --filter reka-ui build` it starts normally and
serves `/` and `/docs/components/accordion` (HTTP 200).

### 📸 Screenshots (if appropriate)

N/A — documentation only.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation development setup instructions to build the core package first.
  * Added troubleshooting guidance for fresh checkouts where the documentation site cannot start until the core package is built.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->