### PR TITLE
fix(Tooltip): receive the open broadcast on document instead of window

### DIFF
--- a/packages/core/src/Tooltip/Tooltip.test.ts
+++ b/packages/core/src/Tooltip/Tooltip.test.ts
@@ -1,9 +1,10 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 import Tooltip from './stories/_Tooltip.vue'
 import TooltipProvider from './TooltipProvider.vue'
+import { TOOLTIP_OPEN } from './utils'
 
 describe('given default Tooltip', () => {
   let wrapper: VueWrapper<InstanceType<typeof Tooltip>>
@@ -18,6 +19,11 @@ describe('given default Tooltip', () => {
     wrapper = mount(Tooltip, { attachTo: document.body })
   },
   )
+
+  afterEach(async () => {
+    wrapper.unmount()
+    await flushPromises()
+  })
 
   it('should pass axe accessibility tests', async () => {
     expect(await axe(wrapper.element)).toHaveNoViolations()
@@ -50,6 +56,16 @@ describe('given default Tooltip', () => {
       expect(document.body.innerHTML).not.toContain('Add to library')
     })
   })
+
+  it('should close when another tooltip broadcasts that it opened', async () => {
+    await wrapper.find('button').trigger('focus')
+    expect(document.body.innerHTML).toContain('Add to library')
+
+    document.dispatchEvent(new CustomEvent(TOOLTIP_OPEN))
+    await flushPromises()
+
+    expect(document.body.innerHTML).not.toContain('Add to library')
+  })
 })
 
 describe('given tooltip within TooltipProvider', () => {
@@ -68,6 +84,11 @@ describe('given tooltip within TooltipProvider', () => {
       },
       attachTo: document.body,
     })
+  })
+
+  afterEach(async () => {
+    wrapper.unmount()
+    await flushPromises()
   })
 
   it('should use the provider content values', async () => {

--- a/packages/core/src/Tooltip/TooltipContentImpl.vue
+++ b/packages/core/src/Tooltip/TooltipContentImpl.vue
@@ -87,7 +87,7 @@ onMounted(() => {
       rootContext.onClose()
   }, { capture: true })
   // Close this tooltip if another one opens
-  useEventListener(window, TOOLTIP_OPEN, rootContext.onClose)
+  useEventListener(document, TOOLTIP_OPEN, rootContext.onClose)
 })
 </script>
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2868

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The "close the others when one opens" broadcast never actually ran. `TooltipRoot` dispatches `TOOLTIP_OPEN` on `document`, but `TooltipContentImpl` listens for it on `window`. The event isn't set to bubble, and for something dispatched on `document`, `window` only sees it during the capture phase, not the bubble phase the listener is registered for. So the handler was skipped every time.

This stayed hidden with a mouse because leaving one trigger already closes it before the pointer reaches the next one. It shows up as soon as a tooltip opens without a pointerleave in between, for example with touch input or a programmatic open.

Moved the listener to `document`, matching where the event is dispatched from.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip behavior so opening one tooltip correctly closes any tooltip that is already open.
  * Enhanced tooltip event handling for more reliable behavior across the application.

* **Tests**
  * Added coverage for tooltip replacement behavior and improved test cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->