### PR TITLE
fix(Dialog): re-key auto-focus on presence when force-mounted

### DIFF
--- a/packages/core/src/Dialog/Dialog.test.ts
+++ b/packages/core/src/Dialog/Dialog.test.ts
@@ -243,6 +243,126 @@ describe('given a Dialog with unmountOnHide=false, openAutoFocus', () => {
 
     wrapper.unmount()
   })
+
+  it('should emit openAutoFocus again on reopen', async () => {
+    document.body.innerHTML = ''
+    const onOpenAutoFocus = vi.fn()
+    const wrapper = mount(OpenAutoFocusDialog, { attachTo: document.body, props: { onOpenAutoFocus } })
+    const trigger = wrapper.find('button')
+
+    await fireEvent.click(trigger.element)
+    await vi.waitFor(() => expect(onOpenAutoFocus).toHaveBeenCalledTimes(1))
+
+    await fireEvent.click(await findByText(document.body, CLOSE_TEXT))
+    await fireEvent.click(trigger.element)
+    await vi.waitFor(() => expect(onOpenAutoFocus).toHaveBeenCalledTimes(2))
+
+    wrapper.unmount()
+  })
+})
+
+// `forceMount` also keeps the content in the DOM across open/close, so
+// `FocusScope` never physically remounts and mount-keyed behaviour has to be
+// re-keyed on the presence state. Folding `forceMount` into `Presence`'s
+// `present` pinned that state to `true`, so `openAutoFocus` fired only on the
+// very first open and the overlay never released the body scroll lock (#2450).
+describe('given a Dialog with forceMount', () => {
+  const ForceMountDialog = defineComponent({
+    components: { DialogRoot, DialogTrigger, DialogOverlay, DialogContent, DialogClose, DialogTitle },
+    props: ['onOpenAutoFocus'],
+    template: `<DialogRoot>
+  <DialogTrigger>${OPEN_TEXT}</DialogTrigger>
+  <DialogOverlay force-mount />
+  <DialogContent force-mount @open-auto-focus="onOpenAutoFocus">
+    <DialogTitle>${TITLE_TEXT}</DialogTitle>
+    <DialogClose>${CLOSE_TEXT}</DialogClose>
+  </DialogContent>
+</DialogRoot>`,
+  })
+
+  let wrapper: VueWrapper
+
+  // The body scroll lock is a shared composable: leaving a dialog mounted after
+  // a failed assertion keeps the lock held and cascades into unrelated tests.
+  afterEach(() => {
+    wrapper?.unmount()
+    document.body.style.overflow = ''
+    document.body.style.pointerEvents = ''
+  })
+
+  it('should emit openAutoFocus on every open, not only the first', async () => {
+    document.body.innerHTML = ''
+    const onOpenAutoFocus = vi.fn()
+    wrapper = mount(ForceMountDialog, { attachTo: document.body, props: { onOpenAutoFocus } })
+    const trigger = wrapper.find('button')
+
+    // Force-mounted but closed: the dialog must not grab focus or lock the body
+    // on mount. `FocusScope` dispatches its mount auto-focus a few ticks in, so
+    // a bare `nextTick()` here would pass even when it does fire.
+    await sleep(100)
+    expect(onOpenAutoFocus).toHaveBeenCalledTimes(0)
+    expect(document.activeElement).toBe(document.body)
+    expect(document.body.style.overflow).not.toBe('hidden')
+
+    await fireEvent.click(trigger.element)
+    await vi.waitFor(() => expect(onOpenAutoFocus).toHaveBeenCalledTimes(1))
+
+    await fireEvent.click(await findByText(document.body, CLOSE_TEXT))
+    await fireEvent.click(trigger.element)
+    await vi.waitFor(() => expect(onOpenAutoFocus).toHaveBeenCalledTimes(2))
+  })
+
+  it('should release the body scroll lock on close', async () => {
+    document.body.innerHTML = ''
+    wrapper = mount(ForceMountDialog, { attachTo: document.body, props: { onOpenAutoFocus: vi.fn() } })
+    const trigger = wrapper.find('button')
+
+    await fireEvent.click(trigger.element)
+    await vi.waitFor(() => expect(document.body.style.overflow).toBe('hidden'))
+
+    await fireEvent.click(await findByText(document.body, CLOSE_TEXT))
+    await vi.waitFor(() => expect(document.body.style.overflow).not.toBe('hidden'))
+  })
+})
+
+// Regression guard for the default (unmounting) path: the content unmounts on
+// close, so the auto-focus is driven by the physical remount rather than by
+// `present`.
+describe('given a default Dialog, openAutoFocus', () => {
+  const DefaultAutoFocusDialog = defineComponent({
+    components: { DialogRoot, DialogTrigger, DialogContent, DialogClose, DialogTitle },
+    props: ['onOpenAutoFocus'],
+    template: `<DialogRoot>
+  <DialogTrigger>${OPEN_TEXT}</DialogTrigger>
+  <DialogContent @open-auto-focus="onOpenAutoFocus">
+    <DialogTitle>${TITLE_TEXT}</DialogTitle>
+    <DialogClose>${CLOSE_TEXT}</DialogClose>
+  </DialogContent>
+</DialogRoot>`,
+  })
+
+  it('should emit once per open across repeated opens', async () => {
+    document.body.innerHTML = ''
+    const onOpenAutoFocus = vi.fn()
+    const wrapper = mount(DefaultAutoFocusDialog, { attachTo: document.body, props: { onOpenAutoFocus } })
+    const trigger = wrapper.find('button')
+
+    await nextTick()
+    expect(onOpenAutoFocus).toHaveBeenCalledTimes(0)
+
+    await fireEvent.click(trigger.element)
+    await vi.waitFor(() => expect(onOpenAutoFocus).toHaveBeenCalledTimes(1))
+
+    await fireEvent.click(await findByText(document.body, CLOSE_TEXT))
+    // The content unmounts asynchronously; reopening before it is gone would
+    // reuse the still-mounted scope and tell us nothing about the remount path.
+    await vi.waitFor(() => expect(document.querySelector('[role="dialog"]')).toBeNull())
+
+    await fireEvent.click(trigger.element)
+    await vi.waitFor(() => expect(onOpenAutoFocus).toHaveBeenCalledTimes(2))
+
+    wrapper.unmount()
+  })
 })
 
 // Two dialogs with `unmountOnHide: false` coexist on the page (e.g. a menu

