### PR TITLE
fix(RadioGroup): stop falling back to the item value for aria-label

### DIFF
--- a/packages/core/src/RadioGroup/Radio.vue
+++ b/packages/core/src/RadioGroup/Radio.vue
@@ -55,7 +55,7 @@ const isFormControl = useFormControl(triggerElement)
 // `nested-interactive` a11y violation; forward the parent scope id for scoped styles.
 const scopeIdAttrs = useForwardScopeId()
 
-const ariaLabel = computed(() => props.id && triggerElement.value ? (document.querySelector(`[for="${props.id}"]`) as HTMLLabelElement)?.innerText ?? props.value : undefined)
+const ariaLabel = computed(() => props.id && triggerElement.value ? (document.querySelector(`[for="${props.id}"]`) as HTMLLabelElement)?.innerText : undefined)
 
 function handleClick(event: MouseEvent) {
   if (props.disabled)

--- a/packages/core/src/RadioGroup/RadioGroup.test.ts
+++ b/packages/core/src/RadioGroup/RadioGroup.test.ts
@@ -3,8 +3,9 @@ import { fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { nextTick } from 'vue'
 import { handleSubmit, sleep } from '@/test'
-import { RadioGroupItem } from '..'
+import { RadioGroupItem, RadioGroupRoot } from '..'
 import Radio from './story/_Radio.vue'
 import RadioGroup from './story/_RadioGroup.vue'
 
@@ -90,6 +91,19 @@ describe('given disabled RadioGroup', () => {
   it.each([[0], [1], [2]])('should have disabled attribute on item', async (input) => {
     expect(radios[input].attributes('disabled')).toBe('')
     expect(radios[input].attributes('data-disabled')).toBe('')
+  })
+})
+
+describe('given a RadioGroupItem whose label is not found', () => {
+  it('should not fall back to the value as the accessible name', async () => {
+    document.body.innerHTML = ''
+    const wrapper = mount({
+      components: { RadioGroupItem, RadioGroupRoot },
+      template: '<RadioGroupRoot><RadioGroupItem id="r1" value="event_type" /></RadioGroupRoot>',
+    }, { attachTo: document.body })
+    await nextTick()
+
+    expect(wrapper.find('[role=radio]').attributes('aria-label')).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2860

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`Radio` computes its `aria-label` from a one-shot `document.querySelector('[for=...]')`, and falls back to `props.value` when that lookup misses. The lookup has no reactive dependency on the DOM, so it never re-runs, and in wrappers that render the item before its sibling `<label for>` (Nuxt UI's `RadioGroup`, for example) the label simply isn't there yet at first read.

Since `aria-label` outranks a native `<label for>` in the accessible name computation, the fallback doesn't fail quietly. It replaces a correct, present label with the raw enum value, and whether it does that depends on mount order, so the same markup announces "One total row" in dev and "none" in a production build.

Dropping the fallback leaves the name to the `<label for>`, which is right whenever a label exists. An item with no label at all now ends up with no accessible name, which is a visible authoring bug rather than a silently wrong one. `CheckboxRoot` and `SwitchRoot` already do the lookup without a fallback, so this also brings `Radio` in line with them.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for radio group items without a matching label by preventing the option value from being used as an unintended `aria-label`.
  * Radio items now expose only the associated label text when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->