### PR TITLE
fix(DismissableLayer): remove the stale branch element from the registry on unmount

### DIFF
--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 import { sleep } from '@/test'
-import { DismissableLayer as DismissableLayerPrimitive } from '.'
+import { DismissableLayerBranch, DismissableLayer as DismissableLayerPrimitive } from '.'
 import { context } from './context'
 import DismissableLayer from './story/_DismissableLayer.vue'
 import { isLayerExist } from './utils'
@@ -21,6 +21,23 @@ describe('isLayerExist', () => {
 
     expect(isLayerExist(layer, document as any)).toBe(false)
     expect(isLayerExist(layer, document.createTextNode('x') as any)).toBe(false)
+  })
+})
+
+describe('given a DismissableLayerBranch', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    context.branches.clear()
+  })
+
+  it('should leave the branch registry empty after unmounting', async () => {
+    const wrapper = mount(DismissableLayerBranch, { attachTo: document.body })
+    await nextTick()
+    expect(context.branches.size).toBe(1)
+
+    wrapper.unmount()
+    await nextTick()
+    expect(context.branches.size).toBe(0)
   })
 })
 

--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -33,10 +33,13 @@ describe('given a DismissableLayerBranch', () => {
   it('should leave the branch registry empty after unmounting', async () => {
     const wrapper = mount(DismissableLayerBranch, { attachTo: document.body })
     await nextTick()
+    const branch = wrapper.element
+    expect(context.branches.has(branch)).toBe(true)
     expect(context.branches.size).toBe(1)
 
     wrapper.unmount()
     await nextTick()
+    expect(context.branches.has(branch)).toBe(false)
     expect(context.branches.size).toBe(0)
   })
 })

--- a/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayerBranch.vue
@@ -13,11 +13,19 @@ import { context } from './context'
 const props = defineProps<DismissableLayerBranchProps>()
 
 const { forwardRef, currentElement } = useForwardExpose()
+
+let registeredElement: HTMLElement | null = null
+
 onMounted(() => {
-  context.branches.add(currentElement.value)
+  registeredElement = currentElement.value
+  if (registeredElement)
+    context.branches.add(registeredElement)
 })
 onUnmounted(() => {
-  context.branches.delete(currentElement.value)
+  if (registeredElement) {
+    context.branches.delete(registeredElement)
+    registeredElement = null
+  }
 })
 </script>
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2873

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`DismissableLayerBranch` adds `currentElement.value` to `context.branches` on mount and deletes it again on unmount. By the time `onUnmounted` runs, Vue has already cleared the ref behind that computed, so the delete is a no-op and the element stays in the Set forever. Since `context.branches` is module-level, every branch that unmounts leaks a detached node for the lifetime of the page, and the outside-pointerdown and focus checks in `DismissableLayer` scan the whole Set on every event.

Same fix as #2778 did for `StepperTrigger`: keep the registered element in a local variable and delete that exact reference on unmount.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dismissal behavior for nested layers by reliably registering branch elements when mounted and removing them when unmounted.
  * Prevented invalid or unavailable elements from being registered during the component lifecycle.
* **Tests**
  * Added coverage confirming that branch registration and cleanup work correctly when components mount and unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->