### PR TITLE
fix(Drawer): lock the swipe gesture to one axis on scrollable content

### DIFF
--- a/packages/core/src/Drawer/composables/useSwipeDismiss.test.ts
+++ b/packages/core/src/Drawer/composables/useSwipeDismiss.test.ts
@@ -386,3 +386,249 @@ describe('useSwipeDismiss — releases the popup never sees', () => {
     wrapper.unmount()
   })
 })
+
+/**
+ * A side drawer holding `overflow-y: auto` content used to treat every vertical
+ * flick as a horizontal drag, sliding along X and swallowing the scroll
+ * (unovue/reka-ui#2876). `shouldYieldTouchMove` now arbitrates the two axes.
+ */
+describe('useSwipeDismiss — cross-axis scroll arbitration', () => {
+  /** Marks an element as genuinely scrollable on `axis` for jsdom, which reports every box as 0x0. */
+  function makeScrollable(el: HTMLElement, axis: 'vertical' | 'horizontal', scrollOffset = 0) {
+    el.style.setProperty(axis === 'vertical' ? 'overflow-y' : 'overflow-x', 'auto')
+    const sizes = axis === 'vertical'
+      ? { scrollHeight: 2000, clientHeight: 500, scrollTop: scrollOffset }
+      : { scrollWidth: 2000, clientWidth: 500, scrollLeft: scrollOffset }
+    for (const [key, value] of Object.entries(sizes))
+      Object.defineProperty(el, key, { value, configurable: true, writable: true })
+  }
+
+  function mountTouchHarness(opts: { directions?: Array<'up' | 'down' | 'left' | 'right'> } = {}) {
+    const elementRef = ref<HTMLElement | null>(null)
+    const scrollRef = ref<HTMLElement | null>(null)
+    const onDismiss = vi.fn()
+    const onCancel = vi.fn()
+
+    const Harness = defineComponent({
+      setup() {
+        useSwipeDismiss({
+          enabled: true,
+          elementRef,
+          directions: opts.directions ?? ['right'],
+          movementCssVars: {
+            x: '--drawer-swipe-movement-x',
+            y: '--drawer-swipe-movement-y',
+          },
+          onDismiss,
+          onCancel,
+        })
+        return {}
+      },
+      render() {
+        return h(
+          'div',
+          {
+            ref: (el) => {
+              elementRef.value = el as HTMLElement | null
+            },
+          },
+          [
+            h('div', {
+              ref: (el) => {
+                scrollRef.value = el as HTMLElement | null
+              },
+            }, [h('p', 'content')]),
+          ],
+        )
+      },
+    })
+
+    const wrapper = mount(Harness, { attachTo: document.body })
+    return { wrapper, elementRef, scrollRef, onDismiss, onCancel }
+  }
+
+  // jsdom's `TouchEvent`/`Touch` support varies, so build the event by hand.
+  function dispatchTouch(
+    el: HTMLElement,
+    type: 'touchstart' | 'touchmove' | 'touchend',
+    x: number,
+    y: number,
+    { cancelable = true, target = el }: { cancelable?: boolean, target?: HTMLElement } = {},
+  ) {
+    const event = new Event(type, { bubbles: true, cancelable })
+    Object.defineProperty(event, 'touches', {
+      value: type === 'touchend' ? [] : [{ clientX: x, clientY: y }],
+      configurable: true,
+    })
+    Object.defineProperty(event, 'timeStamp', { value: 0, configurable: true })
+    target.dispatchEvent(event)
+    return event
+  }
+
+  it('yields a mostly-vertical flick to the content scroll on a right drawer', async () => {
+    const { wrapper, elementRef, scrollRef, onDismiss, onCancel } = mountTouchHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+    const scroller = scrollRef.value!
+    makeScrollable(scroller, 'vertical')
+
+    // A real finger never travels on one axis alone; this flick drifts 3px right
+    // while scrolling 40px down, and that 3px used to start the drag.
+    dispatchTouch(el, 'touchstart', 200, 400, { target: scroller })
+    const move1 = dispatchTouch(el, 'touchmove', 201, 388, { target: scroller })
+    const move2 = dispatchTouch(el, 'touchmove', 203, 360, { target: scroller })
+
+    // The browser keeps both moves, and the drawer never budges along X.
+    expect(move1.defaultPrevented).toBe(false)
+    expect(move2.defaultPrevented).toBe(false)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('')
+
+    dispatchTouch(el, 'touchend', 203, 360, { target: scroller })
+    await nextTick()
+
+    expect(onDismiss).not.toHaveBeenCalled()
+    expect(onCancel).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('keeps yielding for the rest of the gesture once the cross axis has won', async () => {
+    const { wrapper, elementRef, scrollRef, onDismiss } = mountTouchHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+    const scroller = scrollRef.value!
+    makeScrollable(scroller, 'vertical')
+
+    dispatchTouch(el, 'touchstart', 200, 400, { target: scroller })
+    dispatchTouch(el, 'touchmove', 200, 380, { target: scroller }) // vertical claims it
+
+    // Re-arbitrating on this hard curve would hand the drawer the gesture
+    // mid-scroll.
+    const curve = dispatchTouch(el, 'touchmove', 320, 380, { target: scroller })
+    expect(curve.defaultPrevented).toBe(false)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('')
+
+    dispatchTouch(el, 'touchend', 320, 380, { target: scroller })
+    await nextTick()
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('still swipes when the drag is decisively along the dismiss axis', async () => {
+    const { wrapper, elementRef, scrollRef, onDismiss } = mountTouchHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+    const scroller = scrollRef.value!
+    makeScrollable(scroller, 'vertical')
+
+    // The scroller has nothing to offer on the horizontal axis.
+    dispatchTouch(el, 'touchstart', 100, 400, { target: scroller })
+    dispatchTouch(el, 'touchmove', 110, 402, { target: scroller })
+    const move = dispatchTouch(el, 'touchmove', 180, 404, { target: scroller })
+
+    expect(move.defaultPrevented).toBe(true)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('80px')
+
+    dispatchTouch(el, 'touchend', 180, 404, { target: scroller })
+    await nextTick()
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
+  it('does not arbitrate when the content has no cross-axis scroller', async () => {
+    const { wrapper, elementRef, scrollRef } = mountTouchHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+    const scroller = scrollRef.value!
+    // Short content: nothing to scroll, so the drawer owns every pixel as before.
+    makeScrollable(scroller, 'horizontal')
+
+    dispatchTouch(el, 'touchstart', 100, 400, { target: scroller })
+    const move = dispatchTouch(el, 'touchmove', 102, 430, { target: scroller })
+
+    expect(move.defaultPrevented).toBe(true)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('2px')
+
+    dispatchTouch(el, 'touchend', 102, 430, { target: scroller })
+    wrapper.unmount()
+  })
+
+  it('yields when the browser has already committed the gesture to a native scroll', async () => {
+    const { wrapper, elementRef, scrollRef, onDismiss } = mountTouchHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+    const scroller = scrollRef.value!
+    makeScrollable(scroller, 'vertical')
+
+    dispatchTouch(el, 'touchstart', 100, 400, { target: scroller })
+    // Non-cancelable: the scroll is already under way.
+    dispatchTouch(el, 'touchmove', 140, 402, { target: scroller, cancelable: false })
+    // Even a decisive horizontal move afterwards stays with the scroll.
+    const move = dispatchTouch(el, 'touchmove', 260, 404, { target: scroller })
+
+    expect(move.defaultPrevented).toBe(false)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-x')).toBe('')
+
+    dispatchTouch(el, 'touchend', 260, 404, { target: scroller })
+    await nextTick()
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('yields a horizontal drift on a bottom drawer to horizontally scrollable content', async () => {
+    const { wrapper, elementRef, scrollRef, onDismiss } = mountTouchHarness({ directions: ['down'] })
+    await nextTick()
+
+    const el = elementRef.value!
+    const scroller = scrollRef.value!
+    makeScrollable(scroller, 'horizontal')
+
+    // Swiping a carousel inside a bottom sheet must not pull the sheet down.
+    dispatchTouch(el, 'touchstart', 200, 400, { target: scroller })
+    const move1 = dispatchTouch(el, 'touchmove', 188, 401, { target: scroller })
+    const move2 = dispatchTouch(el, 'touchmove', 160, 403, { target: scroller })
+
+    expect(move1.defaultPrevented).toBe(false)
+    expect(move2.defaultPrevented).toBe(false)
+    expect(el.style.getPropertyValue('--drawer-swipe-movement-y')).toBe('')
+
+    dispatchTouch(el, 'touchend', 160, 403, { target: scroller })
+    await nextTick()
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('starts clean after a gesture whose end was never seen', async () => {
+    const { wrapper, elementRef, scrollRef, onDismiss } = mountTouchHarness()
+    await nextTick()
+
+    const el = elementRef.value!
+    const scroller = scrollRef.value!
+    makeScrollable(scroller, 'vertical')
+
+    // A vertical scroll that the cross axis wins, abandoned without a touchend.
+    dispatchTouch(el, 'touchstart', 200, 400, { target: scroller })
+    dispatchTouch(el, 'touchmove', 200, 360, { target: scroller })
+
+    // Inheriting that verdict would leave the drawer unswipeable for good.
+    dispatchTouch(el, 'touchstart', 100, 400, { target: scroller })
+    dispatchTouch(el, 'touchmove', 110, 400, { target: scroller })
+    const move = dispatchTouch(el, 'touchmove', 180, 400, { target: scroller })
+
+    expect(move.defaultPrevented).toBe(true)
+    dispatchTouch(el, 'touchend', 180, 400, { target: scroller })
+    await nextTick()
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/core/src/Drawer/composables/useSwipeDismiss.ts
+++ b/packages/core/src/Drawer/composables/useSwipeDismiss.ts
@@ -35,6 +35,10 @@ export interface UseSwipeDismissOptions {
 const DEFAULT_SWIPE_THRESHOLD = 40
 const REVERSE_CANCEL_THRESHOLD = 10
 const MIN_DRAG_THRESHOLD = 1
+// Travel an axis must cover from the touch origin to claim the gesture, and the
+// margin the cross axis must beat the drawer axis by to win it.
+const AXIS_LOCK_SLOP = 6
+const AXIS_LOCK_BIAS = 2
 const MIN_RELEASE_VELOCITY_DURATION_MS = 16
 const MAX_RELEASE_VELOCITY_AGE_MS = 80
 const DEFAULT_IGNORE_SELECTOR = 'button,a,input,select,textarea,label,[role="button"]'
@@ -131,6 +135,14 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
   const allowLeft = computed(() => toValue(directions).includes('left'))
   const allowRight = computed(() => toValue(directions).includes('right'))
 
+  // The axis the drawer dismisses along, or `null` when both axes are
+  // dismissable and there is no cross axis to yield native scrolling to.
+  const drawerAxis = computed<'vertical' | 'horizontal' | null>(() => {
+    if (hasVertical.value === hasHorizontal.value)
+      return null
+    return hasVertical.value ? 'vertical' : 'horizontal'
+  })
+
   const isSwiping = ref(false)
   const swipeDirection = ref<SwipeDirection | undefined>(undefined)
   const dragOffset = ref({ x: 0, y: 0 })
@@ -145,6 +157,10 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
   let pendingSwipeStartPos: { x: number, y: number } | null = null
   let swipeFromScrollable = false
   let scrollableAncestor: HTMLElement | null = null
+  // Cross-axis arbitration state (touch only), reset per gesture.
+  let crossAxisScrollable: HTMLElement | null = null
+  let drawerAxisAttributed = false
+  let preserveNativeCrossAxisScroll = false
   let elementSize = { width: 0, height: 0 }
   let swipeProgress = 0
   let lastDragSample: { x: number, y: number, time: number } | null = null
@@ -214,6 +230,9 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
     resetGestureState()
     swipeFromScrollable = false
     scrollableAncestor = null
+    crossAxisScrollable = null
+    drawerAxisAttributed = false
+    preserveNativeCrossAxisScroll = false
     activePointerId = null
     pointerStarted = false
   }
@@ -254,6 +273,52 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
       ? dampAxis(deltaY, allowUp.value, allowDown.value)
       : exponent(deltaY)
     return { x: newDx, y: newDy }
+  }
+
+  /**
+   * Arbitrates a touchmove between the drawer swipe and a native scroll on the
+   * cross axis. Returns `true` when the move must be left alone — the cross axis
+   * already won the gesture, or neither axis has passed the slop yet.
+   */
+  function shouldYieldTouchMove(e: TouchEvent, pos: { x: number, y: number }): boolean {
+    if (preserveNativeCrossAxisScroll)
+      return true
+
+    // Attribution happens once per gesture: the slop is measured from the touch
+    // origin, which is never re-baselined, so re-arbitrating mid-drag would
+    // freeze the drawer and drop `preventDefault()`.
+    if (drawerAxisAttributed || !crossAxisScrollable || !drawerAxis.value)
+      return false
+
+    // The browser has already committed the gesture to a native scroll.
+    if (!e.cancelable) {
+      preserveNativeCrossAxisScroll = true
+      return true
+    }
+
+    const isVerticalDrawerAxis = drawerAxis.value === 'vertical'
+    const drawerAxisDelta = isVerticalDrawerAxis ? pos.y - dragStartPos.y : pos.x - dragStartPos.x
+    const crossAxisDelta = isVerticalDrawerAxis ? pos.x - dragStartPos.x : pos.y - dragStartPos.y
+    const absDrawerAxisDelta = Math.abs(drawerAxisDelta)
+    const absCrossAxisDelta = Math.abs(crossAxisDelta)
+
+    if (
+      absCrossAxisDelta >= AXIS_LOCK_SLOP
+      && absCrossAxisDelta > absDrawerAxisDelta + AXIS_LOCK_BIAS
+    ) {
+      preserveNativeCrossAxisScroll = true
+      return true
+    }
+
+    if (absDrawerAxisDelta >= AXIS_LOCK_SLOP) {
+      drawerAxisAttributed = true
+      return false
+    }
+
+    // Unattributed. Leave the event alone: on iOS, `preventDefault()` on the
+    // first cancelable touchmove cancels native scrolling for the whole gesture,
+    // locking out a cross-axis scroll that only passes the slop on a later move.
+    return true
   }
 
   function processMove(el: HTMLElement, pos: { x: number, y: number }, time: number) {
@@ -496,6 +561,12 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
     if (!el)
       return
 
+    // A gesture whose end we never saw would otherwise leak its verdict into
+    // this one, permanently muting the swipe.
+    crossAxisScrollable = null
+    drawerAxisAttributed = false
+    preserveNativeCrossAxisScroll = false
+
     if (!options.ignoreScrollableAncestors) {
       const axis = hasVertical.value ? 'vertical' : 'horizontal'
       const scrollable = findScrollableAncestor(target, axis)
@@ -503,6 +574,15 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
         swipeFromScrollable = true
         scrollableAncestor = scrollable
       }
+    }
+
+    // The scroller on the axis the drawer does NOT dismiss along, so
+    // `shouldYieldTouchMove` can hand the gesture to it. Deliberately not gated
+    // on `ignoreScrollableAncestors`: that option is about starting a swipe from
+    // inside a scroller on the dismiss axis.
+    if (drawerAxis.value) {
+      const crossAxis = drawerAxis.value === 'vertical' ? 'horizontal' : 'vertical'
+      crossAxisScrollable = findScrollableAncestor(target, crossAxis)
     }
 
     const t = e.touches[0]
@@ -521,6 +601,10 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions) {
       return
 
     const pos = { x: t.clientX, y: t.clientY }
+
+    // Bailing here leaves the move untouched, so the browser can scroll natively.
+    if (shouldYieldTouchMove(e, pos))
+      return
 
     if (swipeFromScrollable && pendingSwipe && scrollableAncestor) {
       const dx = pos.x - dragStartPos.x


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2876

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

A side drawer holding `overflow-y: auto` content dragged along X whenever you flicked vertically to scroll it, and the scroll itself was swallowed.

**Why it happened**

Two spots in `useSwipeDismiss` conspired:

1. `onTouchStart` picked the scroll axis to probe as `hasVertical ? 'vertical' : 'horizontal'`. For a `right` drawer that resolves to `'horizontal'`, so a vertically-scrolling content region was **never found** — `swipeFromScrollable` stayed `false` and the entire scroll guard in `onTouchMove` was skipped.
2. `processMove` only arbitrates axes when the drawer has *both* directions. With a single horizontal direction it hard-set `lockedAxis = 'horizontal'` and zeroed `dy`, so the pending-start check collapsed to `Math.abs(dx) >= MIN_DRAG_THRESHOLD` — **1px**. Any horizontal jitter in a vertical flick started the swipe, and the subsequent `e.preventDefault()` cancelled native scrolling for the rest of the gesture on iOS.

**The fix**

`onTouchStart` now also records the scroller on the **cross axis** (the one the drawer does not dismiss along), and a new `shouldYieldTouchMove` arbitrates every move before anything else touches it:

```
AXIS_LOCK_SLOP = 6, AXIS_LOCK_BIAS = 2

!event.cancelable                       → cross axis wins (browser already committed to a native scroll)
|cross| >= 6 && |cross| > |drawer| + 2  → cross axis wins for the rest of the gesture
|drawer| >= 6                           → drawer claims the gesture
otherwise                               → yield this move, do NOT preventDefault yet
```

That last branch is the subtle one, and the opposite of what we did before: it deliberately withholds `preventDefault()` until an axis has passed the slop, because on iOS preventing the *first* cancelable `touchmove` cancels native scrolling for the whole gesture. Attribution is also sticky — the slop is measured from a touch origin that is never re-baselined, so re-arbitrating mid-drag would freeze the drawer and drop `preventDefault()`.

Two notes on the wiring:

- The cross-axis lookup is deliberately not gated on `ignoreScrollableAncestors` — that option is about letting a swipe start from inside a scroller on the *dismiss* axis, whereas yielding to a cross-axis scroll is always what the user meant.
- Arbitration state is cleared on both `reset()` and `touchstart`, so a gesture whose end was never seen can't leave the drawer permanently unswipeable.

Behaviour is unchanged when there is no cross-axis scroller (short content owns nothing, the drawer keeps every pixel as before), for pointer/mouse drags, and for snap-point drawers that pass both directions on one axis.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests.

Seven cases added to `useSwipeDismiss.test.ts`, covering the regression and the guards against over-blocking:

- a mostly-vertical flick on a right drawer yields to the content scroll
- once the cross axis wins it keeps winning, even if the finger curves hard
- a decisive horizontal drag off scrollable content still dismisses
- no arbitration when there is no cross-axis scroller
- a non-cancelable move hands the gesture to the browser
- the mirror case: horizontal drift on a bottom drawer over a carousel
- a gesture whose end was never seen doesn't poison the next one

The four "yields" cases fail on `v2` without this change; all 64 Drawer tests, `type-check` and `lint` pass with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swipe-to-dismiss gesture handling in drawers.
  - Preserves native scrolling when touch movement is primarily along the content’s scroll axis.
  - Reduces accidental drawer dismissal during diagonal or cross-axis scrolling.
  - Improves directional locking, including horizontal scrolling in bottom drawers.
  - Ensures gesture state resets correctly after interrupted or abandoned touch interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->