### PR TITLE
fix(DismissableLayer): ignore outside pointerdown while not present

### DIFF
--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -441,8 +441,8 @@ describe('given a not-present DismissableLayer (e.g. unmountOnHide hidden)', () 
     expect(wrapper.emitted('dismiss')).toBeUndefined()
   })
 
-  // Regression (nuxt/ui#6797): on touch, `pointerDownOutside` is deferred to the `click`
-  // event. A layer listening while not present captures the `pointerdown` of the tap that
+  // Regression: on touch, `pointerDownOutside` is deferred to the `click` event.
+  // A layer listening while not present captures the `pointerdown` of the tap that
   // opens it, and dismisses itself when that tap's `click` arrives.
   it('should not dismiss on the tap that made it present', async () => {
     // jsdom has no `PointerEvent`, so `fireEvent.pointerDown` loses `pointerType`

--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -441,6 +441,42 @@ describe('given a not-present DismissableLayer (e.g. unmountOnHide hidden)', () 
     expect(wrapper.emitted('dismiss')).toBeUndefined()
   })
 
+  // Regression (nuxt/ui#6797): on touch, `pointerDownOutside` is deferred to the `click`
+  // event. A layer listening while not present captures the `pointerdown` of the tap that
+  // opens it, and dismisses itself when that tap's `click` arrives.
+  it('should not dismiss on the tap that made it present', async () => {
+    // jsdom has no `PointerEvent`, so `fireEvent.pointerDown` loses `pointerType`
+    // and would take the mouse path instead of the deferred touch one.
+    function touchPointerDown() {
+      const event = new MouseEvent('pointerdown', { bubbles: true })
+      Object.defineProperty(event, 'pointerType', { value: 'touch' })
+      document.body.dispatchEvent(event)
+    }
+
+    const wrapper = mount(DismissableLayerPrimitive, {
+      attachTo: document.body,
+      props: { present: false },
+    })
+    await sleep(1)
+
+    touchPointerDown()
+    await wrapper.setProps({ present: true })
+    await sleep(1)
+    await fireEvent.click(document.body)
+    await sleep(1)
+
+    expect(wrapper.emitted('pointerDownOutside')).toBeUndefined()
+    expect(wrapper.emitted('dismiss')).toBeUndefined()
+
+    // a later tap outside still dismisses it
+    touchPointerDown()
+    await fireEvent.click(document.body)
+    await sleep(1)
+
+    expect(wrapper.emitted('pointerDownOutside')?.length).toBe(1)
+    expect(wrapper.emitted('dismiss')?.length).toBe(1)
+  })
+
   it('should emit escapeKeyDown and dismiss on Escape once present', async () => {
     const wrapper = mount(DismissableLayerPrimitive, {
       attachTo: document.body,

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -109,6 +109,11 @@ const isPointerEventsEnabled = computed(() => {
   return index.value >= highestLayerWithOutsidePointerEventsDisabledIndex
 })
 
+// A layer that stays mounted while hidden (e.g. a Dialog with `unmountOnHide: false`)
+// must not listen while it is not present, hence the `present` guard passed as `enabled`.
+// On touch the dispatch is deferred to the `click` event, so a `pointerdown` captured
+// while hidden would be delivered right after the layer opened and dismiss it on the
+// very interaction that opened it.
 const pointerDownOutside = usePointerDownOutside(async (event) => {
   const isPointerDownOnBranch = [...context.branches].some(branch =>
     branch?.contains(event.target as HTMLElement),
@@ -121,7 +126,7 @@ const pointerDownOutside = usePointerDownOutside(async (event) => {
   await nextTick()
   if (!event.defaultPrevented)
     emits('dismiss')
-}, layerElement)
+}, layerElement, () => props.present)
 
 const focusOutside = useFocusOutside((event) => {
   const isFocusInBranch = [...context.branches].some(branch =>


### PR DESCRIPTION
### 🔗 Linked issue

Reported downstream in nuxt/ui#6797.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

On touch, `usePointerDownOutside` doesn't dispatch on `pointerdown`, it defers to the next `click` so the ~350ms tap delay can't replay events that should have been prevented.

A layer that stays mounted while hidden (`unmountOnHide: false`) was still listening while `present` was `false`, so it captured the `pointerdown` of the tap that opens it. By the time that tap's `click` fired the layer was present, the deferred handler ran, and it dismissed itself on the very interaction that opened it. On mouse there's no deferral, so the event is dispatched while the layer is still not present and the `!props.present` guard in the handler catches it. Touch never hits that guard.

Passing `present` as the composable's `enabled` means the listener isn't registered at all while hidden, and the existing `setTimeout(0)` before attaching covers the tick where the layer becomes present.

`useFocusOutside` takes the same `enabled` argument but is deliberately left alone here: it also gates `onBlurCapture`, so `isFocusInsideDOMTree` would stay stuck at `true` when focus leaves a hidden layer, and a later outside focus would be read as inside.

### 📸 Screenshots (if appropriate)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where showing a dismissible layer after a touch interaction could incorrectly trigger outside dismissal.
  - Touch interactions outside the layer now correctly emit outside-pointer and dismissal events.
  - Hidden but mounted layers no longer respond to deferred touch events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->