--- a/packages/core/src/Dialog/DialogContent.vue
+++ b/packages/core/src/Dialog/DialogContent.vue
@@ -16,6 +16,7 @@ export interface DialogContentProps extends Omit<DialogContentImplProps, 'trapFo
 </script>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Presence } from '@/Presence'
 import { useEmitAsProps, useForwardExpose } from '@/shared'
 import DialogContentModal from './DialogContentModal.vue'
@@ -35,28 +36,38 @@ const rootContext = injectDialogRootContext()
 
 const emitsAsProps = useEmitAsProps(emits)
 const { forwardRef } = useForwardExpose()
+
+// The node stays in the DOM across open/close when force-mounted, or when the
+// root opts out of unmounting. Only then does the child need the real presence
+// state: mount-keyed behaviour (`FocusScope`'s auto-focus, layer stacks) has to
+// be re-keyed on `present` because no physical unmount happens. When the node
+// does unmount on close, keep passing a constant `true` so the child is never
+// briefly told it is absent while `usePresence` settles on `MOUNT`.
+const staysMounted = computed(
+  () => props.forceMount || !rootContext.unmountOnHide.value,
+)
 </script>
 
 <template>
   <Presence
     v-slot="{ present }"
-    :present="forceMount || rootContext.open.value"
-    :force-mount="forceMount || !rootContext.unmountOnHide.value"
+    :present="rootContext.open.value"
+    :force-mount="staysMounted"
   >
     <DialogContentModal
       v-if="rootContext.modal.value"
-      v-show="rootContext.unmountOnHide.value || present"
+      v-show="forceMount || rootContext.unmountOnHide.value || present"
       :ref="forwardRef"
-      :present="rootContext.unmountOnHide.value || present"
+      :present="staysMounted ? present : true"
       v-bind="{ ...props, ...emitsAsProps, ...$attrs }"
     >
       <slot />
     </DialogContentModal>
     <DialogContentNonModal
       v-else
-      v-show="rootContext.unmountOnHide.value || present"
+      v-show="forceMount || rootContext.unmountOnHide.value || present"
       :ref="forwardRef"
