### PR TITLE
fix(Combobox): defer highlight scroll until Popper placement

### DIFF
--- a/packages/core/src/Autocomplete/AutocompleteRoot.vue
+++ b/packages/core/src/Autocomplete/AutocompleteRoot.vue
@@ -147,7 +147,7 @@ const inputElement = ref<HTMLInputElement>()
 const triggerElement = ref<HTMLElement>()
 
 const highlightedElement = computed(() => primitiveElement.value?.highlightedElement ?? undefined)
-const contentPositioning = useComboboxContentPositioning(open, highlightedElement)
+const contentPositioning = useComboboxContentPositioning(open)
 
 const allItems = ref<Map<string, string>>(new Map())
 const allGroups = ref<Map<string, Set<string>>>(new Map())

--- a/packages/core/src/Autocomplete/AutocompleteRoot.vue
+++ b/packages/core/src/Autocomplete/AutocompleteRoot.vue
@@ -3,6 +3,7 @@ import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
 import type { Direction, GenericComponentInstance } from '@/shared/types'
 import { provideComboboxRootContext } from '@/Combobox/ComboboxRoot.vue'
+import { useComboboxContentPositioning } from '@/Combobox/useComboboxContentPositioning'
 import { usePrimitiveElement } from '@/Primitive'
 import { createContext, useDirection, useFilter } from '@/shared'
 
@@ -146,6 +147,7 @@ const inputElement = ref<HTMLInputElement>()
 const triggerElement = ref<HTMLElement>()
 
 const highlightedElement = computed(() => primitiveElement.value?.highlightedElement ?? undefined)
+const contentPositioning = useComboboxContentPositioning(open, highlightedElement)
 
 const allItems = ref<Map<string, string>>(new Map())
 const allGroups = ref<Map<string, Set<string>>>(new Map())
@@ -218,6 +220,7 @@ provideComboboxRootContext({
   disabled,
   open,
   onOpenChange,
+  ...contentPositioning,
   contentId: '',
   isUserInputted,
   isVirtual,

--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -1,10 +1,10 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { handleSubmit, sleep } from '@/test'
-import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxRoot, ComboboxTrigger, ComboboxViewport, ComboboxVirtualizer } from '.'
+import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot, ComboboxTrigger, ComboboxViewport, ComboboxVirtualizer } from '.'
 import Combobox from './story/_Combobox.vue'
 import ComboboxObject from './story/_ComboboxObject.vue'
 import ComboboxTagsInput from './story/_ComboboxTagsInput.vue'
