### PR TITLE
fix(FocusScope): confirm focus is orphaned before pulling it to the container

### DIFF
--- a/packages/core/src/FocusScope/FocusScope.test.ts
+++ b/packages/core/src/FocusScope/FocusScope.test.ts
@@ -2,7 +2,7 @@ import type { RenderResult } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { render } from '@testing-library/vue'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent, nextTick, onMounted, ref, useTemplateRef } from 'vue'
 import { FocusScope } from '.'
 import { ComboboxAnchor, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxPortal, ComboboxRoot, ComboboxTrigger, ComboboxViewport } from '../Combobox'
 import { DialogContent, DialogRoot, DialogTitle, DialogTrigger } from '../Dialog'
@@ -291,6 +291,64 @@ describe('focusScope', () => {
       // The Select content traps focus; its FocusScope must pause the Dialog's
       // trap so focus lands inside the Select rather than being yanked back.
       expect(content.contains(document.activeElement)).toBe(true)
+    })
+  })
+
+  describe('given a Dialog view swapped by a Combobox item select (#2886)', () => {
+    // The swapped-in view focuses its own input on mount. The Combobox content's
+    // FocusScope is still pausing the Dialog's trap at that moment (it only
+    // resumes in a `setTimeout`), so the Dialog's `lastFocusedElementRef` keeps
+    // pointing at the now-removed Combobox trigger. The mutation handler must not
+    // conclude from that stale reference that focus was orphaned.
+    const FormView = defineComponent({
+      setup() {
+        const nameInput = useTemplateRef<HTMLInputElement>('name-input')
+        onMounted(() => nameInput.value?.focus())
+      },
+      template: `<input ref="name-input" data-testid="form-input">`,
+    })
+
+    const DialogWithComboboxSwap = defineComponent({
+      components: { DialogRoot, DialogTrigger, DialogContent, DialogTitle, ComboboxRoot, ComboboxAnchor, ComboboxTrigger, ComboboxPortal, ComboboxContent, ComboboxViewport, ComboboxInput, ComboboxItem, FormView },
+      setup() {
+        const view = ref<'combobox' | 'form'>('combobox')
+        return { view }
+      },
+      template: `
+        <DialogRoot>
+          <DialogTrigger>Open</DialogTrigger>
+          <DialogContent>
+            <DialogTitle>Test Dialog</DialogTitle>
+            <ComboboxRoot v-if="view === 'combobox'">
+              <ComboboxAnchor as-child>
+                <ComboboxTrigger>Open combobox</ComboboxTrigger>
+              </ComboboxAnchor>
+              <ComboboxPortal>
+                <ComboboxContent position="popper">
+                  <ComboboxViewport>
+                    <ComboboxInput data-testid="combobox-input" />
+                    <ComboboxItem value="custom" @select="view = 'form'">Add custom product</ComboboxItem>
+                  </ComboboxViewport>
+                </ComboboxContent>
+              </ComboboxPortal>
+            </ComboboxRoot>
+            <FormView v-else />
+          </DialogContent>
+        </DialogRoot>
+      `,
+    })
+
+    it('should keep focus on the input the swapped-in view focused on mount', async () => {
+      const rendered = render(DialogWithComboboxSwap)
+
+      await userEvent.click(rendered.getByRole('button', { name: 'Open' }))
+      await userEvent.click(rendered.getByText('Open combobox'))
+      await nextTick()
+
+      await userEvent.click(rendered.getByText('Add custom product'))
+      await nextTick()
+
+      expect(rendered.getByTestId('form-input')).toHaveFocus()
     })
   })
 })

--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -148,6 +148,17 @@ watchEffect((cleanupFn) => {
       return
     }
 
+    // Confirm focus was actually orphaned before pulling it back. `lastFocusedElement`
+    // is only tracked while the scope is not paused, so an open popper (which pauses
+    // this trap and only resumes it in a `setTimeout`) leaves it pointing at a stale
+    // element. Without this check, an element focused inside the container during that
+    // window — e.g. a view swapped in by the popper's `select` handler focusing its own
+    // input on mount — would be robbed of focus.
+    // -- related: https://github.com/unovue/reka-ui/issues/2886
+    const activeElement = getActiveElement()
+    if (activeElement && container.contains(activeElement))
+      return
+
     const isLastFocusedElementExist = container.contains(lastFocusedElement)
     if (!isLastFocusedElementExist)
       focus(container)


### PR DESCRIPTION
Fixes #2886.

### Problem

`handleMutations` in `FocusScope.vue` decides that focus was orphaned purely from `lastFocusedElementRef` no longer being inside the container:

```js
const isLastFocusedElementExist = container.contains(lastFocusedElement)
if (!isLastFocusedElementExist)
  focus(container)
```

But `lastFocusedElementRef` is only written by `handleFocusIn`, and only while the scope is **not paused**. An open popper pauses the ancestor trap (`ComboboxContentImpl` renders its own `FocusScope`, which joins the stack), and that pause is lifted in the popper scope's cleanup — inside a `setTimeout(..., 0)`. So while a popper is open, the remembered element is stale by design.

That makes this sequence misfire:

1. A `ComboboxItem`'s `@select` handler swaps a Dialog's content for another view, in the same tick the popper closes.
2. The new view focuses its own input in `onMounted`. The resulting `focusin` is ignored — the trap is still paused — so `lastFocusedElementRef` keeps pointing at the removed element.
3. `handleMutations` fires, sees the remembered element is gone, and calls `focus(container)` — pulling focus off an input that is *inside* the container and perfectly focusable. Typing goes nowhere.

The same swap triggered by a plain button (no popper involved) works fine, because there the trap is never paused and step 2 updates the reference.

### Fix

Confirm focus is actually orphaned before acting — the guard Radix has and Reka was missing:

```js
const activeElement = getActiveElement()
if (activeElement && container.contains(activeElement))
  return
```

Radix compares against `document.body`; `container.contains()` is the same test in stricter form (body is never inside the container) and additionally covers the shadow-DOM case `getActiveElement` exists for.

This keeps the `lastFocusedElementRef` tracking that #519 introduced for the `document.activeElement` lag in #518: when the focused element has been removed but is still `document.activeElement`, it is detached, so `container.contains()` is `false` and the handler falls through to the existing check unchanged.

### Test

Added a regression test reproducing the report: a Dialog whose view is swapped by a `ComboboxItem` `@select`, with the new view focusing its input on mount. It fails on `v2` (focus lands on the dialog content) and passes with this change.

Full `packages/core` suite passes (97 files / 2032 tests), plus `type-check` and lint.

Credit to @mkeyy0 for the diagnosis and the suggested guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
