### PR TITLE
fix(tabs): keep aria-controls resolvable when SSR and client ids diverge

### DIFF
--- a/packages/core/src/Tabs/Tabs.test.ts
+++ b/packages/core/src/Tabs/Tabs.test.ts
@@ -139,4 +139,46 @@ describe('given Tabs without TabsContent', () => {
     expect(triggers[0].attributes('aria-controls')).toBeDefined()
     expect(triggers[1].attributes('aria-controls')).toBeUndefined()
   })
+
+  it('should render aria-controls matching the TabsContent id', async () => {
+    const wrapper = mount({
+      components: { TabsRoot, TabsList, TabsTrigger, TabsContent },
+      template: `
+        <TabsRoot default-value="tab1">
+          <TabsList>
+            <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          </TabsList>
+          <TabsContent id="rendered-id" value="tab1">Content 1</TabsContent>
+        </TabsRoot>
+      `,
+    })
+    await flushPromises()
+
+    const trigger = wrapper.find('[role="tab"]')
+    const content = wrapper.find('[role="tabpanel"]')
+    expect(trigger.attributes('aria-controls')).toBe(content.attributes('id'))
+  })
+
+  it('should update aria-controls when the TabsContent value changes', async () => {
+    const wrapper = mount({
+      components: { TabsRoot, TabsList, TabsTrigger, TabsContent },
+      props: { value: String },
+      template: `
+        <TabsRoot :default-value="value">
+          <TabsList>
+            <TabsTrigger :value="value">Tab 1</TabsTrigger>
+          </TabsList>
+          <TabsContent :value="value">Content 1</TabsContent>
+        </TabsRoot>
+      `,
+    }, { props: { value: 'tab1' } })
+    await flushPromises()
+
+    await wrapper.setProps({ value: 'tab2' })
+    await flushPromises()
+
+    const trigger = wrapper.find('[role="tab"]')
+    const content = wrapper.find('[role="tabpanel"]')
+    expect(trigger.attributes('aria-controls')).toBe(content.attributes('id'))
+  })
 })

--- a/packages/core/src/Tabs/TabsContent.vue
+++ b/packages/core/src/Tabs/TabsContent.vue
@@ -15,7 +15,7 @@ export interface TabsContentProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { Presence } from '@/Presence'
 import { Primitive } from '@/Primitive'
 import { injectTabsRootContext } from './TabsRoot.vue'
@@ -23,7 +23,7 @@ import { makeContentId, makeTriggerId } from './utils'
 
 const props = defineProps<TabsContentProps>()
 
-const { forwardRef } = useForwardExpose()
+const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectTabsRootContext()
 const triggerId = computed(() => makeTriggerId(rootContext.baseId, props.value))
 const contentId = computed(() => makeContentId(rootContext.baseId, props.value))
@@ -33,7 +33,19 @@ const isSelected = computed(() => props.value === rootContext.modelValue.value)
 const isMountAnimationPreventedRef = ref(isSelected.value)
 
 onMounted(() => {
-  rootContext.registerContent(props.value)
+  // The rendered element keeps the id from the SSR pass, which can differ from
+  // contentId when useId diverges between server and client.
+  watch(
+    [() => props.value, () => currentElement.value?.id || contentId.value],
+    ([value, id], old) => {
+      const oldValue = old?.[0]
+      if (oldValue !== undefined && oldValue !== value)
+        rootContext.unregisterContent(oldValue)
+      rootContext.registerContent(value, id)
+    },
+    { immediate: true, flush: 'post' },
+  )
+
   requestAnimationFrame(() => {
     isMountAnimationPreventedRef.value = false
   })

--- a/packages/core/src/Tabs/TabsRoot.vue
+++ b/packages/core/src/Tabs/TabsRoot.vue
@@ -14,8 +14,8 @@ export interface TabsRootContext {
   activationMode: 'automatic' | 'manual'
   baseId: string
   tabsList: Ref<HTMLElement | undefined>
-  contentIds: Ref<Set<StringOrNumber>>
-  registerContent: (value: StringOrNumber) => void
+  contentIds: Ref<Map<StringOrNumber, string>>
+  registerContent: (value: StringOrNumber, id: string) => void
   unregisterContent: (value: StringOrNumber) => void
 }
 
@@ -85,7 +85,7 @@ const modelValue = useVModel<TabsRootProps<T>, 'modelValue', 'update:modelValue'
 })
 
 const tabsList = ref<HTMLElement>()
