### PR TITLE
fix(Select,Popover): drop aria-controls while the content is not rendered

### DIFF
--- a/packages/core/src/Popover/Popover.test.ts
+++ b/packages/core/src/Popover/Popover.test.ts
@@ -22,6 +22,16 @@ describe('given default Popover', () => {
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
 
+  it('should only reference the content while open', async () => {
+    const trigger = wrapper.find('button')
+    expect(trigger.attributes('aria-controls')).toBeUndefined()
+
+    trigger.element.click()
+    await nextTick()
+
+    expect(document.getElementById(trigger.attributes('aria-controls')!)).not.toBeNull()
+  })
+
   describe('after opening popover', async () => {
     beforeEach(async () => {
       wrapper.find('button').element.click()

--- a/packages/core/src/Popover/Popover.test.ts
+++ b/packages/core/src/Popover/Popover.test.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
 import Popover from './story/_Popover.vue'
@@ -18,11 +18,15 @@ describe('given default Popover', () => {
     wrapper = mount(Popover, { attachTo: document.body })
   })
 
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
   it('should pass axe accessibility tests', async () => {
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
 
-  it('should only reference the content while open', async () => {
+  it('should only render aria-controls while open', async () => {
     const trigger = wrapper.find('button')
     expect(trigger.attributes('aria-controls')).toBeUndefined()
 

--- a/packages/core/src/Popover/PopoverTrigger.vue
+++ b/packages/core/src/Popover/PopoverTrigger.vue
@@ -36,7 +36,7 @@ onMounted(() => {
       :type="as === 'button' ? 'button' : undefined"
       aria-haspopup="dialog"
       :aria-expanded="rootContext.open.value"
-      :aria-controls="rootContext.contentId"
+      :aria-controls="rootContext.open.value ? rootContext.contentId : undefined"
       :data-state="rootContext.open.value ? 'open' : 'closed'"
       :as="as"
       :as-child="props.asChild"

--- a/packages/core/src/Popover/PopoverTrigger.vue
+++ b/packages/core/src/Popover/PopoverTrigger.vue
@@ -20,6 +20,7 @@ const rootContext = injectPopoverRootContext()
 const { forwardRef, currentElement: triggerElement } = useForwardExpose()
 
 rootContext.triggerId ||= useId(undefined, 'reka-popover-trigger')
+rootContext.contentId ||= useId(undefined, 'reka-popover-content')
 onMounted(() => {
   rootContext.triggerElement.value = triggerElement.value
 })

--- a/packages/core/src/Select/Select.test.ts
+++ b/packages/core/src/Select/Select.test.ts
@@ -38,6 +38,16 @@ describe('given default Select', () => {
     expect(selectTrigger.attributes('data-placeholder')).toBe('')
   })
 
+  it('should only render aria-controls while open', async () => {
+    const trigger = wrapper.find('[role="combobox"]')
+    expect(trigger.attributes('aria-controls')).toBeUndefined()
+
+    await trigger.trigger('pointerdown', { button: 0, ctrlKey: false })
+    await nextTick()
+
+    expect(document.getElementById(trigger.attributes('aria-controls')!)).not.toBeNull()
+  })
+
   describe('trigger mouse interop', () => {
     async function openSelectWithMouseClick() {
       const button = wrapper.find('button')
@@ -99,16 +109,6 @@ describe('given default Select', () => {
       expect(wrapper.html()).toContain('Apple')
       expect(document.activeElement).not.toBe(trigger)
     })
-  })
-
-  it('should only reference the content while open', async () => {
-    const trigger = wrapper.find('[role="combobox"]')
-    expect(trigger.attributes('aria-controls')).toBeUndefined()
-
-    await trigger.trigger('pointerdown', { button: 0, ctrlKey: false })
-    await nextTick()
-
-    expect(document.getElementById(trigger.attributes('aria-controls')!)).not.toBeNull()
   })
 
   describe('opening the modal', () => {

--- a/packages/core/src/Select/Select.test.ts
+++ b/packages/core/src/Select/Select.test.ts
@@ -101,6 +101,16 @@ describe('given default Select', () => {
     })
   })
 
+  it('should only reference the content while open', async () => {
+    const trigger = wrapper.find('[role="combobox"]')
+    expect(trigger.attributes('aria-controls')).toBeUndefined()
+
+    await trigger.trigger('pointerdown', { button: 0, ctrlKey: false })
+    await nextTick()
+
+    expect(document.getElementById(trigger.attributes('aria-controls')!)).not.toBeNull()
+  })
+
   describe('opening the modal', () => {
     beforeEach(async () => {
       await wrapper.find('button').trigger('pointerdown', {

--- a/packages/core/src/Select/SelectTrigger.vue
+++ b/packages/core/src/Select/SelectTrigger.vue
@@ -104,7 +104,7 @@ function onTriggerClick(event: MouseEvent) {
       :ref="forwardRef"
       role="combobox"
       :type="as === 'button' ? 'button' : undefined"
-      :aria-controls="rootContext.contentId"
+      :aria-controls="rootContext.open.value ? rootContext.contentId : undefined"
       :aria-expanded="rootContext.open.value || false"
       :aria-required="rootContext.required?.value"
       aria-autocomplete="none"


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2882

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A closed `SelectTrigger` renders `aria-controls="reka-select-content-…"`, but that content is only mounted once the select opens, so the reference dangles. `PopoverTrigger` has the same problem and is a bit worse: `contentId` starts as `''` in `PopoverRoot`, so a closed popover ships `aria-controls=""`. HTML validators flag both, and `aria-controls` is optional on a collapsed combobox or button anyway, so a broken reference buys nothing.

Both triggers now emit the attribute only while open, which is what `DialogTrigger`, `DropdownMenuTrigger`, `MenubarTrigger` and `DrawerTrigger` already do.

Popover needed one extra line. Its `contentId` was only minted once `PopoverContent` mounted, so when the content sits behind a `v-if` the trigger has nothing to point at and an open popover still rendered `aria-controls=""`. `PopoverTrigger` now mints the id itself, the way `DialogTrigger` already does.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved Popover and Select trigger accessibility by exposing `aria-controls` only while the component is open.
  - Closed triggers no longer reference unavailable or hidden content.
  - Ensured open triggers correctly reference their associated content.

- **Tests**
  - Added coverage confirming correct `aria-controls` behavior for Popover and Select components.
  - Added cleanup to improve test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->