### PR TITLE
fix(Drawer): track drags in non-dismissable directions so the drawer pulls elastically

### DIFF
--- a/docs/components/demo/Drawer/css/styles.css
+++ b/docs/components/demo/Drawer/css/styles.css
@@ -24,12 +24,19 @@ input {
 }
 
 .DrawerContent {
+  /* Extra drawer area that hangs below the viewport edge, kept off-screen by an
+     equal negative margin. Pulling the drawer away from its edge slides the
+     bleed into view instead of exposing the overlay behind it, so the drawer
+     stretches rather than visually detaching while it rubber-bands. */
+  --bleed: 48px;
   background-color: white;
   border-radius: 16px 16px 0 0;
   position: fixed;
   inset-inline: 0;
   bottom: 0;
   margin-inline: auto;
+  margin-bottom: calc(-1 * var(--bleed));
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + var(--bleed));
   max-width: 500px;
   display: flex;
   flex-direction: column;
@@ -159,13 +166,16 @@ input {
     opacity: 0;
   }
 }
+/* The bleed already sits below the viewport edge, so the drawer only has to
+   travel `height - bleed` to clear it. Translating a full 100% would overshoot
+   by the bleed and make the slide look faster than it is. */
 @keyframes drawerSlideBottomIn {
   from {
-    translate: 0 100%;
+    translate: 0 calc(100% - var(--bleed));
   }
 }
 @keyframes drawerSlideBottomOut {
   to {
-    translate: 0 100%;
+    translate: 0 calc(100% - var(--bleed));
   }
 }