@@ -891,5 +891,240 @@ describe('comboboxContent with popper positioning', () => {
 
     expect(wrapper.text()).toContain('Option 59')
     expect(wrapper.text()).not.toContain('Option 1')
+  })
+})
+
+describe('combobox highlight scrolling with popper positioning', () => {
+  const PopperContentStub = defineComponent({
+    name: 'PopperContent',
+    emits: ['placed'],
+    setup(_, { emit, slots }) {
+      return () => h('div', {
+        'data-test': 'popper-content',
+        'onClick': () => emit('placed'),
+      }, slots.default?.())
+    },
+  })
+
+  const TestCombobox = defineComponent({
+    props: {
+      forceMount: Boolean,
+      showItems: {
+        type: Boolean,
+        default: true,
+      },
+    },
+    setup(props) {
+      const modelValue = ref<string>()
+      const open = ref(false)
+
+      return () => h(ComboboxRoot, {
+        'modelValue': modelValue.value,
+        'open': open.value,
+        'onUpdate:modelValue': (value: string) => modelValue.value = value,
+        'onUpdate:open': (value: boolean) => open.value = value,
+      }, {
+        default: () => [
+          h(ComboboxAnchor, null, {
+            default: () => [
+              h(ComboboxInput),
+              h(ComboboxTrigger, null, { default: () => 'Open' }),
+            ],
+          }),
+          h(ComboboxPortal, null, {
+            default: () => h(ComboboxContent, {
+              forceMount: props.forceMount,
+              position: 'popper',
+            }, {
+              default: () => h(ComboboxViewport, null, {
+                default: () => props.showItems
+                  ? [
+                      h(ComboboxItem, { value: 'alpha' }, { default: () => 'Alpha' }),
+                      h(ComboboxItem, { value: 'beta' }, { default: () => 'Beta' }),
+                    ]
+                  : [],
+              }),
+            }),
+          }),
+        ],
+      })
+    },
+  })
+
+  const InlineCombobox = defineComponent({
+    setup() {
+      const modelValue = ref<string>()
+
+      return () => h(ComboboxRoot, {
+        'modelValue': modelValue.value,
+        'onUpdate:modelValue': (value: string) => modelValue.value = value,
+      }, {
+        default: () => [
+          h(ComboboxAnchor, null, { default: () => h(ComboboxInput) }),
+          h(ComboboxContent, { position: 'inline' }, {
+            default: () => h(ComboboxViewport, null, {
+              default: () => [
+                h(ComboboxItem, { value: 'alpha' }, { default: () => 'Alpha' }),
+                h(ComboboxItem, { value: 'beta' }, { default: () => 'Beta' }),
+              ],
+            }),
+          }),
+        ],
+      })
+    },
+  })
+
+  const wrappers: VueWrapper[] = []
+
+  function mountTestCombobox(props: { forceMount?: boolean, showItems?: boolean } = {}) {
+    const wrapper = mount(TestCombobox, {
+      attachTo: document.body,
+      props,
+      global: {
+        stubs: { PopperContent: PopperContentStub },
+      },
+    })
+    wrappers.push(wrapper)
+    return wrapper
+  }
+
+  function getHighlightedElement(input: DOMWrapper<HTMLInputElement>) {
+    const id = input.attributes('aria-activedescendant')
+    const element = id ? document.getElementById(id) : null
+    expect(element).toBeInstanceOf(HTMLElement)
+    return element as HTMLElement
+  }
+
+  function emitPlaced() {
+    const content = document.querySelector<HTMLElement>('[data-test="popper-content"]')
+    expect(content).toBeInstanceOf(HTMLElement)
+    content?.click()
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    window.HTMLElement.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => {
+    for (const wrapper of wrappers.splice(0))
+      wrapper.unmount()
+  })
+
+  it('defers the opening highlight scroll until placement and handles repeated placement idempotently', async () => {
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = mountTestCombobox()
+    const input = wrapper.get('input[role="combobox"]') as DOMWrapper<HTMLInputElement>
+
+    await input.setValue('a')
+    await flushPromises()
+
+    const highlightedElement = getHighlightedElement(input)
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    emitPlaced()
+    await flushPromises()
+    emitPlaced()
+    await flushPromises()
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
+    expect(scrollSpy.mock.instances[0]).toBe(highlightedElement)
+
+    scrollSpy.mockClear()
+    await input.trigger('keydown', { key: 'ArrowDown' })
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' })
+  })
+
+  it('scrolls the live highlight when keyboard navigation occurs before placement', async () => {
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = mountTestCombobox()
+    const input = wrapper.get('input[role="combobox"]') as DOMWrapper<HTMLInputElement>
+
+    await input.setValue('a')
+    await flushPromises()
+    await input.trigger('keydown', { key: 'ArrowDown' })
+
+    const highlightedElement = getHighlightedElement(input)
+    expect(highlightedElement.textContent).toContain('Beta')
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    emitPlaced()
+    await flushPromises()
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
+    expect(scrollSpy.mock.instances[0]).toBe(highlightedElement)
+  })
+
+  it('resumes normal highlight scrolling when options mount after placement', async () => {
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = mountTestCombobox({ showItems: false })
+    const input = wrapper.get('input[role="combobox"]') as DOMWrapper<HTMLInputElement>
+
+    await input.setValue('b')
+    await flushPromises()
+    expect(input.attributes('aria-activedescendant')).toBeUndefined()
+
+    emitPlaced()
+    await flushPromises()
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    await wrapper.setProps({ showItems: true })
+    await flushPromises()
+
+    expect(getHighlightedElement(input).textContent).toContain('Beta')
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('tracks force-mounted content that is placed while closed', async () => {
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = mountTestCombobox({ forceMount: true })
+
+    await flushPromises()
+    emitPlaced()
+    await flushPromises()
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    await wrapper.get('button').trigger('click')
+    await flushPromises()
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses highlight scrolling again when content remounts', async () => {
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = mountTestCombobox()
+    const input = wrapper.get('input[role="combobox"]') as DOMWrapper<HTMLInputElement>
+
+    await input.setValue('a')
+    await flushPromises()
+    document.querySelector<HTMLElement>('[role="option"]')?.click()
+    await flushPromises()
+    scrollSpy.mockClear()
+
+    await input.setValue('b')
+    await flushPromises()
+
+    const highlightedElement = getHighlightedElement(input)
+    expect(highlightedElement.textContent).toContain('Beta')
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    emitPlaced()
+    await flushPromises()
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
+    expect(scrollSpy.mock.instances[0]).toBe(highlightedElement)
+  })
+
+  it('leaves inline Combobox highlight scrolling immediate', async () => {
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = mount(InlineCombobox, { attachTo: document.body })
+    wrappers.push(wrapper)
+    const input = wrapper.get('input[role="combobox"]') as DOMWrapper<HTMLInputElement>
+
+    await input.setValue('a')
+    await flushPromises()
+
+    expect(getHighlightedElement(input).textContent).toContain('Alpha')
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' })
   })
 })

--- a/packages/core/src/Combobox/Combobox.test.ts
+++ b/packages/core/src/Combobox/Combobox.test.ts
@@ -913,6 +913,10 @@ describe('combobox highlight scrolling with popper positioning', () => {
         type: Boolean,
         default: true,
       },
+      withInput: {
+        type: Boolean,
+        default: true,
+      },
     },
     setup(props) {
       const modelValue = ref<string>()
@@ -927,7 +931,7 @@ describe('combobox highlight scrolling with popper positioning', () => {
         default: () => [
           h(ComboboxAnchor, null, {
             default: () => [
-              h(ComboboxInput),
+              props.withInput ? h(ComboboxInput) : null,
               h(ComboboxTrigger, null, { default: () => 'Open' }),
             ],
           }),
@@ -974,9 +978,77 @@ describe('combobox highlight scrolling with popper positioning', () => {
     },
   })
 
+  const virtualOptions = Array.from({ length: 100 }, (_, index) => ({ label: `Item ${index}`, value: index }))
+  const VirtualPopperCombobox = defineComponent({
+    setup() {
+      const modelValue = ref(virtualOptions[3])
+
+      return () => h(ComboboxRoot, {
+        'modelValue': modelValue.value,
+        'open': true,
+        'onUpdate:modelValue': value => modelValue.value = value as typeof modelValue.value,
+      }, {
+        default: () => [
+          h(ComboboxAnchor, null, { default: () => h(ComboboxInput) }),
+          h(ComboboxPortal, null, {
+            default: () => h(ComboboxContent, { position: 'popper' }, {
+              default: () => h(ComboboxViewport, { style: 'height: 200px; overflow: auto' }, {
+                default: () => h(ComboboxVirtualizer, {
+                  options: virtualOptions,
+                  estimateSize: 25,
+                  textContent: option => option.label,
+                }, {
+                  default: ({ option }) => h(ComboboxItem, { value: option }, { default: () => option.label }),
+                }),
+              }),
+            }),
+          }),
+        ],
+      })
+    },
+  })
+
+  const OverlappingPopperContentCombobox = defineComponent({
+    props: {
+      first: {
+        type: Boolean,
+        default: true,
+      },
+      second: Boolean,
+    },
+    setup(props) {
+      const modelValue = ref<string>()
+
+      function renderContent(key: string) {
+        return h(ComboboxPortal, { key }, {
+          default: () => h(ComboboxContent, { position: 'popper' }, {
+            default: () => h(ComboboxViewport, null, {
+              default: () => [
+                h(ComboboxItem, { value: 'alpha' }, { default: () => 'Alpha' }),
+                h(ComboboxItem, { value: 'beta' }, { default: () => 'Beta' }),
+              ],
+            }),
+          }),
+        })
+      }
+
+      return () => h(ComboboxRoot, {
+        'modelValue': modelValue.value,
+        'open': true,
+        'onUpdate:modelValue': value => modelValue.value = value as string,
+      }, {
+        default: () => [
+          h(ComboboxAnchor, null, { default: () => h(ComboboxInput) }),
+          props.first ? renderContent('first') : null,
+          props.second ? renderContent('second') : null,
+        ],
+      })
+    },
+  })
+
   const wrappers: VueWrapper[] = []
 
-  function mountTestCombobox(props: { forceMount?: boolean, showItems?: boolean } = {}) {
+  function mountTestCombobox(props: { forceMount?: boolean, showItems?: boolean, withInput?: boolean } = {}) {
     const wrapper = mount(TestCombobox, {
       attachTo: document.body,
       props,
@@ -985,6 +1057,34 @@ describe('combobox highlight scrolling with popper positioning', () => {
       },
     })
     wrappers.push(wrapper)
+    return wrapper
+  }
+
+  async function mountVirtualPopperCombobox() {
+    const getBoundingClientRect = vi.spyOn(window.HTMLElement.prototype, 'getBoundingClientRect')
+    getBoundingClientRect.mockReturnValue({
+      width: 200,
+      height: 200,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 200,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    })
+
+    const wrapper = mount(VirtualPopperCombobox, {
+      attachTo: document.body,
+      global: {
+        stubs: { PopperContent: PopperContentStub },
+      },
+    })
+    wrappers.push(wrapper)
+    await nextTick()
+    await nextTick()
+    await new Promise(resolve => requestAnimationFrame(() => resolve(null)))
+    await nextTick()
     return wrapper
   }
 
@@ -1009,6 +1109,27 @@ describe('combobox highlight scrolling with popper positioning', () => {
   afterEach(() => {
     for (const wrapper of wrappers.splice(0))
       wrapper.unmount()
+    vi.restoreAllMocks()
+  })
+
+  it('prevents trigger-only option focus from scrolling before placement', async () => {
+    const focusSpy = vi.spyOn(window.HTMLElement.prototype, 'focus')
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = mountTestCombobox({ withInput: false })
+
+    await wrapper.get('button').trigger('click')
+    await flushPromises()
+
+    const highlightedElement = document.querySelector<HTMLElement>('[role="option"][data-highlighted]')
+    expect(highlightedElement).toBeInstanceOf(HTMLElement)
+    const optionFocusCalls = focusSpy.mock.calls.filter((_, index) => focusSpy.mock.instances[index] === highlightedElement)
+    expect(optionFocusCalls).toContainEqual([{ preventScroll: true }])
+    expect(optionFocusCalls).not.toContainEqual([])
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    emitPlaced()
+    await flushPromises()
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
   })
 
   it('defers the opening highlight scroll until placement and handles repeated placement idempotently', async () => {
@@ -1053,6 +1174,91 @@ describe('combobox highlight scrolling with popper positioning', () => {
 
     expect(scrollSpy).toHaveBeenCalledTimes(1)
     expect(scrollSpy.mock.instances[0]).toBe(highlightedElement)
+  })
+
+  it('does not flush a highlight that explicitly opted out of scrolling', async () => {
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = mountTestCombobox()
+    const input = wrapper.get('input[role="combobox"]') as DOMWrapper<HTMLInputElement>
+
+    await input.setValue('a')
+    await flushPromises()
+
+    const beta = Array.from(document.querySelectorAll<HTMLElement>('[role="option"]'))
+      .find(item => item.textContent?.includes('Beta'))
+    expect(beta).toBeDefined()
+    beta!.dispatchEvent(new Event('pointermove', { bubbles: true }))
+    await flushPromises()
+    expect(getHighlightedElement(input).textContent).toContain('Beta')
+
+    emitPlaced()
+    await flushPromises()
+    expect(scrollSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not flush the virtualizer mount highlight after placement', async () => {
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = await mountVirtualPopperCombobox()
+
+    expect(document.querySelector('[role="option"][data-highlighted]')).toBeInstanceOf(HTMLElement)
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    emitPlaced()
+    await flushPromises()
+    expect(scrollSpy).not.toHaveBeenCalled()
+  })
+
+  it('prevents virtualized option focus from scrolling before placement', async () => {
+    const focusSpy = vi.spyOn(window.HTMLElement.prototype, 'focus')
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = await mountVirtualPopperCombobox()
+    const root = wrapper.getComponent(ComboboxRoot)
+    const highlightSelected = root.vm.$.exposed?.highlightSelected as ((event?: Event, scroll?: boolean) => Promise<void>) | undefined
+
+    expect(highlightSelected).toBeTypeOf('function')
+    await highlightSelected!(new Event('keydown'))
+    await new Promise(resolve => requestAnimationFrame(() => resolve(null)))
+    await nextTick()
+
+    const highlightedElement = document.querySelector('[role="option"][data-highlighted]')
+    expect(highlightedElement).toBeInstanceOf(HTMLElement)
+    const optionFocusCalls = focusSpy.mock.calls.filter((_, index) => focusSpy.mock.instances[index] === highlightedElement)
+    expect(optionFocusCalls).toContainEqual([{ preventScroll: true }])
+    expect(optionFocusCalls).not.toContainEqual([])
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    emitPlaced()
+    await flushPromises()
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores an outgoing content unmount after replacement content mounts', async () => {
+    const scrollSpy = vi.mocked(window.HTMLElement.prototype.scrollIntoView)
+    const wrapper = mount(OverlappingPopperContentCombobox, {
+      attachTo: document.body,
+      global: {
+        stubs: { PopperContent: PopperContentStub },
+      },
+    })
+    wrappers.push(wrapper)
+    await flushPromises()
+
+    await wrapper.setProps({ second: true })
+    await flushPromises()
+    await wrapper.setProps({ first: false })
+    await flushPromises()
+    scrollSpy.mockClear()
+
+    const input = wrapper.get('input[role="combobox"]') as DOMWrapper<HTMLInputElement>
+    await input.setValue('b')
+    await flushPromises()
+
+    expect(getHighlightedElement(input).textContent).toContain('Beta')
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    emitPlaced()
+    await flushPromises()
+    expect(scrollSpy).toHaveBeenCalledTimes(1)
   })
 
   it('resumes normal highlight scrolling when options mount after placement', async () => {

--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -46,8 +46,9 @@ const emits = defineEmits<ComboboxContentImplEmits>()
 
 const { position } = toRefs(props)
 const rootContext = injectComboboxRootContext()
+const contentId = Symbol('ComboboxContent')
 
-watch(position, value => rootContext.onContentPositionChange(value), { immediate: true })
+watch(position, value => rootContext.onContentPositionChange(contentId, value), { immediate: true })
 
 const isEmpty = computed(() => rootContext.ignoreFilter.value
   ? rootContext.allItems.value.size === 0
@@ -94,7 +95,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  rootContext.onContentUnmount()
+  rootContext.onContentUnmount(contentId)
   const activeElement = getActiveElement()
   if (isInputWithinContent.value && (!activeElement || activeElement === document.body)) {
     rootContext.triggerElement.value?.focus()
@@ -112,6 +113,10 @@ function isEventTargetWithinCombobox(target: EventTarget | null) {
   const label = target instanceof Element ? target.closest('label') : null
   const control = label?.control
   return !!control && !!rootContext.parentElement.value?.contains(control)
+}
+
+const popperContentEvents = {
+  placed: () => rootContext.onContentPlaced(contentId),
 }
 </script>
 
@@ -158,7 +163,7 @@ function isEventTargetWithinCombobox(target: EventTarget | null) {
             outline: 'none',
             ...(position === 'popper' ? popperStyle : {}),
           }"
-          @placed="rootContext.onContentPlaced"
+          v-on="position === 'popper' ? popperContentEvents : {}"
         >
           <slot />
         </component>

--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -31,7 +31,7 @@ export const [injectComboboxContentContext, provideComboboxContentContext]
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, toRefs } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toRefs, watch } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { FocusScope } from '@/FocusScope'
 import { ListboxContent } from '@/Listbox'
@@ -46,6 +46,8 @@ const emits = defineEmits<ComboboxContentImplEmits>()
 
 const { position } = toRefs(props)
 const rootContext = injectComboboxRootContext()
+
+watch(position, value => rootContext.onContentPositionChange(value), { immediate: true })
 
 const isEmpty = computed(() => rootContext.ignoreFilter.value
   ? rootContext.allItems.value.size === 0
@@ -92,6 +94,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  rootContext.onContentUnmount()
   const activeElement = getActiveElement()
   if (isInputWithinContent.value && (!activeElement || activeElement === document.body)) {
     rootContext.triggerElement.value?.focus()
@@ -155,6 +158,7 @@ function isEventTargetWithinCombobox(target: EventTarget | null) {
             outline: 'none',
             ...(position === 'popper' ? popperStyle : {}),
           }"
+          @placed="rootContext.onContentPlaced"
         >
           <slot />
         </component>

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -11,6 +11,9 @@ type ComboboxRootContext<T> = {
   disabled: Ref<boolean>
   open: Ref<boolean>
   onOpenChange: (value: boolean) => void
+  onContentPositionChange: (position: 'inline' | 'popper') => void
+  onContentPlaced: () => void
+  onContentUnmount: () => void
   isUserInputted: Ref<boolean>
   isVirtual: Ref<boolean>
   contentId: string
@@ -86,6 +89,7 @@ import { createEventHook, useVModel } from '@vueuse/core'
 import { computed, getCurrentInstance, nextTick, onMounted, ref, toRefs } from 'vue'
 import { ListboxRoot } from '@/Listbox'
 import { PopperRoot } from '@/Popper'
+import { useComboboxContentPositioning } from './useComboboxContentPositioning'
 
 const props = withDefaults(defineProps<ComboboxRootProps<T>>(), {
   open: undefined,
@@ -150,6 +154,7 @@ const inputElement = ref<HTMLInputElement>()
 const triggerElement = ref<HTMLElement>()
 
 const highlightedElement = computed(() => primitiveElement.value?.highlightedElement ?? undefined)
+const contentPositioning = useComboboxContentPositioning(open, highlightedElement)
 
 const allItems = ref<Map<string, string>>(new Map())
 const allGroups = ref<Map<string, Set<string>>>(new Map())
@@ -224,6 +229,7 @@ provideComboboxRootContext({
   disabled,
   open,
   onOpenChange,
+  ...contentPositioning,
   contentId: '',
   isUserInputted,
   isVirtual,

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -11,9 +11,9 @@ type ComboboxRootContext<T> = {
   disabled: Ref<boolean>
   open: Ref<boolean>
   onOpenChange: (value: boolean) => void
-  onContentPositionChange: (position: 'inline' | 'popper') => void
-  onContentPlaced: () => void
-  onContentUnmount: () => void
+  onContentPositionChange: (content: symbol, position: 'inline' | 'popper') => void
+  onContentPlaced: (content: symbol) => void
+  onContentUnmount: (content: symbol) => void
   isUserInputted: Ref<boolean>
   isVirtual: Ref<boolean>
   contentId: string
@@ -154,7 +154,7 @@ const inputElement = ref<HTMLInputElement>()
 const triggerElement = ref<HTMLElement>()
 
 const highlightedElement = computed(() => primitiveElement.value?.highlightedElement ?? undefined)
-const contentPositioning = useComboboxContentPositioning(open, highlightedElement)
+const contentPositioning = useComboboxContentPositioning(open)
 
 const allItems = ref<Map<string, string>>(new Map())
 const allGroups = ref<Map<string, Set<string>>>(new Map())

--- a/packages/core/src/Combobox/useComboboxContentPositioning.ts
+++ b/packages/core/src/Combobox/useComboboxContentPositioning.ts
@@ -1,0 +1,46 @@
+import type { Ref } from 'vue'
+import { computed, ref } from 'vue'
+import { provideListboxHighlightScrollContext } from '@/Listbox/ListboxRoot.vue'
+
+export function useComboboxContentPositioning(
+  open: Readonly<Ref<boolean>>,
+  highlightedElement: Readonly<Ref<HTMLElement | undefined>>,
+) {
+  const contentPosition = ref<'inline' | 'popper'>('inline')
+  const contentPlaced = ref(false)
+  const suppressHighlightScroll = computed(() => contentPosition.value === 'popper' && !contentPlaced.value)
+
+  provideListboxHighlightScrollContext({ suppressHighlightScroll })
+
+  function scrollHighlightedElement() {
+    const element = highlightedElement.value
+    if (element?.isConnected)
+      element.scrollIntoView({ block: 'nearest' })
+  }
+
+  function onContentPositionChange(position: 'inline' | 'popper') {
+    if (contentPosition.value !== position)
+      contentPlaced.value = false
+    contentPosition.value = position
+  }
+
+  function onContentPlaced() {
+    if (contentPosition.value !== 'popper' || contentPlaced.value)
+      return
+
+    contentPlaced.value = true
+    if (open.value)
+      scrollHighlightedElement()
+  }
+
+  function onContentUnmount() {
+    contentPosition.value = 'inline'
+    contentPlaced.value = false
+  }
+
+  return {
+    onContentPositionChange,
+    onContentPlaced,
+    onContentUnmount,
+  }
+}

--- a/packages/core/src/Combobox/useComboboxContentPositioning.ts
+++ b/packages/core/src/Combobox/useComboboxContentPositioning.ts
@@ -4,38 +4,48 @@ import { provideListboxHighlightScrollContext } from '@/Listbox/ListboxRoot.vue'
 
 export function useComboboxContentPositioning(
   open: Readonly<Ref<boolean>>,
-  highlightedElement: Readonly<Ref<HTMLElement | undefined>>,
 ) {
   const contentPosition = ref<'inline' | 'popper'>('inline')
   const contentPlaced = ref(false)
+  const currentContent = ref<symbol>()
   const suppressHighlightScroll = computed(() => contentPosition.value === 'popper' && !contentPlaced.value)
+  let pendingHighlightScroll: (() => void) | undefined
 
-  provideListboxHighlightScrollContext({ suppressHighlightScroll })
+  provideListboxHighlightScrollContext({
+    suppressHighlightScroll,
+    onHighlightScrollRequest(scroll) {
+      pendingHighlightScroll = scroll
+    },
+  })
 
-  function scrollHighlightedElement() {
-    const element = highlightedElement.value
-    if (element?.isConnected)
-      element.scrollIntoView({ block: 'nearest' })
-  }
-
-  function onContentPositionChange(position: 'inline' | 'popper') {
-    if (contentPosition.value !== position)
+  function onContentPositionChange(content: symbol, position: 'inline' | 'popper') {
+    if (currentContent.value !== content || contentPosition.value !== position) {
       contentPlaced.value = false
+      pendingHighlightScroll = undefined
+    }
+    currentContent.value = content
     contentPosition.value = position
   }
 
-  function onContentPlaced() {
-    if (contentPosition.value !== 'popper' || contentPlaced.value)
+  function onContentPlaced(content: symbol) {
+    if (currentContent.value !== content || contentPosition.value !== 'popper' || contentPlaced.value)
       return
 
     contentPlaced.value = true
+    const scroll = pendingHighlightScroll
+    pendingHighlightScroll = undefined
     if (open.value)
-      scrollHighlightedElement()
+      scroll?.()
   }
 
-  function onContentUnmount() {
+  function onContentUnmount(content: symbol) {
+    if (currentContent.value !== content)
+      return
+
+    currentContent.value = undefined
     contentPosition.value = 'inline'
     contentPlaced.value = false
+    pendingHighlightScroll = undefined
   }
 
   return {

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -42,6 +42,7 @@ export const [injectListboxRootContext, provideListboxRootContext]
 /** Controls highlight scrolling while a parent composite is being positioned. */
 type ListboxHighlightScrollContext = {
   suppressHighlightScroll: Readonly<Ref<boolean>>
+  onHighlightScrollRequest: (scroll: (() => void) | undefined) => void
 }
 
 export const [injectListboxHighlightScrollContext, provideListboxHighlightScrollContext]
@@ -115,7 +116,10 @@ const dir = useDirection(propDir)
 const highlightScrollContext = injectListboxHighlightScrollContext(null)
 
 // Prevent nested Listbox roots from inheriting this root's scroll coordination.
-provideListboxHighlightScrollContext({ suppressHighlightScroll: ref(false) })
+provideListboxHighlightScrollContext({
+  suppressHighlightScroll: ref(false),
+  onHighlightScrollRequest: () => {},
+})
 
 const isFormControl = useFormControl(currentElement)
 
@@ -175,10 +179,26 @@ function changeHighlight(el: HTMLElement, scrollIntoView = true, focus?: boolean
     return
 
   highlightedElement.value = el
-  if (focus ?? focusable.value)
-    highlightedElement.value.focus()
-  if (scrollIntoView && !highlightScrollContext?.suppressHighlightScroll.value)
+  const suppressHighlightScroll = highlightScrollContext?.suppressHighlightScroll.value ?? false
+  if (focus ?? focusable.value) {
+    if (suppressHighlightScroll)
+      highlightedElement.value.focus({ preventScroll: true })
+    else
+      highlightedElement.value.focus()
+  }
+
+  if (suppressHighlightScroll) {
+    highlightScrollContext?.onHighlightScrollRequest(scrollIntoView
+      ? () => {
+          const element = highlightedElement.value
+          if (element?.isConnected)
+            element.scrollIntoView({ block: 'nearest' })
+        }
+      : undefined)
+  }
+  else if (scrollIntoView) {
     highlightedElement.value.scrollIntoView({ block: 'nearest' })
+  }
 
   const highlightedItem = getItems().find(i => i.ref === el)
   emits('highlight', highlightedItem)

--- a/packages/core/src/Listbox/ListboxRoot.vue
+++ b/packages/core/src/Listbox/ListboxRoot.vue
@@ -39,6 +39,14 @@ type ListboxRootContext<T> = {
 export const [injectListboxRootContext, provideListboxRootContext]
   = createContext<ListboxRootContext<AcceptableValue>>('ListboxRoot')
 
+/** Controls highlight scrolling while a parent composite is being positioned. */
+type ListboxHighlightScrollContext = {
+  suppressHighlightScroll: Readonly<Ref<boolean>>
+}
+
+export const [injectListboxHighlightScrollContext, provideListboxHighlightScrollContext]
+  = createContext<ListboxHighlightScrollContext>('ListboxHighlightScroll')
+
 export interface ListboxRootProps<T = AcceptableValue> extends PrimitiveProps, FormFieldProps {
   /** The controlled value of the listbox. Can be binded with `v-model`. */
   modelValue?: T | Array<T>
@@ -104,6 +112,10 @@ const { handleTypeaheadSearch } = useTypeahead()
 const { primitiveElement, currentElement } = usePrimitiveElement()
 const kbd = useKbd()
 const dir = useDirection(propDir)
+const highlightScrollContext = injectListboxHighlightScrollContext(null)
+
+// Prevent nested Listbox roots from inheriting this root's scroll coordination.
+provideListboxHighlightScrollContext({ suppressHighlightScroll: ref(false) })
 
 const isFormControl = useFormControl(currentElement)
 
@@ -165,7 +177,7 @@ function changeHighlight(el: HTMLElement, scrollIntoView = true, focus?: boolean
   highlightedElement.value = el
   if (focus ?? focusable.value)
     highlightedElement.value.focus()
-  if (scrollIntoView)
+  if (scrollIntoView && !highlightScrollContext?.suppressHighlightScroll.value)
     highlightedElement.value.scrollIntoView({ block: 'nearest' })
 
   const highlightedItem = getItems().find(i => i.ref === el)

--- a/packages/core/src/Listbox/ListboxVirtualizer.vue
+++ b/packages/core/src/Listbox/ListboxVirtualizer.vue
@@ -124,9 +124,8 @@ rootContext.virtualFocusHook.on(({ event, scroll }) => {
     requestAnimationFrame(() => {
       const item = queryCheckedElement(parentEl.value)
       if (item) {
-        rootContext.changeHighlight(item, scroll, scroll ? undefined : false)
-        if (event)
-          item?.focus()
+        const focus = event ? true : scroll ? undefined : false
+        rootContext.changeHighlight(item, scroll, focus)
       }
     })
   }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2884

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Portalled Combobox content is rendered off-screen while Popper measures it. Highlighting an option during that window called `scrollIntoView`, which could move the page.

This defers only the highlight scroll until Popper emits `placed`, then scrolls the current connected highlight once. Highlight state, focus, inline Comboboxes, standalone Listboxes, and positioning strategy remain unchanged. Autocomplete receives the same coordination because it shares Combobox content.

Regression tests cover pre-placement keyboard changes, repeated placement, late-mounted options, force-mounted content, remounts, and inline behavior.

### 📸 Screenshots (if appropriate)

Reproduction: https://stackblitz.com/edit/hn2yox-2uvmbefw?file=src%2FApp.vue

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. No public API or documentation changes are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved highlighted-option scrolling in comboboxes using popper-positioned content.
  * Scrolling now waits for placement to complete, including delayed mounting and remounting scenarios.
  * Preserved immediate scrolling for inline combobox content.
  * Prevented unwanted scrolling during content repositioning, including nested listbox interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->