### PR TITLE
fix(Stepper): default StepperIndicator as <span>

### DIFF
--- a/docs/content/meta/StepperIndicator.md
+++ b/docs/content/meta/StepperIndicator.md
@@ -7,7 +7,7 @@
     'description': '<p>The element or component this component should render as. Can be overwritten by <code>asChild</code>.</p>\n',
     'type': 'AsTag | Component',
     'required': false,
-    'default': '\'div\''
+    'default': '\'span\''
   },
   {
     'name': 'asChild',
@@ -32,7 +32,7 @@
 
 | Name | Description | Type | Required | Default |
 | --- | --- | --- | --- | --- |
-| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
+| `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"span"` |
 | `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
 
 **Slots**

--- a/packages/core/src/Stepper/StepperIndicator.vue
+++ b/packages/core/src/Stepper/StepperIndicator.vue
@@ -9,7 +9,7 @@ import { Primitive } from '@/Primitive'
 
 export interface StepperIndicatorProps extends PrimitiveProps { }
 
-const props = withDefaults(defineProps<StepperDescriptionProps>(), { as: 'span' })
+const props = withDefaults(defineProps<StepperIndicatorProps>(), { as: 'span' })
 
 defineSlots<{
   default?: (props: {

--- a/packages/core/src/Stepper/StepperIndicator.vue
+++ b/packages/core/src/Stepper/StepperIndicator.vue
@@ -9,7 +9,7 @@ import { Primitive } from '@/Primitive'
 
 export interface StepperIndicatorProps extends PrimitiveProps { }
 
-const props = defineProps<StepperIndicatorProps>()
+const props = withDefaults(defineProps<StepperDescriptionProps>(), { as: 'span' })
 
 defineSlots<{
   default?: (props: {


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
https://github.com/unovue/reka-ui/issues/2864

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves https://github.com/unovue/reka-ui/issues/2864
StepperIndicator renders as a div within a button element from the StepperTrigger

### 📸 Screenshots (if appropriate)
<img width="2418" height="422" alt="image" src="https://github.com/user-attachments/assets/b85ef347-5780-409e-a794-424748e473f8" />

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Stepper Indicator’s default rendered element from `div` to `span`.

* **Documentation**
  * Updated the Stepper Indicator property documentation to reflect the new default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->