-      :present="rootContext.unmountOnHide.value || present"
+      :present="staysMounted ? present : true"
       v-bind="{ ...props, ...emitsAsProps, ...$attrs }"
     >
       <slot />

--- a/packages/core/src/Dialog/DialogOverlay.vue
+++ b/packages/core/src/Dialog/DialogOverlay.vue
@@ -13,29 +13,37 @@ export interface DialogOverlayProps extends DialogOverlayImplProps {
 </script>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Presence } from '@/Presence'
 import { injectDialogRootContext } from './DialogRoot.vue'
 
-defineProps<DialogOverlayProps>()
+const props = defineProps<DialogOverlayProps>()
 const rootContext = injectDialogRootContext()
 
 const { forwardRef } = useForwardExpose()
+
+// See `DialogContent.vue`: when the overlay is kept mounted across open/close it
+// must report the real presence state, otherwise `DialogOverlayImpl` keeps the
+// body scroll locked after the dialog is dismissed.
+const staysMounted = computed(
+  () => props.forceMount || !rootContext.unmountOnHide.value,
+)
 </script>
 
 <template>
   <Presence
     v-if="rootContext?.modal.value"
     v-slot="{ present }"
-    :present="forceMount || rootContext.open.value"
-    :force-mount="forceMount || !rootContext.unmountOnHide.value"
+    :present="rootContext.open.value"
+    :force-mount="staysMounted"
   >
     <DialogOverlayImpl
-      v-show="rootContext.unmountOnHide.value || present"
+      v-show="forceMount || rootContext.unmountOnHide.value || present"
       v-bind="$attrs"
       :ref="forwardRef"
       :as="as"
       :as-child="asChild"
-      :present="rootContext.unmountOnHide.value || present"
+      :present="staysMounted ? present : true"
     >
       <slot />
     </DialogOverlayImpl>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2450

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`DialogContent` folded `forceMount` into `Presence`'s `present`:

```vue
:present="forceMount || rootContext.open.value"
```

With `forceMount` set, `present` is pinned to `true`, so `usePresence` never leaves the mounted state and `FocusScope` never physically remounts — and `FocusScope.vue:187-236` keys its mount auto-focus on that effect re-running.

The `present` watcher added in #2662 (`FocusScope.vue:246-268`) couldn't compensate either: the value passed down was `:present="rootContext.unmountOnHide.value || present"`, a constant `true` under the default `unmountOnHide: true`, so it never saw a `false → true` transition.

Both paths dead at once means exactly one dispatch — and it happens **at mount**, not on first open. A force-mounted dialog that has never been opened already steals focus into its closed content and locks body scroll on page load.

**Fix:** stop conflating "stays in the DOM" with "is open". `:force-mount` already expresses the former, so `:present` can carry the real open state. `forceMount` is kept in the `v-show` expression so a force-mounted dialog stays visible and the consumer retains control of its own animation. Where the node does unmount on close, `:present` remains a constant `true` so the child is never briefly told it is absent while `usePresence` settles on `MOUNT` — the default and `unmountOnHide: false` paths are boolean-equivalent to before.

`DialogOverlay` gets the identical change: its `present` drives the body scroll lock in `DialogOverlayImpl.vue:19-20`, which otherwise stayed locked after dismissing a force-mounted dialog.

Measured in a real browser (Chrome via CDP), `openAutoFocus` count over open → close → reopen:

| Setup | Before | After |
|---|---|---|
| Plain dialog, no animation | 2 | 2 |
| Enter + leave animation | 2 | 2 |
| Enter animation only | 2 | 2 |
| `<DialogContent force-mount>` | **1** | **2** |
| `force-mount`, hidden via opacity | **1** | **2** |

Three new tests in `Dialog.test.ts` fail on `v2` and pass with this patch: auto-focus fires once per open across repeated opens, does not fire at all while force-mounted and closed, and the body scroll lock is released on close. Full `packages/core` suite, `type-check` and lint are unaffected.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dialog open and close behavior across default, force-mounted, and keep-mounted configurations.
  * Fixed autofocus behavior so it triggers once per opening and remains suppressed while the Dialog is closed.
  * Ensured overlays and content correctly reflect dismissed state while remaining mounted.
  * Fixed body scroll locking so it is released when force-mounted Dialogs close.

* **Tests**
  * Added regression coverage for autofocus, reopening, mounting, visibility, and scroll-lock behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->