### PR TITLE
docs: improve clarity on usage of Slot component, improve language

### DIFF
--- a/docs/content/docs/utilities/slot.md
+++ b/docs/content/docs/utilities/slot.md
@@ -11,19 +11,19 @@ Merges its props onto its immediate child.
 
 <Callout type="info" title="Question">
 
-How is this component different from [Vue native slot](https://vuejs.org/guide/components/slots.html)?
+How is this component different from [Vue's native slot](https://vuejs.org/guide/components/slots.html)?
 
-A: The biggest different is how it handles the `attributes` assigned to it.
+A: `<Slot /> automatically assigns `attributes`.
 
 </Callout>
 
-Native slot treat any binded value as [Scoped Slots](https://vuejs.org/guide/components/slots.html#scoped-slots), where the values will be exposed to the parent template and be consumed.
+Vue's native slot treats any binded value as [Scoped Slots](https://vuejs.org/guide/components/slots.html#scoped-slots), where the values will be exposed to the parent template to be consumed.
 
-But Reka UI's slot behave differently, it would merge all the assigned attributes onto it's immediate child.
+But Reka UI's slot behaves differently. Instead, it merges all the assigned attributes onto it's immediate child.
 
 ## Example
 
-Say we want to assign an `id` attribute to whatever component/element that was rendered, but Native slot will convert it into a scoped slot, and you will need to assign that id manually.
+Say we want to assign an `id` attribute to whatever component/element that was rendered. Vue's native slot will convert it into a scoped slot, and you will need to assign that id manually.
 
 ```vue
 <!-- Native Slot -->
@@ -42,13 +42,17 @@ Say we want to assign an `id` attribute to whatever component/element that was r
 <template>
 ```
 (You can check out
-[Vue SFC Playground](https://play.vuejs.org/#eNp9UrFOwzAQ/ZWTly4oUelWhUgFdYABKmD0EpJr45LYln1JK1X5d84OTQEB2/m9d+fnez6JlbVJ36FYisyXTlkCj9TZXGrVWuMITuBwCwNsnWlhxtLZRN2Z1o64FEkaTmGUFFKD1Fk6zuNJfCBsbVMQ8gkgq+f5xhnr0xWRU28doQelwTeG4FB4PSMoC+cUVmB6dFnKDbEx3BErrrmNjM4VO65N11RQFz2Cqm6kmF8vpMjST0XsjPa4zNLJirgS5Eujt2qX7L3RvINT0EpRslY16J4sKaO9FEuITOCKpjGHh4iR6/DqjJc1lu+/4Ht/DJgUG4ceXc/7mTgq3A5ppNcvj3jkeiJbU3UNq/8hn9GbpgseR9ltpyu2/UUX3d7HuJTevfr1kVD786OC0aAcol4KTi+s6a+nX+wukkXsk3rgLZ6TD5/oW9C895jpJZScvwUjP4IYPgAfN9Yc) and see that the `id` wasn't being inherited.)
+[Vue SFC Playground](https://play.vuejs.org/#eNp9UrFOwzAQ/ZWTly4oUelWhUgFdYABKmD0EpJr45LYln1JK1X5d84OTQEB2/m9d+fnez6JlbVJ36FYisyXTlkCj9TZXGrVWuMITuBwCwNsnWlhxtLZRN2Z1o64FEkaTmGUFFKD1Fk6zuNJfCBsbVMQ8gkgq+f5xhnr0xWRU28doQelwTeG4FB4PSMoC+cUVmB6dFnKDbEx3BErrrmNjM4VO65N11RQFz2Cqm6kmF8vpMjST0XsjPa4zNLJirgS5Eujt2qX7L3RvINT0EpRslY16J4sKaO9FEuITOCKpjGHh4iR6/DqjJc1lu+/4Ht/DJgUG4ceXc/7mTgq3A5ppNcvj3jkeiJbU3UNq/8hn9GbpgseR9ltpyu2/UUX3d7HuJTevfr1kVD786OC0aAcol4KTi+s6a+nX+wukkXsk3rgLZ6TD5/oW9C895jpJZScvwUjP4IYPgAfN9Yc) and see that the `id` wasn't inherited.)
 
-This would be troublesome if you want to ensure some attributes are being passed onto certain element, maybe for accessibility reason.
+This can be troublesome and takes more boilerplate if you want to ensure some attributes are being passed onto certain element.
 
 ---
 
-Alternatively, If you use `Slot` from Reka UI, the attributes assigned to the Slot component will be inherited by the immediate child element, but you will no longer have access to the `Scoped Slot`,
+Alternatively, If you use `Slot` from Reka UI, the attributes assigned to the Slot component will be inherited by the immediate child element.
+
+<Callout type="warning" title="Warning">
+Using Reka UI's `<Slot />` prevent's native slots' `Scoped Slot` functionality from working.
+</Callout>
 
 ```vue
 <!-- Reka UI Slot -->
@@ -58,16 +62,23 @@ import { Slot } from 'reka-ui'
 
 <!-- Comp.vue -->
 <template>
-  <Slot id="reka-01">
-    ...
-  </Slot>
+  <div id="my-component">
+    <Slot id="reka-01" class="inherit-me">
+      <slot />
+    </Slot>
+  </div>
 </template>
 
 <!-- parent template -->
 <template>
   <Comp>
-    <!-- id will be inherited -->
+    <!-- id and class will be inherited -->
     <button>...<button>
   <Comp>
 <template>
+
+<!-- final output -->
+<div id="my-component">
+  <button id="reka-01" class="inherit-me">...<button>
+<div>
 ```


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

https://github.com/unovue/reka-ui/issues/2870

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
I have improved the example in the Slot documentation and added language corrections so it reads more fluently.

<!-- Why is this change required? What problem does it solve? -->
The current explanation of the Slot component is not quite clear, and took quite a bit of playing around before I was able to integrate it properly into a component in my Vue library.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #2870 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how the Slot utility differs from Vue’s native slots.
  * Documented attribute merging behavior and the limitation of native scoped-slot functionality.
  * Added a playground reference and updated examples to show inherited `id` and `class` attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->