### PR TITLE
fix(DismissableLayer): drop stale deferred click listener on inside pointerdown

### DIFF
--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -387,6 +387,86 @@ describe('given a default DismissableLayer', () => {
   })
 })
 
+describe('given a DismissableLayer after a cancelled touch tap outside', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // jsdom has no `PointerEvent`, so `fireEvent.pointerDown` loses `pointerType`
+  // and would take the mouse path instead of the deferred touch one.
+  function touchPointerDown(target: EventTarget) {
+    const event = new MouseEvent('pointerdown', { bubbles: true })
+    Object.defineProperty(event, 'pointerType', { value: 'touch' })
+    target.dispatchEvent(event)
+  }
+
+  // Regression: on touch, `pointerDownOutside` is deferred to the next `click`.
+  // When the outside tap turns into a scroll or drag no `click` follows, so the
+  // deferred listener stays armed. The next tap INSIDE the layer (or a nested
+  // layer above it) must drop that stale listener instead of letting its own
+  // `click` dismiss the layer. Mirrors radix-ui/primitives#2171.
+  it('should not dismiss on the next tap inside a nested layer', async () => {
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => h('div', [
+          h(DismissableLayerPrimitive, { 'data-testid': 'outer' }, () => 'Outer'),
+          h(DismissableLayerPrimitive, { 'data-testid': 'inner' }, () => [
+            h('button', { 'data-testid': 'inner-button' }, 'Inner'),
+          ]),
+        ])
+      },
+    }), { attachTo: document.body })
+    await sleep(1)
+
+    const outer = wrapper.findComponent('[data-testid="outer"]') as VueWrapper
+    const innerButton = wrapper.find('[data-testid="inner-button"]').element
+
+    // Outside touch that is cancelled: no `click` follows the `pointerdown`.
+    touchPointerDown(document.body)
+    await sleep(1)
+
+    // Next tap lands inside the nested layer.
+    touchPointerDown(innerButton)
+    await fireEvent.click(innerButton)
+    await sleep(1)
+
+    expect(outer.emitted('pointerDownOutside')).toBeUndefined()
+    expect(outer.emitted('dismiss')).toBeUndefined()
+
+    // A completed tap outside still dismisses the outer layer.
+    touchPointerDown(document.body)
+    await fireEvent.click(document.body)
+    await sleep(1)
+
+    expect(outer.emitted('pointerDownOutside')?.length).toBe(1)
+    expect(outer.emitted('dismiss')?.length).toBe(1)
+
+    wrapper.unmount()
+  })
+
+  it('should not dismiss on the next tap inside the layer itself', async () => {
+    const wrapper = mount(DismissableLayerPrimitive, {
+      attachTo: document.body,
+      slots: { default: () => h('button', { 'data-testid': 'inside' }, 'Inside') },
+    })
+    await sleep(1)
+
+    const inside = wrapper.find('[data-testid="inside"]').element
+
+    touchPointerDown(document.body)
+    await sleep(1)
+
+    touchPointerDown(inside)
+    await fireEvent.click(inside)
+    await sleep(1)
+
+    expect(wrapper.emitted('pointerDownOutside')).toBeUndefined()
+    expect(wrapper.emitted('dismiss')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+})
+
 describe('given a mounted DismissableLayer toggling disableOutsidePointerEvents', () => {
   beforeEach(() => {
     document.body.innerHTML = ''

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -65,6 +65,11 @@ export function usePointerDownOutside(
         return
 
       if (isLayerExist(element.value, target)) {
+        // A touch `pointerdown` outside arms a one-shot `click` listener that
+        // never fires when the tap becomes a scroll/drag. Drop it here so the
+        // next tap inside a layer cannot trigger the stale dismissal (mirrors
+        // Radix's inside-tree branch, radix-ui/primitives#2171).
+        ownerDocument.removeEventListener('click', handleClickRef.value)
         isPointerInsideDOMTree.value = false
         return
       }


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #2891

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

On touch devices `usePointerDownOutside` defers the `pointerDownOutside` dispatch for an outside `pointerdown` to a one-shot document `click` listener. When that touch turns into a scroll or drag, no `click` follows and the listener stays armed. The `isLayerExist(...)` early return for inside and nested-layer targets skipped the cleanup that runs for other inside pointerdowns, so the `click` of the next tap inside the layer fired the stale listener and dismissed the layer.

This mirrors the inside-tree branch in Radix's `usePointerDownOutside` (radix-ui/primitives#2171): remove the pending `click` listener before the inside-layer early return.

Changes:

- `DismissableLayer/utils.ts`: drop the deferred `click` listener at the top of the `isLayerExist` branch (one line plus a comment).
- `DismissableLayer.test.ts`: two regression tests (tap inside the layer itself, and inside a nested layer, after a cancelled touch outside). Both fail on `v2` without the fix and pass with it; the existing outside tap-then-click case still dismisses.

Resolves #2891

### 📸 Screenshots (if appropriate)

n/a

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. (no docs change needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where canceled touch taps could leave a stale outside-click handler active.
  - Tapping inside a nested or current layer no longer causes unexpected dismissal.
  - Later completed taps outside the layer continue to dismiss it as expected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->