### PR TITLE
fix(Drawer): toggle open state on trigger click

### DIFF
--- a/packages/core/src/Drawer/Drawer.test.ts
+++ b/packages/core/src/Drawer/Drawer.test.ts
@@ -1,4 +1,5 @@
 import type { Mock, MockInstance } from 'vitest'
+import userEvent from '@testing-library/user-event'
 import { findByText, fireEvent, render } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
@@ -159,9 +160,10 @@ describe('update:open change event details', () => {
     components: { DrawerRoot, DrawerTrigger, DrawerPortal, DrawerContent, DrawerTitle, DrawerClose },
     props: {
       onOpenChange: { type: Function, required: true },
+      modal: { type: [Boolean, String], default: true },
     },
     template: `
-      <DrawerRoot @update:open="onOpenChange">
+      <DrawerRoot @update:open="onOpenChange" :modal="modal">
         <DrawerTrigger>Open</DrawerTrigger>
         <DrawerPortal>
           <DrawerContent>
@@ -204,6 +206,19 @@ describe('update:open change event details', () => {
     onOpenChange.mockClear()
     await fireEvent.click(getByText('Open'))
     await nextTick()
+    expect(onOpenChange).toHaveBeenCalledWith(false, { reason: 'trigger-press' })
+  })
+
+  it('closes on a second trigger click in non-modal mode', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const { getByText } = render(DrawerWithReason, { props: { onOpenChange, modal: false } })
+    await user.click(getByText('Open'))
+    await nextTick()
+    onOpenChange.mockClear()
+    await user.click(getByText('Open'))
+    await nextTick()
+    expect(onOpenChange).toHaveBeenCalledTimes(1)
     expect(onOpenChange).toHaveBeenCalledWith(false, { reason: 'trigger-press' })
   })
 })

--- a/packages/core/src/Drawer/Drawer.test.ts
+++ b/packages/core/src/Drawer/Drawer.test.ts
@@ -195,4 +195,15 @@ describe('update:open change event details', () => {
     await nextTick()
     expect(onOpenChange).toHaveBeenCalledWith(false, { reason: 'close-press' })
   })
+
+  it('closes on a second trigger click (toggle)', async () => {
+    const onOpenChange = vi.fn()
+    const { getByText } = render(DrawerWithReason, { props: { onOpenChange } })
+    await fireEvent.click(getByText('Open'))
+    await nextTick()
+    onOpenChange.mockClear()
+    await fireEvent.click(getByText('Open'))
+    await nextTick()
+    expect(onOpenChange).toHaveBeenCalledWith(false, { reason: 'trigger-press' })
+  })
 })

--- a/packages/core/src/Drawer/DrawerRoot.vue
+++ b/packages/core/src/Drawer/DrawerRoot.vue
@@ -206,6 +206,10 @@ provideDrawerRootContext({
   descriptionId,
 })
 
+function handleClose() {
+  handleOpenChange(false, 'close-press')
+}
+
 function handleOpenChange(value: boolean, reason?: DrawerOpenChangeReason) {
   if (open.value === value)
     return
@@ -240,6 +244,6 @@ onUnmounted(() => {
 <template>
   <slot
     :open="open"
-    :close="() => handleOpenChange(false, 'close-press')"
+    :close="handleClose"
   />
 </template>

--- a/packages/core/src/Drawer/DrawerRoot.vue
+++ b/packages/core/src/Drawer/DrawerRoot.vue
@@ -206,13 +206,6 @@ provideDrawerRootContext({
   descriptionId,
 })
 
-function handleClose() {
-  if (!open.value)
-    return
-  uncontrolledOpen.value = false
-  emit('update:open', false, { reason: 'close-press' })
-}
-
 function handleOpenChange(value: boolean, reason?: DrawerOpenChangeReason) {
   if (open.value === value)
     return
@@ -247,6 +240,6 @@ onUnmounted(() => {
 <template>
   <slot
     :open="open"
-    :close="handleClose"
+    :close="() => handleOpenChange(false, 'close-press')"
   />
 </template>

--- a/packages/core/src/Drawer/DrawerRoot.vue
+++ b/packages/core/src/Drawer/DrawerRoot.vue
@@ -69,6 +69,7 @@ export interface DrawerRootContext {
   isSwiping: Ref<boolean>
   nestedSwipeProgressStore: NestedSwipeProgressStore
   onOpenChange: (value: boolean, reason?: DrawerOpenChangeReason) => void
+  onOpenToggle: () => void
   notifyOpenComplete: (value: boolean) => void
   setActiveSnapPoint: (point: DrawerSnapPoint | null) => void
   onPopupHeightChange: (height: number) => void
@@ -163,13 +164,8 @@ provideDrawerRootContext({
   nestedSwiping,
   isSwiping,
   nestedSwipeProgressStore,
-  onOpenChange(value, reason) {
-    if (open.value === value)
-      return
-    const details: DrawerOpenChangeDetails | undefined = reason ? { reason } : undefined
-    uncontrolledOpen.value = value
-    emit('update:open', value, details)
-  },
+  onOpenChange: handleOpenChange,
+  onOpenToggle: handleOpenToggle,
   notifyOpenComplete(value) {
     emit('update:openComplete', value)
   },
@@ -215,6 +211,18 @@ function handleClose() {
     return
   uncontrolledOpen.value = false
   emit('update:open', false, { reason: 'close-press' })
+}
+
+function handleOpenChange(value: boolean, reason?: DrawerOpenChangeReason) {
+  if (open.value === value)
+    return
+  const details: DrawerOpenChangeDetails | undefined = reason ? { reason } : undefined
+  uncontrolledOpen.value = value
+  emit('update:open', value, details)
+}
+
+function handleOpenToggle() {
+  handleOpenChange(!open.value, 'trigger-press')
 }
 
 // Sync open state with DrawerProvider

--- a/packages/core/src/Drawer/DrawerTrigger.vue
+++ b/packages/core/src/Drawer/DrawerTrigger.vue
@@ -37,7 +37,7 @@ onUnmounted(() => {
     :aria-expanded="rootContext.open.value"
     :aria-controls="rootContext.open.value ? rootContext.contentId : undefined"
     :data-state="rootContext.open.value ? 'open' : 'closed'"
-    @click="rootContext.onOpenChange(true, 'trigger-press')"
+    @click="rootContext.onOpenToggle"
   >
     <slot />
   </Primitive>


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2872

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`DrawerTrigger`'s click handler hardcodes `onOpenChange(true, 'trigger-press')`, so it can only ever open the drawer. That's invisible in the default modal mode, where an overlay sits over the page and blocks the trigger once the drawer is open — but in `:modal="false"` or `"trap-focus"` mode the trigger stays clickable while open, and a second click does nothing instead of closing the drawer. `DialogTrigger` doesn't have this problem: it calls `onOpenToggle`, exposed on `DialogRootContext`.

This mirrors that pattern for Drawer: `DrawerRootContext` gains its own `onOpenToggle`, built on the existing guarded `onOpenChange` logic (tagged with the same `'trigger-press'` reason the old hardcoded call used), and `DrawerTrigger`'s click handler now calls it instead of hardcoding `true`.

Worth flagging: while extracting `onOpenChange` into its own function, I noticed `handleClose` (used by the root slot's `close` prop) duplicates the exact same guard/emit shape and could be reduced to `handleOpenChange(false, 'close-press')`. Left it as-is to keep this PR scoped to the toggle bug — happy to fold that in here or as a follow-up, whichever you'd prefer.

---

This is my first contribution to reka-ui, and to open source generally — paired with Claude Code to work through the codebase's conventions while writing this, but the reasoning and decisions here are mine. Happy to take feedback on approach, style, anything.

### 📸 Screenshots

_(none — behavior-only change, no visual difference)_

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. _(not applicable — no public props/emits/slots changed)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Drawer trigger so clicking it while the Drawer is open now closes the Drawer correctly.
  * Drawer state updates now report the `trigger-press` reason consistently.

* **Tests**
  * Added regression coverage for toggling the Drawer closed through its trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->