--- a/docs/components/demo/Drawer/css/styles.css
+++ b/docs/components/demo/Drawer/css/styles.css
@@ -29,6 +29,7 @@ input {
      bleed into view instead of exposing the overlay behind it, so the drawer
      stretches rather than visually detaching while it rubber-bands. */
   --bleed: 48px;
+
   background-color: white;
   border-radius: 16px 16px 0 0;
   position: fixed;

--- a/docs/components/demo/Drawer/tailwind/index.vue
+++ b/docs/components/demo/Drawer/tailwind/index.vue
@@ -21,8 +21,12 @@ import {
     </DrawerTrigger>
     <DrawerPortal>
       <DrawerOverlay class="DrawerOverlay fixed inset-0 z-30 bg-black/40" />
+      <!-- `--bleed` is extra drawer area hanging below the viewport edge, kept
+           off-screen by an equal negative margin. Pulling the drawer away from
+           its edge slides the bleed into view instead of exposing the overlay,
+           so the drawer stretches rather than detaching while it rubber-bands. -->
       <DrawerContent
-        class="DrawerContent fixed inset-x-0 bottom-0 z-[100] mx-auto flex max-w-[500px] flex-col rounded-t-[16px] bg-white outline-none"
+        class="DrawerContent fixed inset-x-0 bottom-0 z-[100] mx-auto flex max-w-[500px] flex-col rounded-t-[16px] bg-white outline-none [--bleed:48px] mb-[calc(-1*var(--bleed))] pb-[calc(env(safe-area-inset-bottom,0px)+var(--bleed))]"
       >
         <DrawerHandle class="mx-auto mt-3 h-1.5 w-12 shrink-0 rounded-full bg-mauve6" />
         <div class="p-6">

--- a/docs/components/demo/Drawer/tailwind/index.vue
+++ b/docs/components/demo/Drawer/tailwind/index.vue
@@ -99,6 +99,9 @@ import {
 
 @keyframes drawer-overlay-in { from { opacity: 0; } }
 @keyframes drawer-overlay-out { to { opacity: 0; } }
-@keyframes drawer-slide-bottom-in { from { translate: 0 100%; } }
-@keyframes drawer-slide-bottom-out { to { translate: 0 100%; } }
+/* The bleed already sits below the viewport edge, so the drawer only has to
+   travel `height - bleed` to clear it. A full 100% would overshoot by the
+   bleed and make the slide look faster than it is. */
+@keyframes drawer-slide-bottom-in { from { translate: 0 calc(100% - var(--bleed)); } }
+@keyframes drawer-slide-bottom-out { to { translate: 0 calc(100% - var(--bleed)); } }
 </style>

--- a/docs/content/docs/components/drawer.md
+++ b/docs/content/docs/components/drawer.md
@@ -132,8 +132,25 @@ detachment.
 @keyframes slideOut { to { translate: 0 calc(100% - var(--bleed)); } }
 ```
 
-For a left/right drawer, swap the axis: `padding-inline-end` and
-`margin-inline-end` with `translate: calc(100% - var(--bleed)) 0`.
+For a side drawer, swap the axis and point the bleed at the edge the drawer is
+anchored to — a right-anchored drawer bleeds right, a left-anchored one bleeds
+left:
+
+```css
+/* Anchored right */
+.DrawerContent {
+  padding-inline-end: calc(24px + var(--bleed));
+  margin-inline-end: calc(-1 * var(--bleed));
+}
+@keyframes slideIn { from { translate: calc(100% - var(--bleed)) 0; } }
+
+/* Anchored left */
+.DrawerContent {
+  padding-inline-start: calc(24px + var(--bleed));
+  margin-inline-start: calc(-1 * var(--bleed));
+}
+@keyframes slideIn { from { translate: calc(-100% + var(--bleed)) 0; } }
+```
 
 ## API Reference
 

--- a/docs/content/docs/components/drawer.md
+++ b/docs/content/docs/components/drawer.md
@@ -107,6 +107,34 @@ custom properties so you can wire up the live transform:
 @keyframes slideOut { to { translate: 0 100%; } }
 ```
 
+### Bleeding past the edge
+
+Dragging a drawer *away* from the edge it is anchored to doesn't dismiss it —
+the gesture is damped and the drawer rubber-bands back on release. Without extra
+room the drawer lifts clean off the edge during that pull and the overlay shows
+through the gap.
+
+Give the drawer some **bleed**: extra area past its anchored edge, held
+off-screen by an equal negative margin. Pulling the drawer now slides the bleed
+into view instead of the overlay, so it reads as a stretch rather than a
+detachment.
+
+```css
+.DrawerContent {
+  --bleed: 48px;
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + var(--bleed));
+  margin-bottom: calc(-1 * var(--bleed));
+}
+
+/* The bleed already sits below the viewport edge, so the drawer only has to
+   travel `height - bleed` to clear it. */
+@keyframes slideIn { from { translate: 0 calc(100% - var(--bleed)); } }
+@keyframes slideOut { to { translate: 0 calc(100% - var(--bleed)); } }
+```
+
+For a left/right drawer, swap the axis: `padding-inline-end` and
+`margin-inline-end` with `translate: calc(100% - var(--bleed)) 0`.
+
 ## API Reference
 
 ### Root

--- a/packages/core/src/Drawer/composables/useSwipeDismiss.test.ts
+++ b/packages/core/src/Drawer/composables/useSwipeDismiss.test.ts
@@ -283,3 +283,106 @@ describe('useSwipeDismiss — non-dismissable direction (elastic pull)', () => {
     wrapper.unmount()
   })
 })
+
+/**
+ * The listeners live on the popup, which the pointer leaves as soon as the drag
+ * goes past the drawer's bounds (BaseUI instead hangs them off a full-screen
+ * `Drawer.Viewport`). `setPointerCapture` covers an ordinary in-window drag, but
+ * a release the popup never sees — outside the window, over another app, or
+ * after capture is dropped — used to leave the gesture wedged: the drawer stayed
+ * frozen mid-pull with `data-swiping` set (pinning the transition to 0ms) and
+ * ignored every subsequent drag.
+ */
+describe('useSwipeDismiss — releases the popup never sees', () => {
+  it('treats a move with no button held as the missing pointerup', async () => {
+    const { wrapper, elementRef, onCancel } = mountHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+
+    dispatchPointer(el, 'pointerdown', 100, 400)
+    dispatchPointer(el, 'pointermove', 100, 390)
+    dispatchPointer(el, 'pointermove', 100, 340)
+    expect(el.hasAttribute('data-swiping')).toBe(false) // marker lives on the consumer
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-y')).not.toBe('0px')
+
+    // The release happened somewhere we never saw; the pointer only comes back
+    // over the page with the button already up.
+    dispatchPointer(el, 'pointermove', 100, 300, 0, { buttons: 0 })
+    await nextTick()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-y')).toBe('0px')
+
+    wrapper.unmount()
+  })
+
+  it('finishes on a pointerup that only reaches the document', async () => {
+    const { wrapper, elementRef, onCancel } = mountHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+
+    dispatchPointer(el, 'pointerdown', 100, 400)
+    dispatchPointer(el, 'pointermove', 100, 390)
+    dispatchPointer(el, 'pointermove', 100, 340)
+
+    // Released over some other element entirely — never retargeted to the popup.
+    dispatchPointer(document.body, 'pointerup', 100, 340)
+    await nextTick()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-y')).toBe('0px')
+
+    wrapper.unmount()
+  })
+
+  it('finishes when the window loses focus mid-drag', async () => {
+    const { wrapper, elementRef, onCancel } = mountHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+
+    dispatchPointer(el, 'pointerdown', 100, 400)
+    dispatchPointer(el, 'pointermove', 100, 390)
+    dispatchPointer(el, 'pointermove', 100, 340)
+
+    // Dragged out of the window and released over another application.
+    window.dispatchEvent(new Event('blur'))
+    await nextTick()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-y')).toBe('0px')
+
+    wrapper.unmount()
+  })
+
+  it('does not leak state from an unfinished gesture into the next one', async () => {
+    const onDismiss = vi.fn()
+    const { wrapper, elementRef, onCancel } = mountHarness({ onDismiss })
+    await nextTick()
+
+    const el = elementRef.value!
+
+    // A change-of-mind drag that never ends: down past half the threshold, then
+    // reversed far enough to latch `cancelledSwipe`, and no pointerup at all.
+    dispatchPointer(el, 'pointerdown', 100, 400)
+    dispatchPointer(el, 'pointermove', 100, 420)
+    dispatchPointer(el, 'pointermove', 100, 460)
+    dispatchPointer(el, 'pointermove', 100, 415)
+
+    // A fresh press must start clean. If the latched cancel leaks into this
+    // gesture, the drawer silently refuses to close no matter how far it is
+    // dragged.
+    dispatchPointer(el, 'pointerdown', 100, 400, 0, { pointerId: 2 })
+    dispatchPointer(el, 'pointermove', 100, 410, 0, { pointerId: 2 })
+    dispatchPointer(el, 'pointermove', 100, 470, 0, { pointerId: 2 })
+    dispatchPointer(el, 'pointerup', 100, 470, 0, { pointerId: 2 })
+    await nextTick()
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    expect(onCancel).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+})

--- a/packages/core/src/Drawer/composables/useSwipeDismiss.test.ts
+++ b/packages/core/src/Drawer/composables/useSwipeDismiss.test.ts
@@ -205,3 +205,81 @@ describe('useSwipeDismiss — dismiss vs cancel CSS var clearing', () => {
     wrapper.unmount()
   })
 })
+
+/**
+ * The gesture must be tracked from the first pointer move regardless of its
+ * direction (BaseUI `startSwipeAtPosition` sets `swiping` on press). A drag
+ * away* from the dismiss direction is sqrt-damped by `applyDirectionalDamping`
+ * and written to the movement vars — that damped offset is the elastic "pull"
+ * feedback. Previously `processMove` returned early whenever the drag had no
+ * allowed direction, so a bottom drawer pulled upward stayed completely frozen.
+ */
+describe('useSwipeDismiss — non-dismissable direction (elastic pull)', () => {
+  it('damps and tracks a drag away from the dismiss direction', async () => {
+    const { wrapper, elementRef, onDismiss, onCancel } = mountHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+
+    // Pull UP on a `down`-dismiss drawer: 100px of travel.
+    dispatchPointer(el, 'pointerdown', 100, 400)
+    dispatchPointer(el, 'pointermove', 100, 380)
+    dispatchPointer(el, 'pointermove', 100, 300)
+
+    // sqrt-damped: -sqrt(100) = -10px, not the raw -100px.
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-y')).toBe('-10px')
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('0px')
+
+    dispatchPointer(el, 'pointerup', 100, 300)
+    await nextTick()
+
+    // A pull that never moves in a dismissable direction cancels: the drawer
+    // springs back to rest and stays open.
+    expect(onDismiss).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-y')).toBe('0px')
+    expect(el.hasAttribute('data-swipe-dismissed')).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('still adopts the dismiss direction when the drag reverses into it', async () => {
+    const { wrapper, elementRef, onDismiss, onCancel } = mountHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+
+    // Pull up first (no dismissable direction yet), then push back down past
+    // the 40px threshold. The gesture must dismiss rather than stay stuck
+    // without an intended direction.
+    dispatchPointer(el, 'pointerdown', 100, 400)
+    dispatchPointer(el, 'pointermove', 100, 350)
+    dispatchPointer(el, 'pointermove', 100, 420)
+    dispatchPointer(el, 'pointermove', 100, 470) // +70px from origin
+    dispatchPointer(el, 'pointerup', 100, 470)
+    await nextTick()
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    expect(onCancel).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('leaves an allowed direction undamped when both axes directions are allowed', async () => {
+    // Snap-point drawers pass both the dismiss direction and its opposite, so
+    // neither vertical direction should be damped.
+    const { wrapper, elementRef } = mountHarness({ directions: ['down', 'up'] })
+    await nextTick()
+
+    const el = elementRef.value!
+
+    dispatchPointer(el, 'pointerdown', 100, 400)
+    dispatchPointer(el, 'pointermove', 100, 380)
+    dispatchPointer(el, 'pointermove', 100, 300)
+
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-y')).toBe('-100px')
+
+    dispatchPointer(el, 'pointerup', 100, 300)
+    wrapper.unmount()
+  })
+})

--- a/packages/core/src/Drawer/composables/useSwipeDismiss.ts
+++ b/packages/core/src/Drawer/composables/useSwipeDismiss.ts
@@ -187,7 +187,12 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
     el.style.setProperty(movementCssVars.y, '0px')
   }
 
-  function reset() {
+  /**
+   * Clears the per-gesture tracking state. Deliberately leaves the pointer
+   * identity and the touch scroll-guard flags alone, so it is safe to call at
+   * the start of a gesture as well as at the end of one.
+   */
+  function resetGestureState() {
     setSwiping(false)
     swipeDirection.value = undefined
     dragOffset.value = { x: 0, y: 0 }
@@ -198,18 +203,27 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
     isFirstMove = false
     pendingSwipe = false
     pendingSwipeStartPos = null
-    swipeFromScrollable = false
-    scrollableAncestor = null
     elementSize = { width: 0, height: 0 }
     swipeProgress = 0
     lastDragSample = null
     lastVelocity = { x: 0, y: 0 }
     lockedAxis = null
+  }
+
+  function reset() {
+    resetGestureState()
+    swipeFromScrollable = false
+    scrollableAncestor = null
     activePointerId = null
     pointerStarted = false
   }
 
   function startSwipe(el: HTMLElement, pos: { x: number, y: number }) {
+    // Start from a clean slate (BaseUI parity: `startSwipeAtPosition` resets the
+    // gesture refs on every press). A previous gesture whose end we never saw
+    // would otherwise leak `isSwiping`, the intended direction and the velocity
+    // samples into this one.
+    resetGestureState()
     // Capture the element's current transform so we can account for it
     getElementTransform(el)
     dragStartPos = pos
@@ -425,8 +439,16 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
     const el = elementRef.value
     if (!el)
       return
-    if ((e.buttons & 1) === 0)
+    if ((e.buttons & 1) === 0) {
+      // The primary button is no longer held, but we never saw the release —
+      // it happened outside the window, over another application, or after the
+      // browser dropped pointer capture. Treat this move as the missing
+      // `pointerup`: without it the gesture stays wedged with `data-swiping`
+      // set (which pins the transition to 0ms), leaving the drawer frozen
+      // mid-pull and ignoring every subsequent drag.
+      finishSwipe(el)
       return
+    }
     processMove(el, { x: e.clientX, y: e.clientY }, e.timeStamp)
   }
 
@@ -434,8 +456,27 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
     if (!pointerStarted || e.pointerId !== activePointerId)
       return
     const el = elementRef.value
-    if (!el)
+    if (!el) {
+      reset()
       return
+    }
+    finishSwipe(el)
+  }
+
+  /**
+   * Ends an in-flight pointer drag that can no longer be tracked — pointer
+   * capture was lost, or the window lost focus mid-drag (which is what happens
+   * when the release lands over another application). The drawer settles from
+   * wherever it was last dragged to.
+   */
+  function onPointerInterrupted() {
+    if (!pointerStarted)
+      return
+    const el = elementRef.value
+    if (!el) {
+      reset()
+      return
+    }
     finishSwipe(el)
   }
 
@@ -539,16 +580,34 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
       if (!el)
         return
 
+      // BaseUI hangs the gesture off `Drawer.Viewport`, a `position: fixed;
+      // inset: 0` element, so the pointer can never leave the element that is
+      // listening. Here the listeners live on the popup itself, which the
+      // pointer leaves as soon as the drag goes past the drawer's bounds.
+      // `setPointerCapture` covers that for an ordinary in-window drag, but a
+      // release the popup never sees — outside the window, over another app, or
+      // after capture is dropped — would otherwise leave the gesture wedged.
+      // Mirror the pointer end events on the document and window so the drag
+      // can always be finished.
+      const doc = el.ownerDocument
+      const win = doc.defaultView
+
       cleanups.push(
         useEventListener(el, 'pointerdown', onPointerDown as EventListener),
         useEventListener(el, 'pointermove', onPointerMove as EventListener),
         useEventListener(el, 'pointerup', onPointerUp as EventListener),
         useEventListener(el, 'pointercancel', onPointerUp as EventListener),
+        useEventListener(el, 'lostpointercapture', onPointerInterrupted as EventListener),
+        useEventListener(doc, 'pointerup', onPointerUp as EventListener),
+        useEventListener(doc, 'pointercancel', onPointerUp as EventListener),
         useEventListener(el, 'touchstart', onTouchStart as EventListener, { passive: true }),
         useEventListener(el, 'touchmove', onTouchMove as EventListener, { passive: false }),
         useEventListener(el, 'touchend', onTouchEnd as EventListener),
         useEventListener(el, 'touchcancel', onTouchEnd as EventListener),
       )
+
+      if (win)
+        cleanups.push(useEventListener(win, 'blur', onPointerInterrupted))
     },
     { immediate: true },
   )

--- a/packages/core/src/Drawer/composables/useSwipeDismiss.ts
+++ b/packages/core/src/Drawer/composables/useSwipeDismiss.ts
@@ -269,22 +269,18 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
     const dir: SwipeDirection | undefined = toValue(directions).find(d => getDisplacement(d, dx, dy) > 0)
 
     if (pendingSwipe && pendingSwipeStartPos) {
-      // Only promote to an active swipe when we've identified an allowed
-      // direction. If the user is dragging against the dismiss direction
-      // (dir === undefined), bail out so we don't steal scroll/drag from
-      // one-direction drawers.
-      if (!dir)
-        return
-      const pending = getDisplacement(
-        dir,
-        pos.x - pendingSwipeStartPos.x,
-        pos.y - pendingSwipeStartPos.y,
-      )
-      if (Math.abs(pending) < MIN_DRAG_THRESHOLD)
+      // BaseUI parity (`useSwipeDismiss.ts:startSwipeAtPosition`): the drag is
+      // tracked from the first movement whatever its direction — the gesture
+      // does NOT need to point at a dismissable direction to begin. Movement
+      // along a non-dismissable direction still reaches
+      // `applyDirectionalDamping` below, which sqrt-damps it; that damped
+      // offset is the elastic "pull" feedback you get when dragging a bottom
+      // drawer upward. Bailing out on `!dir` instead would leave the drawer
+      // completely frozen until the user drags the dismissable way.
+      const pending = Math.max(Math.abs(dx), Math.abs(dy))
+      if (pending < MIN_DRAG_THRESHOLD)
         return
       pendingSwipe = false
-      intendedDirection = dir
-      swipeDirection.value = dir
       setSwiping(true)
       onSwipeStart?.()
     }
@@ -292,11 +288,21 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
     if (!isSwiping.value)
       return
 
-    const currentDir = intendedDirection ?? toValue(directions)[0]
-    const displacement = getDisplacement(currentDir, dx, dy)
+    // The intended (dismissable) direction is adopted the first time the drag
+    // moves in one, which may be many moves after the swipe started — e.g. pull
+    // up, then push back down on a `down` drawer. Until then the gesture has no
+    // dismiss candidate and only rubber-bands.
+    if (!intendedDirection && dir) {
+      intendedDirection = dir
+      swipeDirection.value = dir
+      maxDisplacement = getDisplacement(dir, dx, dy)
+    }
+
+    const currentDir = intendedDirection
 
     // Detect reversal (cancel swipe)
-    if (!cancelledSwipe) {
+    if (currentDir && !cancelledSwipe) {
+      const displacement = getDisplacement(currentDir, dx, dy)
       maxDisplacement = Math.max(maxDisplacement, displacement)
       if (
         maxDisplacement > DEFAULT_SWIPE_THRESHOLD / 2
@@ -315,14 +321,18 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
     setCssVars(el, damped.x, damped.y)
     recordSample({ x: damped.x, y: damped.y }, time)
 
-    // Progress: 0 = closed/start, 1 = fully dismissed
+    // Progress: 0 = closed/start, 1 = fully dismissed. Before a dismissable
+    // direction is adopted, measure against the primary one — a pull away from
+    // it yields a negative displacement, which clamps to 0 (BaseUI parity:
+    // `progressDirection = primaryDirection ?? intendedSwipeDirection`).
     const currentEl = elementRef.value
-    if (currentEl) {
-      const dim = (currentDir === 'up' || currentDir === 'down')
+    const progressDir = currentDir ?? toValue(directions)[0]
+    if (currentEl && progressDir) {
+      const dim = (progressDir === 'up' || progressDir === 'down')
         ? elementSize.height || currentEl.offsetHeight
         : elementSize.width || currentEl.offsetWidth
-      const threshold = getThreshold(currentEl, currentDir)
-      const p = Math.min(1, Math.max(0, displacement / (dim + threshold)))
+      const threshold = getThreshold(currentEl, progressDir)
+      const p = Math.min(1, Math.max(0, getDisplacement(progressDir, dx, dy) / (dim + threshold)))
       if (p !== swipeProgress) {
         swipeProgress = p
         onProgress?.(p, { deltaX: damped.x, deltaY: damped.y, direction: currentDir })


### PR DESCRIPTION
## Problem

The Drawer has no elastic "pull" feedback. Dragging a bottom drawer **upward** does nothing at all — no transform, no `data-swiping` — where [Base UI's Drawer](https://base-ui.com/react/components/drawer) rubber-bands.

## Root cause

`applyDirectionalDamping()` sqrt-damps any axis moving in a direction that can't dismiss the drawer. That's exactly the elastic pull, and it was a faithful port — but it was **unreachable**. `processMove` bailed out first:

```js
if (!dir)   // no allowed dismiss direction in this drag
  return
```

Base UI starts tracking the gesture on pointerdown regardless of direction (`startSwipeAtPosition` calls `setSwiping(true)` unconditionally) and only *later* adopts an intended direction, once the drag first moves in a dismissable one. This port folded direction-adoption into the promotion step, so a pure pull-up never became an active swipe.

## Fix

1. Promote to an active swipe on any movement past `MIN_DRAG_THRESHOLD`, not just movement in an allowed direction.
2. Adopt `intendedDirection` lazily on each move until one is found — otherwise a pull-up-then-push-down gesture would be permanently stuck without a dismiss candidate.
3. Guard the reversal-cancel branch on having an intended direction, and fall back to `directions[0]` for progress (a pull away clamps to 0), matching Base UI's `progressDirection = primaryDirection ?? intendedSwipeDirection`.

## Verification

Drove both implementations in Chromium via Playwright — 150px upward drag on a bottom drawer, reading the computed transform:

| | Base UI (base-ui.com) | before | after |
|---|---|---|---|
| `transform` | `translateY(-11.83px)` | `translateY(0)` | `translateY(-12.25px)` |
| `--drawer-swipe-movement-y` | `-11.83px` | `0px` | `-12.25px` |
| `data-swiping` | present | absent | present |

−12.25 = −√150, the expected sqrt damping. Base UI's −11.83 = −√140 — it absorbs the first move into the drag origin, hence the 10px difference.

Also browser-verified, no regressions:
- pull-up-then-push-down past threshold still dismisses
- sub-threshold down-drag still cancels and springs back
- Snap Points variant unchanged (both vertical directions are allowed there, so nothing is damped)
- Top / Right drawers now rubber-band on their non-dismiss axis too (`-12px` for a 144px drag)

Left alone deliberately: on touch, if the drawer body is scrollable and not at the relevant edge, an upward drag still yields to scrolling instead of rubber-banding. That matches Base UI, which refuses to start the swipe on a scrollable touch target.

## Checks

- 3 regression tests added to `useSwipeDismiss.test.ts`
- Full suite: 2007 tests pass
- `pnpm lint` and `pnpm --filter reka-ui type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drawer swipe-to-dismiss gestures when dragging opposite to the configured dismiss direction.
  * Added elastic resistance and smoother progress tracking for opposing movement.
  * Swipes can now reverse into the dismiss direction without losing gesture state.
  * Improved recovery when pointer releases, capture is lost, or the window blurs.
  * Gestures are correctly canceled and reset between interrupted or incomplete swipes.
  * Improved drawer stretching during overscroll to keep content connected to its anchored edge.

* **Documentation**
  * Added guidance for configuring overscroll bleed and safe-area spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->