-const contentIds = shallowRef<Set<StringOrNumber>>(new Set())
+const contentIds = shallowRef<Map<StringOrNumber, string>>(new Map())
 
 provideTabsRootContext({
   modelValue,
@@ -99,13 +99,13 @@ provideTabsRootContext({
   baseId: useId(undefined, 'reka-tabs'),
   tabsList,
   contentIds,
-  registerContent: (value: StringOrNumber) => {
-    contentIds.value = new Set([...contentIds.value, value])
+  registerContent: (value: StringOrNumber, id: string) => {
+    contentIds.value = new Map(contentIds.value).set(value, id)
   },
   unregisterContent: (value: StringOrNumber) => {
-    const newSet = new Set(contentIds.value)
-    newSet.delete(value)
-    contentIds.value = newSet
+    const newMap = new Map(contentIds.value)
+    newMap.delete(value)
+    contentIds.value = newMap
   },
 })
 </script>

--- a/packages/core/src/Tabs/TabsTrigger.vue
+++ b/packages/core/src/Tabs/TabsTrigger.vue
@@ -16,7 +16,7 @@ import { computed } from 'vue'
 import { Primitive } from '@/Primitive'
 import { RovingFocusItem } from '@/RovingFocus'
 import { injectTabsRootContext } from './TabsRoot.vue'
-import { makeContentId, makeTriggerId } from './utils'
+import { makeTriggerId } from './utils'
 
 const props = withDefaults(defineProps<TabsTriggerProps>(), {
   disabled: false,
@@ -27,7 +27,7 @@ const { forwardRef } = useForwardExpose()
 const rootContext = injectTabsRootContext()
 
 const triggerId = computed(() => makeTriggerId(rootContext.baseId, props.value))
-const contentId = computed(() => rootContext.contentIds.value.has(props.value) ? makeContentId(rootContext.baseId, props.value) : undefined)
+const contentId = computed(() => rootContext.contentIds.value.get(props.value))
 
 const isSelected = computed(() => props.value === rootContext.modelValue.value)
 </script>


### PR DESCRIPTION
## Problem

`TabsTrigger` rebuilds the content id from `rootContext.baseId` instead of using the id the panel actually rendered with:

```ts
const contentId = computed(() => rootContext.contentIds.value.has(props.value)
  ? makeContentId(rootContext.baseId, props.value)
  : undefined)
```

`baseId` comes from `useId()`, and that counter can land on a different value during hydration than it did during SSR. The panel keeps its server id, the trigger recomputes `aria-controls` from the client one, and it points at nothing:

```
trigger id:    reka-tabs-v-0-0-16-0-trigger-queue
aria-controls: reka-tabs-v-0-0-2-0-content-queue   <- no such element
panel id:      reka-tabs-v-0-0-16-0-content-queue
```

One `TabsRoot` per side, so this is not a double mount. axe reports it as a critical `aria-valid-attr-value` violation.

It only shows up after hydration in a production build, never in `nuxt dev`, because `aria-controls` is unset until `TabsContent` registers in `onMounted`. Related: #2682 shows the same id drift.

## Reproduction

Any page where the two passes consume a different number of `useId()` calls before the tabs render. Forcing it directly:

```vue
<script setup lang="ts">
if (import.meta.server) {
  useId(); useId(); useId(); useId(); useId()
}
</script>
```

Build, serve, and compare each trigger's `aria-controls` against the panel ids. Before: 2 of 2 dangle. After: 0.

## Fix

`TabsContent` registers the id it rendered with, and `TabsTrigger` reads that back. Registration runs from a `watch` so it stays correct if the value changes. Triggers with no matching content still get no `aria-controls` (#2601 behaviour unchanged).

## Verified

2014 tests pass, `type-check` and eslint clean. Two regression tests, both fail on `v2`. Checked against the app this came from: axe on the real page went from 2 failures to 0.

## Breaking

`contentIds` becomes a `Map<StringOrNumber, string>` and `registerContent` takes the id as a second argument. Both are exported. Happy to keep the `Set` alongside if you would rather not break it.