### PR TITLE
docs: add ten composition examples

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -339,6 +339,7 @@ export default defineConfig({
           {
             text: 'Combobox',
             items: [
+              { text: 'Combobox Async', link: '/examples/combobox-async' },
               {
                 text: 'Combobox Tags Input',
                 link: '/examples/combobox-tags-input',
@@ -346,6 +347,10 @@ export default defineConfig({
               {
                 text: 'Combobox Textarea',
                 link: '/examples/combobox-textarea',
+              },
+              {
+                text: 'Combobox Virtualized',
+                link: '/examples/combobox-virtualized',
               },
             ],
           },
@@ -360,6 +365,10 @@ export default defineConfig({
                 text: 'Date Picker View Switching',
                 link: '/examples/date-picker-view-switching',
               },
+              {
+                text: 'Date Range Presets',
+                link: '/examples/date-range-presets',
+              },
             ],
           },
           {
@@ -367,12 +376,22 @@ export default defineConfig({
             items: [
               { text: 'Dialog Command Menu', link: '/examples/dialog-command-menu' },
               { text: 'Dialog Gesture Driven', link: '/examples/dialog-gesture-driven' },
+              {
+                text: 'Responsive Dialog Drawer',
+                link: '/examples/dialog-responsive-drawer',
+              },
             ],
           },
           {
             text: 'Listbox',
             items: [
               { text: 'Listbox Transfer', link: '/examples/listbox-transfer' },
+            ],
+          },
+          {
+            text: 'Pin Input',
+            items: [
+              { text: 'Pin Input OTP', link: '/examples/pin-input-otp' },
             ],
           },
           {
@@ -383,6 +402,42 @@ export default defineConfig({
                 link: '/examples/slider-number-field',
               },
               { text: 'Slider Tooltip', link: '/examples/slider-tooltip' },
+            ],
+          },
+          {
+            text: 'Splitter',
+            items: [
+              {
+                text: 'Splitter IDE Layout',
+                link: '/examples/splitter-ide-layout',
+              },
+            ],
+          },
+          {
+            text: 'Stepper',
+            items: [
+              {
+                text: 'Stepper Form Wizard',
+                link: '/examples/stepper-form-wizard',
+              },
+            ],
+          },
+          {
+            text: 'Table',
+            items: [
+              { text: 'Data Table', link: '/examples/data-table' },
+            ],
+          },
+          {
+            text: 'Toast',
+            items: [
+              { text: 'Toast Undo', link: '/examples/toast-undo' },
+            ],
+          },
+          {
+            text: 'Toolbar',
+            items: [
+              { text: 'Toolbar Rich Text', link: '/examples/toolbar-rich-text' },
             ],
           },
           {

--- a/docs/components/examples/ComboboxAsync/api.ts
+++ b/docs/components/examples/ComboboxAsync/api.ts
@@ -1,0 +1,44 @@
+export interface User {
+  id: number
+  name: string
+  handle: string
+  team: string
+}
+
+const USERS: User[] = [
+  { id: 1, name: 'Ada Lovelace', handle: 'ada', team: 'Engineering' },
+  { id: 2, name: 'Alan Turing', handle: 'alan', team: 'Engineering' },
+  { id: 3, name: 'Grace Hopper', handle: 'grace', team: 'Engineering' },
+  { id: 4, name: 'Katherine Johnson', handle: 'katherine', team: 'Research' },
+  { id: 5, name: 'Barbara Liskov', handle: 'barbara', team: 'Research' },
+  { id: 6, name: 'Margaret Hamilton', handle: 'margaret', team: 'Research' },
+  { id: 7, name: 'Radia Perlman', handle: 'radia', team: 'Infrastructure' },
+  { id: 8, name: 'Anita Borg', handle: 'anita', team: 'Infrastructure' },
+  { id: 9, name: 'Frances Allen', handle: 'frances', team: 'Compilers' },
+  { id: 10, name: 'Jean Bartik', handle: 'jean', team: 'Compilers' },
+  { id: 11, name: 'Shafi Goldwasser', handle: 'shafi', team: 'Security' },
+  { id: 12, name: 'Elizabeth Feinler', handle: 'elizabeth', team: 'Security' },
+]
+
+/**
+ * Stands in for a real endpoint. The latency is deliberately random so that
+ * responses come back out of order — which is exactly the case `AbortController`
+ * in `index.vue` exists to handle.
+ */
+export function searchUsers(query: string, signal: AbortSignal): Promise<User[]> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      const q = query.trim().toLowerCase()
+      resolve(
+        q
+          ? USERS.filter(user => `${user.name} ${user.handle} ${user.team}`.toLowerCase().includes(q))
+          : USERS.slice(0, 5),
+      )
+    }, 250 + Math.random() * 600)
+
+    signal.addEventListener('abort', () => {
+      clearTimeout(timer)
+      reject(new DOMException('Aborted', 'AbortError'))
+    })
+  })
+}

--- a/docs/components/examples/ComboboxAsync/index.vue
+++ b/docs/components/examples/ComboboxAsync/index.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import type { User } from './api'
+import { Icon } from '@iconify/vue'
+import { watchDebounced } from '@vueuse/core'
+import { ComboboxAnchor, ComboboxContent, ComboboxEmpty, ComboboxInput, ComboboxItem, ComboboxItemIndicator, ComboboxRoot, ComboboxTrigger, ComboboxViewport } from 'reka-ui'
+import { ref, shallowRef } from 'vue'
+import { searchUsers } from './api'
+
+const selected = shallowRef<User | undefined>()
+const searchTerm = ref('')
+const results = shallowRef<User[]>([])
+const isPending = ref(false)
+
+let controller: AbortController | undefined
+
+async function runSearch(query: string) {
+  // Abort the request still in flight. Without this a slow response for an
+  // earlier keystroke can land after a fast one and overwrite fresher results.
+  controller?.abort()
+  controller = new AbortController()
+  isPending.value = true
+
+  try {
+    results.value = await searchUsers(query, controller.signal)
+    isPending.value = false
+  }
+  catch (error) {
+    // A superseded request is not a failure — the newer one owns the state now.
+    if ((error as Error).name !== 'AbortError')
+      throw error
+  }
+}
+
+// `immediate` fills the list with default suggestions before the first keystroke.
+watchDebounced(searchTerm, runSearch, { debounce: 300, immediate: true })
+</script>
+
+<template>
+  <ComboboxRoot
+    v-model="selected"
+    class="relative w-[280px]"
+    open-on-focus
+    open-on-click
+    ignore-filter
+  >
+    <ComboboxAnchor class="w-full inline-flex items-center justify-between gap-2 rounded-lg border border-muted bg-card px-3 h-10 text-sm text-foreground focus-within:ring-2 focus-within:ring-primary/40">
+      <Icon
+        icon="lucide:search"
+        class="size-4 shrink-0 text-muted-foreground"
+      />
+      <ComboboxInput
+        v-model="searchTerm"
+        class="w-full bg-transparent outline-none placeholder-muted-foreground"
+        placeholder="Search teammates…"
+        :display-value="(user: User | undefined) => user?.name ?? ''"
+      />
+      <ComboboxTrigger class="shrink-0">
+        <Icon
+          v-if="isPending"
+          icon="lucide:loader-circle"
+          class="size-4 animate-spin text-muted-foreground"
+        />
+        <Icon
+          v-else
+          icon="lucide:chevron-down"
+          class="size-4 text-muted-foreground"
+        />
+      </ComboboxTrigger>
+    </ComboboxAnchor>
+
+    <ComboboxContent class="absolute z-10 w-full mt-1 rounded-lg border border-muted bg-card shadow-lg overflow-hidden data-[side=bottom]:animate-slideUpAndFade data-[side=top]:animate-slideDownAndFade">
+      <ComboboxViewport class="max-h-[240px] p-1">
+        <!-- `ignore-filter` hands filtering to the server, so the empty state has
+             to distinguish "still loading" from "the server found nothing". -->
+        <div
+          v-if="isPending && !results.length"
+          class="flex items-center justify-center gap-2 p-4 text-sm text-muted-foreground"
+        >
+          <Icon
+            icon="lucide:loader-circle"
+            class="size-4 animate-spin"
+          />
+          Searching…
+        </div>
+        <ComboboxEmpty
+          v-else
+          class="p-4 text-center text-sm text-muted-foreground"
+        >
+          No teammate matches “{{ searchTerm }}”
+        </ComboboxEmpty>
+
+        <ComboboxItem
+          v-for="user in results"
+          :key="user.id"
+          :value="user"
+          class="flex items-center gap-3 rounded-md px-2 py-1.5 text-sm text-foreground select-none cursor-default outline-none data-[highlighted]:bg-muted"
+        >
+          <span class="grid size-7 shrink-0 place-items-center rounded-full bg-muted text-xs font-semibold uppercase text-muted-foreground">
+            {{ user.name[0] }}
+          </span>
+          <span class="min-w-0">
+            <span class="block truncate">{{ user.name }}</span>
+            <span class="block truncate text-xs text-muted-foreground">{{ user.team }}</span>
+          </span>
+          <ComboboxItemIndicator class="ml-auto shrink-0">
+            <Icon
+              icon="lucide:check"
+              class="size-4"
+            />
+          </ComboboxItemIndicator>
+        </ComboboxItem>
+      </ComboboxViewport>
+    </ComboboxContent>
+  </ComboboxRoot>
+</template>

--- a/docs/components/examples/ComboboxVirtualized/hosts.ts
+++ b/docs/components/examples/ComboboxVirtualized/hosts.ts
@@ -1,0 +1,22 @@
+export interface Host {
+  id: number
+  name: string
+  region: string
+  role: string
+}
+
+const REGIONS = ['nyc', 'sfo', 'ams', 'sin', 'fra', 'syd', 'lhr', 'gru']
+const ROLES = ['web', 'api', 'worker', 'cache', 'db', 'edge']
+
+/** 10,000 rows — far past the point where rendering every option is viable. */
+export const hosts: Host[] = Array.from({ length: 10_000 }, (_, index) => {
+  const region = REGIONS[index % REGIONS.length]
+  const role = ROLES[Math.floor(index / REGIONS.length) % ROLES.length]
+
+  return {
+    id: index,
+    region,
+    role,
+    name: `${region}-${role}-${String(index).padStart(4, '0')}`,
+  }
+})

--- a/docs/components/examples/ComboboxVirtualized/index.vue
+++ b/docs/components/examples/ComboboxVirtualized/index.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import type { Host } from './hosts'
+import { Icon } from '@iconify/vue'
+import { ComboboxAnchor, ComboboxContent, ComboboxEmpty, ComboboxInput, ComboboxItem, ComboboxItemIndicator, ComboboxRoot, ComboboxTrigger, ComboboxViewport, ComboboxVirtualizer } from 'reka-ui'
+import { computed, ref, shallowRef } from 'vue'
+import { hosts } from './hosts'
+
+const selected = shallowRef<Host | undefined>()
+const searchTerm = ref('')
+
+// `ignore-filter` turns off the built-in filter: the virtualizer renders from
+// `options`, so the list it is given has to be the already-filtered one.
+const filtered = computed(() => {
+  const query = searchTerm.value.trim().toLowerCase()
+  if (!query)
+    return hosts
+  return hosts.filter(host => host.name.includes(query))
+})
+</script>
+
+<template>
+  <ComboboxRoot
+    v-model="selected"
+    class="relative w-[280px]"
+    open-on-focus
+    open-on-click
+    ignore-filter
+  >
+    <ComboboxAnchor class="w-full inline-flex items-center justify-between gap-2 rounded-lg border border-muted bg-card px-3 h-10 text-sm text-foreground focus-within:ring-2 focus-within:ring-primary/40">
+      <ComboboxInput
+        v-model="searchTerm"
+        class="w-full bg-transparent outline-none placeholder-muted-foreground font-mono text-xs"
+        placeholder="Search 10,000 hosts…"
+        :display-value="(host: Host | undefined) => host?.name ?? ''"
+      />
+      <ComboboxTrigger class="shrink-0">
+        <Icon
+          icon="lucide:chevron-down"
+          class="size-4 text-muted-foreground"
+        />
+      </ComboboxTrigger>
+    </ComboboxAnchor>
+
+    <ComboboxContent class="absolute z-10 w-full mt-1 rounded-lg border border-muted bg-card shadow-lg overflow-hidden data-[side=bottom]:animate-slideUpAndFade data-[side=top]:animate-slideDownAndFade">
+      <!-- The viewport is the scroll container the virtualizer measures against,
+           so it is the element that needs a bounded height. -->
+      <ComboboxViewport class="max-h-[280px] p-1">
+        <ComboboxEmpty class="p-4 text-center text-sm text-muted-foreground">
+          No host matches “{{ searchTerm }}”
+        </ComboboxEmpty>
+
+        <ComboboxVirtualizer
+          v-slot="{ option }"
+          :options="filtered"
+          :estimate-size="32"
+          :overscan="8"
+          :text-content="(host: Host) => host.name"
+        >
+          <ComboboxItem
+            :value="option"
+            class="flex w-full items-center gap-2 rounded-md px-2 h-8 text-xs text-foreground select-none cursor-default outline-none data-[highlighted]:bg-muted"
+          >
+            <span class="font-mono truncate">{{ option.name }}</span>
+            <span class="ml-auto shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+              {{ option.role }}
+            </span>
+            <ComboboxItemIndicator class="shrink-0">
+              <Icon
+                icon="lucide:check"
+                class="size-3.5"
+              />
+            </ComboboxItemIndicator>
+          </ComboboxItem>
+        </ComboboxVirtualizer>
+      </ComboboxViewport>
+    </ComboboxContent>
+  </ComboboxRoot>
+</template>

--- a/docs/components/examples/DataTable/data.ts
+++ b/docs/components/examples/DataTable/data.ts
@@ -1,0 +1,43 @@
+export type PaymentStatus = 'paid' | 'pending' | 'failed'
+
+export interface Payment {
+  id: number
+  customer: string
+  email: string
+  status: PaymentStatus
+  amount: number
+}
+
+export const payments: Payment[] = [
+  { id: 1, customer: 'Ada Lovelace', email: 'ada@analytical.co', status: 'paid', amount: 316 },
+  { id: 2, customer: 'Alan Turing', email: 'alan@bletchley.uk', status: 'pending', amount: 242 },
+  { id: 3, customer: 'Grace Hopper', email: 'grace@cobol.mil', status: 'paid', amount: 837 },
+  { id: 4, customer: 'Katherine Johnson', email: 'katherine@nasa.gov', status: 'failed', amount: 121 },
+  { id: 5, customer: 'Barbara Liskov', email: 'barbara@mit.edu', status: 'paid', amount: 654 },
+  { id: 6, customer: 'Margaret Hamilton', email: 'margaret@apollo.io', status: 'pending', amount: 428 },
+  { id: 7, customer: 'Radia Perlman', email: 'radia@spanning.net', status: 'paid', amount: 903 },
+  { id: 8, customer: 'Anita Borg', email: 'anita@systers.org', status: 'paid', amount: 175 },
+  { id: 9, customer: 'Frances Allen', email: 'frances@ibm.com', status: 'failed', amount: 512 },
+  { id: 10, customer: 'Jean Bartik', email: 'jean@eniac.edu', status: 'paid', amount: 289 },
+  { id: 11, customer: 'Shafi Goldwasser', email: 'shafi@crypto.ac', status: 'pending', amount: 764 },
+  { id: 12, customer: 'Elizabeth Feinler', email: 'elizabeth@arpanet.net', status: 'paid', amount: 341 },
+  { id: 13, customer: 'Karen Spärck Jones', email: 'karen@idf.ac.uk', status: 'paid', amount: 598 },
+  { id: 14, customer: 'Evelyn Boyd Granville', email: 'evelyn@vanguard.gov', status: 'pending', amount: 187 },
+  { id: 15, customer: 'Mary Allen Wilkes', email: 'mary@linc.dev', status: 'paid', amount: 726 },
+  { id: 16, customer: 'Adele Goldberg', email: 'adele@smalltalk.org', status: 'failed', amount: 233 },
+  { id: 17, customer: 'Sophie Wilson', email: 'sophie@acorn.uk', status: 'paid', amount: 881 },
+  { id: 18, customer: 'Lynn Conway', email: 'lynn@vlsi.edu', status: 'paid', amount: 405 },
+  { id: 19, customer: 'Carol Shaw', email: 'carol@atari.com', status: 'pending', amount: 159 },
+  { id: 20, customer: 'Roberta Williams', email: 'roberta@sierra.com', status: 'paid', amount: 672 },
+  { id: 21, customer: 'Erna Hoover', email: 'erna@bell.labs', status: 'paid', amount: 314 },
+  { id: 22, customer: 'Hedy Lamarr', email: 'hedy@spectrum.fm', status: 'failed', amount: 947 },
+  { id: 23, customer: 'Susan Kare', email: 'susan@chicago.font', status: 'paid', amount: 268 },
+]
+
+export const currency = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+
+export const statusStyles: Record<PaymentStatus, string> = {
+  paid: 'bg-green4 text-grass11',
+  pending: 'bg-muted text-muted-foreground',
+  failed: 'bg-destructive/15 text-destructive',
+}

--- a/docs/components/examples/DataTable/index.vue
+++ b/docs/components/examples/DataTable/index.vue
@@ -1,0 +1,334 @@
+<script setup lang="ts">
+import type { Payment } from './data'
+import { Icon } from '@iconify/vue'
+import { CheckboxIndicator, CheckboxRoot, ContextMenuContent, ContextMenuItem, ContextMenuPortal, ContextMenuRoot, ContextMenuSeparator, ContextMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuPortal, DropdownMenuRoot, DropdownMenuSeparator, DropdownMenuTrigger, PaginationEllipsis, PaginationList, PaginationListItem, PaginationNext, PaginationPrev, PaginationRoot, ScrollAreaRoot, ScrollAreaScrollbar, ScrollAreaThumb, ScrollAreaViewport } from 'reka-ui'
+import { computed, ref } from 'vue'
+import { currency, payments, statusStyles } from './data'
+
+const PER_PAGE = 6
+
+type SortKey = 'customer' | 'amount'
+
+const rows = ref<Payment[]>([...payments])
+const selected = ref(new Set<number>())
+const sortKey = ref<SortKey>('customer')
+const sortDesc = ref(false)
+const page = ref(1)
+const lastAction = ref('')
+
+const sorted = computed(() => [...rows.value].sort((a, b) => {
+  const left = a[sortKey.value]
+  const right = b[sortKey.value]
+  const order = typeof left === 'number' && typeof right === 'number'
+    ? left - right
+    : String(left).localeCompare(String(right))
+  return sortDesc.value ? -order : order
+}))
+
+const pageRows = computed(() => sorted.value.slice((page.value - 1) * PER_PAGE, page.value * PER_PAGE))
+
+/**
+ * Tri-state header checkbox: `'indeterminate'` whenever the page is partly
+ * selected, which is what gives the dash instead of a tick.
+ */
+const pageSelection = computed<boolean | 'indeterminate'>({
+  get() {
+    const count = pageRows.value.filter(row => selected.value.has(row.id)).length
+    if (count === 0)
+      return false
+    return count === pageRows.value.length ? true : 'indeterminate'
+  },
+  set(value) {
+    for (const row of pageRows.value) {
+      if (value === true)
+        selected.value.add(row.id)
+      else
+        selected.value.delete(row.id)
+    }
+  },
+})
+
+function toggleRow(row: Payment, checked: boolean | 'indeterminate') {
+  if (checked === true)
+    selected.value.add(row.id)
+  else
+    selected.value.delete(row.id)
+}
+
+function toggleSort(key: SortKey) {
+  if (sortKey.value === key)
+    sortDesc.value = !sortDesc.value
+  else
+    sortKey.value = key
+  page.value = 1
+}
+
+const rowActions = [
+  { id: 'view', label: 'View details', icon: 'lucide:eye' },
+  { id: 'copy', label: 'Copy email', icon: 'lucide:copy' },
+  { id: 'delete', label: 'Delete', icon: 'lucide:trash-2', destructive: true },
+] as const
+
+function runAction(actionId: string, row: Payment) {
+  if (actionId === 'delete') {
+    rows.value = rows.value.filter(item => item.id !== row.id)
+    selected.value.delete(row.id)
+    // Deleting the last row of the final page would strand the viewer there.
+    page.value = Math.min(page.value, Math.max(1, Math.ceil(rows.value.length / PER_PAGE)))
+  }
+  lastAction.value = `${rowActions.find(action => action.id === actionId)!.label} → ${row.customer}`
+}
+
+const checkboxClass = 'grid size-4 shrink-0 place-items-center rounded border border-muted-foreground/40 bg-background data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary focus:outline-none focus:ring-2 focus:ring-primary/40'
+const menuContentClass = 'z-[100] min-w-[11rem] rounded-lg border border-muted bg-card p-1 shadow-lg will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFade data-[side=top]:animate-slideDownAndFade'
+const menuItemClass = 'flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground outline-none data-[highlighted]:bg-muted'
+</script>
+
+<template>
+  <div class="w-full max-w-[640px]">
+    <ScrollAreaRoot
+      class="overflow-hidden rounded-xl border border-muted bg-card"
+      type="auto"
+    >
+      <ScrollAreaViewport class="w-full">
+        <table class="w-full min-w-[520px] border-collapse text-sm">
+          <thead>
+            <tr class="border-b border-muted text-left">
+              <th
+                scope="col"
+                class="w-9 px-3 py-2.5"
+              >
+                <CheckboxRoot
+                  v-model="pageSelection"
+                  :class="checkboxClass"
+                  aria-label="Select all rows on this page"
+                >
+                  <CheckboxIndicator class="text-primary-foreground">
+                    <Icon
+                      :icon="pageSelection === 'indeterminate' ? 'lucide:minus' : 'lucide:check'"
+                      class="size-3"
+                    />
+                  </CheckboxIndicator>
+                </CheckboxRoot>
+              </th>
+              <th
+                scope="col"
+                class="px-3 py-2.5 font-medium"
+              >
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 rounded"
+                  @click="toggleSort('customer')"
+                >
+                  Customer
+                  <Icon
+                    :icon="sortKey === 'customer' ? (sortDesc ? 'lucide:arrow-down' : 'lucide:arrow-up') : 'lucide:chevrons-up-down'"
+                    class="size-3.5"
+                  />
+                </button>
+              </th>
+              <th
+                scope="col"
+                class="px-3 py-2.5 font-medium text-muted-foreground"
+              >
+                Status
+              </th>
+              <th
+                scope="col"
+                class="px-3 py-2.5 text-right font-medium"
+              >
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 rounded"
+                  @click="toggleSort('amount')"
+                >
+                  Amount
+                  <Icon
+                    :icon="sortKey === 'amount' ? (sortDesc ? 'lucide:arrow-down' : 'lucide:arrow-up') : 'lucide:chevrons-up-down'"
+                    class="size-3.5"
+                  />
+                </button>
+              </th>
+              <th
+                scope="col"
+                class="w-10 px-3 py-2.5"
+              >
+                <span class="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <!-- The same `rowActions` list feeds both menus, so right-click and
+                 the ⋯ button can never drift apart. -->
+            <ContextMenuRoot
+              v-for="row in pageRows"
+              :key="row.id"
+            >
+              <ContextMenuTrigger as-child>
+                <tr
+                  class="border-b border-muted last:border-0 data-[state=open]:bg-muted"
+                  :class="selected.has(row.id) && 'bg-muted/60'"
+                >
+                  <td class="px-3 py-2.5">
+                    <CheckboxRoot
+                      :model-value="selected.has(row.id)"
+                      :class="checkboxClass"
+                      :aria-label="`Select ${row.customer}`"
+                      @update:model-value="toggleRow(row, $event)"
+                    >
+                      <CheckboxIndicator class="text-primary-foreground">
+                        <Icon
+                          icon="lucide:check"
+                          class="size-3"
+                        />
+                      </CheckboxIndicator>
+                    </CheckboxRoot>
+                  </td>
+                  <td class="px-3 py-2.5">
+                    <span class="block truncate font-medium text-foreground">{{ row.customer }}</span>
+                    <span class="block truncate text-xs text-muted-foreground">{{ row.email }}</span>
+                  </td>
+                  <td class="px-3 py-2.5">
+                    <span
+                      class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium capitalize"
+                      :class="statusStyles[row.status]"
+                    >
+                      {{ row.status }}
+                    </span>
+                  </td>
+                  <td class="px-3 py-2.5 text-right font-mono text-foreground">
+                    {{ currency.format(row.amount) }}
+                  </td>
+                  <td class="px-3 py-2.5">
+                    <DropdownMenuRoot>
+                      <DropdownMenuTrigger
+                        class="grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                        :aria-label="`Actions for ${row.customer}`"
+                      >
+                        <Icon
+                          icon="lucide:ellipsis"
+                          class="size-4"
+                        />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuPortal>
+                        <DropdownMenuContent
+                          :class="menuContentClass"
+                          align="end"
+                          :side-offset="4"
+                        >
+                          <template
+                            v-for="action in rowActions"
+                            :key="action.id"
+                          >
+                            <DropdownMenuSeparator
+                              v-if="action.destructive"
+                              class="my-1 h-px bg-muted"
+                            />
+                            <DropdownMenuItem
+                              :class="[menuItemClass, action.destructive && 'text-destructive']"
+                              @select="runAction(action.id, row)"
+                            >
+                              <Icon
+                                :icon="action.icon"
+                                class="size-4"
+                              />
+                              {{ action.label }}
+                            </DropdownMenuItem>
+                          </template>
+                        </DropdownMenuContent>
+                      </DropdownMenuPortal>
+                    </DropdownMenuRoot>
+                  </td>
+                </tr>
+              </ContextMenuTrigger>
+
+              <ContextMenuPortal>
+                <ContextMenuContent :class="menuContentClass">
+                  <template
+                    v-for="action in rowActions"
+                    :key="action.id"
+                  >
+                    <ContextMenuSeparator
+                      v-if="action.destructive"
+                      class="my-1 h-px bg-muted"
+                    />
+                    <ContextMenuItem
+                      :class="[menuItemClass, action.destructive && 'text-destructive']"
+                      @select="runAction(action.id, row)"
+                    >
+                      <Icon
+                        :icon="action.icon"
+                        class="size-4"
+                      />
+                      {{ action.label }}
+                    </ContextMenuItem>
+                  </template>
+                </ContextMenuContent>
+              </ContextMenuPortal>
+            </ContextMenuRoot>
+          </tbody>
+        </table>
+      </ScrollAreaViewport>
+
+      <ScrollAreaScrollbar
+        class="flex h-2 touch-none select-none bg-muted/50 p-0.5"
+        orientation="horizontal"
+      >
+        <ScrollAreaThumb class="relative flex-1 rounded-full bg-muted-foreground/40" />
+      </ScrollAreaScrollbar>
+    </ScrollAreaRoot>
+
+    <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
+      <p class="text-xs text-muted-foreground">
+        {{ selected.size }} of {{ rows.length }} selected
+        <template v-if="lastAction">
+          · last action: {{ lastAction }}
+        </template>
+      </p>
+
+      <PaginationRoot
+        v-model:page="page"
+        :total="rows.length"
+        :items-per-page="PER_PAGE"
+        :sibling-count="1"
+      >
+        <PaginationList
+          v-slot="{ items }"
+          class="flex items-center gap-1"
+        >
+          <PaginationPrev class="grid size-8 place-items-center rounded-md text-foreground hover:bg-muted disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-primary/40">
+            <Icon
+              icon="lucide:chevron-left"
+              class="size-4"
+            />
+          </PaginationPrev>
+          <template v-for="(item, index) in items">
+            <PaginationListItem
+              v-if="item.type === 'page'"
+              :key="index"
+              :value="item.value"
+              class="grid size-8 place-items-center rounded-md text-sm text-foreground hover:bg-muted data-[selected]:bg-primary data-[selected]:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            >
+              {{ item.value }}
+            </PaginationListItem>
+            <PaginationEllipsis
+              v-else
+              :key="item.type"
+              :index="index"
+              class="grid size-8 place-items-center text-muted-foreground"
+            >
+              &#8230;
+            </PaginationEllipsis>
+          </template>
+          <PaginationNext class="grid size-8 place-items-center rounded-md text-foreground hover:bg-muted disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-primary/40">
+            <Icon
+              icon="lucide:chevron-right"
+              class="size-4"
+            />
+          </PaginationNext>
+        </PaginationList>
+      </PaginationRoot>
+    </div>
+  </div>
+</template>

--- a/docs/components/examples/DateRangePresets/index.vue
+++ b/docs/components/examples/DateRangePresets/index.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import type { DateRange } from 'reka-ui'
+import type { Preset } from './presets'
+import { Icon } from '@iconify/vue'
+import { DateFormatter, getLocalTimeZone, today } from '@internationalized/date'
+import { useMediaQuery } from '@vueuse/core'
+import { PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger, RangeCalendarCell, RangeCalendarCellTrigger, RangeCalendarGrid, RangeCalendarGridBody, RangeCalendarGridHead, RangeCalendarGridRow, RangeCalendarHeadCell, RangeCalendarHeader, RangeCalendarHeading, RangeCalendarNext, RangeCalendarPrev, RangeCalendarRoot } from 'reka-ui'
+import { computed, ref } from 'vue'
+import { presets } from './presets'
+
+const formatter = new DateFormatter('en-US', { dateStyle: 'medium' })
+const isWide = useMediaQuery('(min-width: 768px)')
+
+const open = ref(false)
+const value = ref<DateRange>(presets[2].range())
+// The calendar navigates from `placeholder`, so a preset has to move it too —
+// otherwise picking "Last month" leaves the view sitting on the current month.
+const placeholder = ref(value.value.start)
+
+const activePreset = computed(() => presets.find((preset) => {
+  const { start, end } = preset.range()
+  return start && end
+    && value.value.start?.compare(start) === 0
+    && value.value.end?.compare(end) === 0
+}))
+
+const label = computed(() => {
+  const { start, end } = value.value
+  if (!start || !end)
+    return 'Pick a date range'
+
+  const range = `${formatter.format(start.toDate(getLocalTimeZone()))} – ${formatter.format(end.toDate(getLocalTimeZone()))}`
+  return activePreset.value ? `${activePreset.value.label}: ${range}` : range
+})
+
+function applyPreset(preset: Preset) {
+  value.value = preset.range()
+  placeholder.value = value.value.start!
+}
+</script>
+
+<template>
+  <PopoverRoot v-model:open="open">
+    <PopoverTrigger class="inline-flex items-center gap-2 h-9 px-3 rounded-lg border border-muted bg-card text-sm text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40">
+      <Icon
+        icon="lucide:calendar"
+        class="size-4 shrink-0 text-muted-foreground"
+      />
+      {{ label }}
+    </PopoverTrigger>
+
+    <PopoverPortal>
+      <PopoverContent
+        class="z-[100] rounded-xl border border-muted bg-card p-3 shadow-lg will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFade data-[side=top]:animate-slideDownAndFade"
+        :side-offset="6"
+        align="start"
+      >
+        <div class="flex flex-col gap-3 md:flex-row">
+          <div class="flex flex-row flex-wrap gap-1 md:w-36 md:flex-col md:border-r md:border-muted md:pr-3">
+            <button
+              v-for="preset in presets"
+              :key="preset.label"
+              type="button"
+              class="rounded-md px-2.5 py-1.5 text-left text-xs text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40"
+              :class="activePreset?.label === preset.label && 'bg-muted font-semibold'"
+              @click="applyPreset(preset)"
+            >
+              {{ preset.label }}
+            </button>
+          </div>
+
+          <RangeCalendarRoot
+            v-slot="{ weekDays, grid }"
+            v-model="value"
+            v-model:placeholder="placeholder"
+            class="select-none"
+            :number-of-months="isWide ? 2 : 1"
+            :max-value="today(getLocalTimeZone())"
+            paged-navigation
+            fixed-weeks
+          >
+            <RangeCalendarHeader class="flex items-center justify-between px-1">
+              <RangeCalendarPrev class="inline-flex size-7 items-center justify-center rounded-md text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40">
+                <Icon
+                  icon="lucide:chevron-left"
+                  class="size-4"
+                />
+              </RangeCalendarPrev>
+              <RangeCalendarHeading class="text-sm font-medium text-foreground" />
+              <RangeCalendarNext class="inline-flex size-7 items-center justify-center rounded-md text-foreground hover:bg-muted disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-primary/40">
+                <Icon
+                  icon="lucide:chevron-right"
+                  class="size-4"
+                />
+              </RangeCalendarNext>
+            </RangeCalendarHeader>
+
+            <div class="flex flex-col gap-4 pt-3 sm:flex-row">
+              <RangeCalendarGrid
+                v-for="month in grid"
+                :key="month.value.toString()"
+                class="w-full border-collapse"
+              >
+                <RangeCalendarGridHead>
+                  <RangeCalendarGridRow class="mb-1 grid w-full grid-cols-7">
+                    <RangeCalendarHeadCell
+                      v-for="day in weekDays"
+                      :key="day"
+                      class="text-[11px] font-normal text-muted-foreground"
+                    >
+                      {{ day }}
+                    </RangeCalendarHeadCell>
+                  </RangeCalendarGridRow>
+                </RangeCalendarGridHead>
+                <RangeCalendarGridBody class="grid">
+                  <RangeCalendarGridRow
+                    v-for="(weekDates, index) in month.rows"
+                    :key="`week-${index}`"
+                    class="grid grid-cols-7"
+                  >
+                    <RangeCalendarCell
+                      v-for="weekDate in weekDates"
+                      :key="weekDate.toString()"
+                      :date="weekDate"
+                    >
+                      <!-- `data-selected` covers every day inside the committed range;
+                           `data-highlighted` previews the range being dragged out. -->
+                      <RangeCalendarCellTrigger
+                        :day="weekDate"
+                        :month="month.value"
+                        class="flex h-8 w-full items-center justify-center rounded-md text-sm text-foreground outline-none hover:bg-muted focus:ring-2 focus:ring-primary/40 data-[outside-view]:text-muted-foreground/50 data-[disabled]:pointer-events-none data-[disabled]:opacity-40 data-[today]:font-semibold data-[highlighted]:bg-primary/10 data-[selected]:bg-primary/15 data-[selection-end]:!bg-primary data-[selection-start]:!bg-primary data-[selection-end]:text-primary-foreground data-[selection-start]:text-primary-foreground"
+                      />
+                    </RangeCalendarCell>
+                  </RangeCalendarGridRow>
+                </RangeCalendarGridBody>
+              </RangeCalendarGrid>
+            </div>
+          </RangeCalendarRoot>
+        </div>
+      </PopoverContent>
+    </PopoverPortal>
+  </PopoverRoot>
+</template>

--- a/docs/components/examples/DateRangePresets/presets.ts
+++ b/docs/components/examples/DateRangePresets/presets.ts
@@ -1,0 +1,71 @@
+import type { DateValue } from '@internationalized/date'
+import type { DateRange } from 'reka-ui'
+import { getLocalTimeZone, today } from '@internationalized/date'
+
+export interface Preset {
+  label: string
+  range: () => DateRange
+}
+
+function startOfMonth(date: DateValue) {
+  return date.set({ day: 1 })
+}
+
+/**
+ * Every preset is a function so the range is computed at click time — a page
+ * left open overnight must not hand out yesterday's "Today".
+ */
+export const presets: Preset[] = [
+  {
+    label: 'Today',
+    range: () => {
+      const now = today(getLocalTimeZone())
+      return { start: now, end: now }
+    },
+  },
+  {
+    label: 'Yesterday',
+    range: () => {
+      const yesterday = today(getLocalTimeZone()).subtract({ days: 1 })
+      return { start: yesterday, end: yesterday }
+    },
+  },
+  {
+    label: 'Last 7 days',
+    range: () => {
+      const now = today(getLocalTimeZone())
+      return { start: now.subtract({ days: 6 }), end: now }
+    },
+  },
+  {
+    label: 'Last 30 days',
+    range: () => {
+      const now = today(getLocalTimeZone())
+      return { start: now.subtract({ days: 29 }), end: now }
+    },
+  },
+  {
+    label: 'Month to date',
+    range: () => {
+      const now = today(getLocalTimeZone())
+      return { start: startOfMonth(now), end: now }
+    },
+  },
+  {
+    label: 'Last month',
+    range: () => {
+      const lastMonth = today(getLocalTimeZone()).subtract({ months: 1 })
+      return {
+        start: startOfMonth(lastMonth),
+        end: startOfMonth(lastMonth).add({ months: 1 }).subtract({ days: 1 }),
+      }
+    },
+  },
+  {
+    label: 'Year to date',
+    range: () => {
+      const now = today(getLocalTimeZone())
+      return { start: now.set({ month: 1, day: 1 }), end: now }
+    },
+  },
+]

--- a/docs/components/examples/DialogResponsiveDrawer/ProfileForm.vue
+++ b/docs/components/examples/DialogResponsiveDrawer/ProfileForm.vue
@@ -4,10 +4,10 @@ defineProps<{
   touch?: boolean
 }>()
 
-const fields = [
-  { id: 'name', label: 'Name', value: 'Pedro Duarte' },
-  { id: 'username', label: 'Username', value: '@peduarte' },
-]
+// The values live in the parent alongside `open`, so crossing the breakpoint —
+// which unmounts one root and mounts the other — does not discard what was typed.
+const name = defineModel<string>('name', { required: true })
+const username = defineModel<string>('username', { required: true })
 </script>
 
 <template>
@@ -15,15 +15,22 @@ const fields = [
     class="flex flex-col gap-3"
     @submit.prevent
   >
-    <label
-      v-for="field in fields"
-      :key="field.id"
-      class="flex flex-col gap-1.5 text-sm"
-    >
-      <span class="font-medium text-foreground">{{ field.label }}</span>
+    <label class="flex flex-col gap-1.5 text-sm">
+      <span class="font-medium text-foreground">Name</span>
       <input
-        :name="field.id"
-        :value="field.value"
+        v-model="name"
+        name="name"
+        autocomplete="name"
+        class="rounded-lg border border-muted bg-background px-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-primary/40"
+        :class="touch ? 'h-11' : 'h-9'"
+      >
+    </label>
+    <label class="flex flex-col gap-1.5 text-sm">
+      <span class="font-medium text-foreground">Username</span>
+      <input
+        v-model="username"
+        name="username"
+        autocomplete="username"
         class="rounded-lg border border-muted bg-background px-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-primary/40"
         :class="touch ? 'h-11' : 'h-9'"
       >

--- a/docs/components/examples/DialogResponsiveDrawer/ProfileForm.vue
+++ b/docs/components/examples/DialogResponsiveDrawer/ProfileForm.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+defineProps<{
+  /** Drawers get roomier controls because they are driven by touch. */
+  touch?: boolean
+}>()
+
+const fields = [
+  { id: 'name', label: 'Name', value: 'Pedro Duarte' },
+  { id: 'username', label: 'Username', value: '@peduarte' },
+]
+</script>
+
+<template>
+  <form
+    class="flex flex-col gap-3"
+    @submit.prevent
+  >
+    <label
+      v-for="field in fields"
+      :key="field.id"
+      class="flex flex-col gap-1.5 text-sm"
+    >
+      <span class="font-medium text-foreground">{{ field.label }}</span>
+      <input
+        :name="field.id"
+        :value="field.value"
+        class="rounded-lg border border-muted bg-background px-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-primary/40"
+        :class="touch ? 'h-11' : 'h-9'"
+      >
+    </label>
+  </form>
+</template>

--- a/docs/components/examples/DialogResponsiveDrawer/index.vue
+++ b/docs/components/examples/DialogResponsiveDrawer/index.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { useMediaQuery } from '@vueuse/core'
 import { DialogClose, DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogRoot, DialogTitle, DialogTrigger, DrawerClose, DrawerContent, DrawerDescription, DrawerHandle, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTitle, DrawerTrigger } from 'reka-ui'
-import { ref } from 'vue'
+import { reactive, ref } from 'vue'
 import ProfileForm from './ProfileForm.vue'
 
-// Resize the window across 640px to swap the presentation. `open` lives outside
-// both roots, so the sheet stays open through the switch.
+// Resize the window across 640px to swap the presentation. `open` and the form
+// values live outside both roots, so neither the sheet nor what was typed into
+// it is lost when one root is unmounted and the other takes over.
 const isDesktop = useMediaQuery('(min-width: 640px)')
 const open = ref(false)
+const profile = reactive({ name: 'Pedro Duarte', username: '@peduarte' })
 
 const triggerClass = 'inline-flex items-center h-9 px-4 rounded-lg border border-muted bg-card text-sm font-medium text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40'
 </script>
@@ -31,7 +33,10 @@ const triggerClass = 'inline-flex items-center h-9 px-4 rounded-lg border border
             Make changes to your profile here. Click save when you're done.
           </DialogDescription>
 
-          <ProfileForm />
+          <ProfileForm
+            v-model:name="profile.name"
+            v-model:username="profile.username"
+          />
 
           <div class="mt-5 flex justify-end">
             <DialogClose :class="triggerClass">
@@ -61,7 +66,11 @@ const triggerClass = 'inline-flex items-center h-9 px-4 rounded-lg border border
               Make changes to your profile here. Swipe down or tap save when you're done.
             </DrawerDescription>
 
-            <ProfileForm touch />
+            <ProfileForm
+              v-model:name="profile.name"
+              v-model:username="profile.username"
+              touch
+            />
 
             <div class="mt-5 flex justify-end">
               <DrawerClose :class="triggerClass">
@@ -74,7 +83,8 @@ const triggerClass = 'inline-flex items-center h-9 px-4 rounded-lg border border
     </DrawerRoot>
 
     <p class="text-xs text-muted-foreground">
-      Currently rendering as a {{ isDesktop ? 'dialog' : 'drawer' }} — resize the window to swap.
+      {{ profile.name }} ({{ profile.username }}) — currently a
+      {{ isDesktop ? 'dialog' : 'drawer' }}, resize the window to swap.
     </p>
   </div>
 </template>

--- a/docs/components/examples/DialogResponsiveDrawer/index.vue
+++ b/docs/components/examples/DialogResponsiveDrawer/index.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { useMediaQuery } from '@vueuse/core'
+import { DialogClose, DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogRoot, DialogTitle, DialogTrigger, DrawerClose, DrawerContent, DrawerDescription, DrawerHandle, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTitle, DrawerTrigger } from 'reka-ui'
+import { ref } from 'vue'
+import ProfileForm from './ProfileForm.vue'
+
+// Resize the window across 640px to swap the presentation. `open` lives outside
+// both roots, so the sheet stays open through the switch.
+const isDesktop = useMediaQuery('(min-width: 640px)')
+const open = ref(false)
+
+const triggerClass = 'inline-flex items-center h-9 px-4 rounded-lg border border-muted bg-card text-sm font-medium text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40'
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-3">
+    <DialogRoot
+      v-if="isDesktop"
+      v-model:open="open"
+    >
+      <DialogTrigger :class="triggerClass">
+        Edit profile
+      </DialogTrigger>
+      <DialogPortal>
+        <DialogOverlay class="fixed inset-0 z-30 bg-background/80 data-[state=open]:animate-overlayShow" />
+        <DialogContent class="fixed z-[100] top-1/2 left-1/2 w-[90vw] max-w-[26rem] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-muted bg-card p-6 focus:outline-none data-[state=open]:animate-contentShow">
+          <DialogTitle class="text-base font-semibold text-foreground">
+            Edit profile
+          </DialogTitle>
+          <DialogDescription class="mt-1 mb-4 text-sm text-muted-foreground">
+            Make changes to your profile here. Click save when you're done.
+          </DialogDescription>
+
+          <ProfileForm />
+
+          <div class="mt-5 flex justify-end">
+            <DialogClose :class="triggerClass">
+              Save changes
+            </DialogClose>
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </DialogRoot>
+
+    <DrawerRoot
+      v-else
+      v-model:open="open"
+    >
+      <DrawerTrigger :class="triggerClass">
+        Edit profile
+      </DrawerTrigger>
+      <DrawerPortal>
+        <DrawerOverlay class="ResponsiveDrawerOverlay fixed inset-0 z-30 bg-background/80" />
+        <DrawerContent class="ResponsiveDrawerContent fixed inset-x-0 bottom-0 z-[100] mx-auto flex max-w-[500px] flex-col rounded-t-2xl border-t border-muted bg-card outline-none">
+          <DrawerHandle class="mx-auto mt-3 h-1.5 w-12 shrink-0 rounded-full bg-muted-foreground/40" />
+          <div class="p-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))]">
+            <DrawerTitle class="text-base font-semibold text-foreground">
+              Edit profile
+            </DrawerTitle>
+            <DrawerDescription class="mt-1 mb-4 text-sm text-muted-foreground">
+              Make changes to your profile here. Swipe down or tap save when you're done.
+            </DrawerDescription>
+
+            <ProfileForm touch />
+
+            <div class="mt-5 flex justify-end">
+              <DrawerClose :class="triggerClass">
+                Save changes
+              </DrawerClose>
+            </div>
+          </div>
+        </DrawerContent>
+      </DrawerPortal>
+    </DrawerRoot>
+
+    <p class="text-xs text-muted-foreground">
+      Currently rendering as a {{ isDesktop ? 'dialog' : 'drawer' }} — resize the window to swap.
+    </p>
+  </div>
+</template>
+
+<!--
+  Not scoped: DrawerPortal teleports these elements to `body`, out of reach of a
+  `scoped` block. They drive the slide animation and the live swipe transform,
+  which utility classes cannot express.
+-->
+<style>
+.ResponsiveDrawerOverlay[data-state="open"] {
+  animation: responsive-drawer-overlay-in 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.ResponsiveDrawerOverlay[data-state="closed"] {
+  animation: responsive-drawer-overlay-out 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.ResponsiveDrawerContent {
+  /* `--drawer-swipe-movement-y` is written by DrawerContent while dragging. */
+  transform: translateY(var(--drawer-swipe-movement-y, 0px));
+  transition: transform 450ms cubic-bezier(0.32, 0.72, 0, 1);
+  will-change: transform;
+}
+/* Enter/exit animate the independent `translate` property so they compose with
+   the inline `transform` carrying the live drag offset. */
+.ResponsiveDrawerContent[data-state="open"] {
+  animation: responsive-drawer-slide-in 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.ResponsiveDrawerContent[data-state="closed"] {
+  animation: responsive-drawer-slide-out 450ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.ResponsiveDrawerContent[data-swiping] {
+  transition-duration: 0ms;
+  user-select: none;
+}
+
+@keyframes responsive-drawer-overlay-in { from { opacity: 0; } }
+@keyframes responsive-drawer-overlay-out { to { opacity: 0; } }
+@keyframes responsive-drawer-slide-in { from { translate: 0 100%; } }
+@keyframes responsive-drawer-slide-out { to { translate: 0 100%; } }
+</style>

--- a/docs/components/examples/PinInputOtp/index.vue
+++ b/docs/components/examples/PinInputOtp/index.vue
@@ -125,7 +125,7 @@ async function verify(value: number[]) {
     <button
       type="button"
       class="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline disabled:no-underline disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-primary/40 rounded"
-      :disabled="secondsLeft > 0"
+      :disabled="secondsLeft > 0 || status === 'verifying'"
       @click="resend"
     >
       {{ secondsLeft > 0 ? `Resend code in ${secondsLeft}s` : 'Resend code' }}

--- a/docs/components/examples/PinInputOtp/index.vue
+++ b/docs/components/examples/PinInputOtp/index.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { useIntervalFn } from '@vueuse/core'
+import { Label, PinInputInput, PinInputRoot } from 'reka-ui'
+import { onMounted, ref } from 'vue'
+
+/** The one code this demo accepts. A real app would ask the server. */
+const VALID_CODE = '123456'
+const RESEND_SECONDS = 30
+
+type Status = 'idle' | 'verifying' | 'error' | 'success'
+
+const code = ref<number[]>([])
+const status = ref<Status>('idle')
+const container = ref<HTMLElement>()
+
+const secondsLeft = ref(0)
+const { pause, resume } = useIntervalFn(() => {
+  secondsLeft.value -= 1
+  if (secondsLeft.value <= 0)
+    pause()
+}, 1000, { immediate: false })
+
+function startCountdown() {
+  secondsLeft.value = RESEND_SECONDS
+  resume()
+}
+
+onMounted(startCountdown)
+
+function resend() {
+  code.value = []
+  status.value = 'idle'
+  startCountdown()
+  container.value?.querySelector('input')?.focus()
+}
+
+// `@complete` fires once every slot is filled — including on paste, which is
+// what makes auto-submit feel instant rather than requiring a button.
+async function verify(value: number[]) {
+  status.value = 'verifying'
+  await new Promise(resolve => setTimeout(resolve, 900))
+
+  if (value.join('') === VALID_CODE) {
+    status.value = 'success'
+    return
+  }
+
+  status.value = 'error'
+  code.value = []
+  container.value?.querySelector('input')?.focus()
+}
+</script>
+
+<template>
+  <div
+    ref="container"
+    class="flex w-[320px] flex-col items-center gap-4 rounded-xl border border-muted bg-card p-6 text-center"
+  >
+    <Icon
+      icon="lucide:shield-check"
+      class="size-7 text-muted-foreground"
+    />
+    <div>
+      <Label
+        for="otp"
+        class="block text-sm font-medium text-foreground"
+      >
+        Verify your device
+      </Label>
+      <p class="mt-1 text-xs text-muted-foreground">
+        Enter the 6-digit code we sent you. Try <code class="font-mono">123456</code>.
+      </p>
+    </div>
+
+    <PinInputRoot
+      id="otp"
+      v-model="code"
+      class="OtpRoot flex gap-2"
+      :class="status === 'error' && 'OtpRoot--error'"
+      :disabled="status === 'verifying' || status === 'success'"
+      placeholder="○"
+      type="number"
+      otp
+      @complete="verify"
+    >
+      <PinInputInput
+        v-for="(id, index) in 6"
+        :key="id"
+        :index="index"
+        class="size-10 rounded-lg border bg-background text-center text-base text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-2 focus:ring-primary/40 disabled:opacity-60"
+        :class="status === 'error' ? 'border-destructive' : 'border-muted'"
+      />
+    </PinInputRoot>
+
+    <p
+      class="flex h-5 items-center gap-1.5 text-xs"
+      role="status"
+      aria-live="polite"
+      :class="status === 'error' ? 'text-destructive' : status === 'success' ? 'text-grass11' : 'text-muted-foreground'"
+    >
+      <template v-if="status === 'verifying'">
+        <Icon
+          icon="lucide:loader-circle"
+          class="size-3.5 animate-spin"
+        />
+        Verifying…
+      </template>
+      <template v-else-if="status === 'error'">
+        <Icon
+          icon="lucide:circle-alert"
+          class="size-3.5"
+        />
+        That code was not right. Try again.
+      </template>
+      <template v-else-if="status === 'success'">
+        <Icon
+          icon="lucide:circle-check"
+          class="size-3.5"
+        />
+        Device verified.
+      </template>
+    </p>
+
+    <button
+      type="button"
+      class="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline disabled:no-underline disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-primary/40 rounded"
+      :disabled="secondsLeft > 0"
+      @click="resend"
+    >
+      {{ secondsLeft > 0 ? `Resend code in ${secondsLeft}s` : 'Resend code' }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+/* Re-triggering the shake on every failure needs the class to be added fresh,
+   which is exactly what toggling `status` does. */
+.OtpRoot--error {
+  animation: otp-shake 400ms cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}
+
+@keyframes otp-shake {
+  10%, 90% { transform: translateX(-2px); }
+  20%, 80% { transform: translateX(4px); }
+  30%, 50%, 70% { transform: translateX(-6px); }
+  40%, 60% { transform: translateX(6px); }
+}
+</style>

--- a/docs/components/examples/SplitterIdeLayout/index.vue
+++ b/docs/components/examples/SplitterIdeLayout/index.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { SplitterGroup, SplitterPanel, SplitterResizeHandle } from 'reka-ui'
+import { ref } from 'vue'
+
+const files = [
+  { name: 'app.vue', icon: 'lucide:file-code' },
+  { name: 'router.ts', icon: 'lucide:file-code' },
+  { name: 'store.ts', icon: 'lucide:file-code' },
+  { name: 'main.css', icon: 'lucide:file-type' },
+  { name: 'README.md', icon: 'lucide:file-text' },
+]
+
+const sidebar = ref<InstanceType<typeof SplitterPanel>>()
+const terminal = ref<InstanceType<typeof SplitterPanel>>()
+
+/** `collapse()`/`expand()` remember the size the panel had before collapsing. */
+function toggle(panel?: InstanceType<typeof SplitterPanel>) {
+  if (!panel)
+    return
+  if (panel.isCollapsed)
+    panel.expand()
+  else
+    panel.collapse()
+}
+
+const railButtonClass = 'grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40'
+</script>
+
+<template>
+  <div class="flex h-[340px] w-full max-w-[640px] flex-col overflow-hidden rounded-xl border border-muted bg-card text-sm">
+    <div class="flex items-center gap-1 border-b border-muted px-2 py-1.5">
+      <button
+        type="button"
+        :class="railButtonClass"
+        aria-label="Toggle sidebar"
+        @click="toggle(sidebar)"
+      >
+        <Icon
+          icon="lucide:panel-left"
+          class="size-4"
+        />
+      </button>
+      <button
+        type="button"
+        :class="railButtonClass"
+        aria-label="Toggle terminal"
+        @click="toggle(terminal)"
+      >
+        <Icon
+          icon="lucide:panel-bottom"
+          class="size-4"
+        />
+      </button>
+      <span class="ml-2 truncate text-xs text-muted-foreground">
+        Layout is restored from <code class="font-mono">localStorage</code> on reload
+      </span>
+    </div>
+
+    <!-- `auto-save-id` writes the panel sizes to localStorage and reads them
+         back on mount, so a refresh does not throw the layout away. -->
+    <SplitterGroup
+      id="reka-ide"
+      class="flex-1"
+      direction="horizontal"
+      auto-save-id="reka-example-ide"
+    >
+      <SplitterPanel
+        id="reka-ide-sidebar"
+        ref="sidebar"
+        :default-size="28"
+        :min-size="16"
+        :collapsed-size="0"
+        collapsible
+        class="overflow-hidden"
+      >
+        <div class="h-full overflow-y-auto p-2">
+          <p class="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Explorer
+          </p>
+          <ul>
+            <li
+              v-for="file in files"
+              :key="file.name"
+              class="flex items-center gap-2 rounded-md px-2 py-1 text-xs text-foreground hover:bg-muted"
+            >
+              <Icon
+                :icon="file.icon"
+                class="size-3.5 shrink-0 text-muted-foreground"
+              />
+              <span class="truncate">{{ file.name }}</span>
+            </li>
+          </ul>
+        </div>
+      </SplitterPanel>
+
+      <SplitterResizeHandle
+        id="reka-ide-handle-x"
+        class="group relative w-px bg-muted data-[state=drag]:bg-primary"
+      >
+        <span class="absolute inset-y-0 -left-1 -right-1 group-hover:bg-primary/20" />
+      </SplitterResizeHandle>
+
+      <SplitterPanel
+        id="reka-ide-main"
+        :min-size="30"
+      >
+        <SplitterGroup
+          id="reka-ide-main-group"
+          direction="vertical"
+          auto-save-id="reka-example-ide-main"
+        >
+          <SplitterPanel
+            id="reka-ide-editor"
+            :default-size="68"
+            :min-size="25"
+            class="overflow-hidden"
+          >
+            <!-- `v-pre` keeps Vue from treating the sample's mustaches as interpolation. -->
+            <pre
+              v-pre
+              class="h-full overflow-auto p-3 font-mono text-xs leading-relaxed text-muted-foreground"
+            ><span class="text-foreground">&lt;script setup&gt;</span>
+import { ref } from 'vue'
+
+const count = ref(0)
+<span class="text-foreground">&lt;/script&gt;</span>
+
+<span class="text-foreground">&lt;template&gt;</span>
+  &lt;button @click="count++"&gt;
+    {{ count }}
+  &lt;/button&gt;
+<span class="text-foreground">&lt;/template&gt;</span></pre>
+          </SplitterPanel>
+
+          <SplitterResizeHandle
+            id="reka-ide-handle-y"
+            class="group relative h-px bg-muted data-[state=drag]:bg-primary"
+          >
+            <span class="absolute inset-x-0 -top-1 -bottom-1 group-hover:bg-primary/20" />
+          </SplitterResizeHandle>
+
+          <SplitterPanel
+            id="reka-ide-terminal"
+            ref="terminal"
+            :default-size="32"
+            :min-size="15"
+            :collapsed-size="0"
+            collapsible
+            class="overflow-hidden"
+          >
+            <div class="h-full overflow-auto bg-muted/40 p-3 font-mono text-xs text-muted-foreground">
+              <p class="text-foreground">
+                $ pnpm dev
+              </p>
+              <p>VITE v6.0.0  ready in 231 ms</p>
+              <p>➜  Local:   http://localhost:5173/</p>
+            </div>
+          </SplitterPanel>
+        </SplitterGroup>
+      </SplitterPanel>
+    </SplitterGroup>
+  </div>
+</template>

--- a/docs/components/examples/StepperFormWizard/index.vue
+++ b/docs/components/examples/StepperFormWizard/index.vue
@@ -1,0 +1,238 @@
+<script setup lang="ts">
+import type { WizardForm } from './schema'
+import { Icon } from '@iconify/vue'
+import { DialogClose, DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogRoot, DialogTitle, DialogTrigger, StepperIndicator, StepperItem, StepperRoot, StepperSeparator, StepperTitle, StepperTrigger } from 'reka-ui'
+import { computed, reactive, ref } from 'vue'
+import { validators } from './schema'
+
+const steps = [
+  { step: 1, title: 'Account' },
+  { step: 2, title: 'Profile' },
+  { step: 3, title: 'Review' },
+]
+
+const open = ref(false)
+const currentStep = ref(1)
+const submitted = ref(false)
+// Errors only surface once the user has tried to move on, so a pristine form
+// does not greet them in red.
+const showErrors = ref(false)
+
+const form = reactive<WizardForm>({ email: '', password: '', name: '', username: '' })
+
+const errors = computed(() => validators[currentStep.value](form))
+
+function isStepComplete(step: number) {
+  return Object.keys(validators[step](form)).length === 0
+}
+
+/** A step is reachable only once every step before it validates. */
+function canReach(step: number) {
+  return steps.slice(0, step - 1).every(item => isStepComplete(item.step))
+}
+
+function goNext(nextStep: () => void) {
+  if (Object.keys(errors.value).length) {
+    showErrors.value = true
+    return
+  }
+  showErrors.value = false
+  nextStep()
+}
+
+function goPrev(prevStep: () => void) {
+  showErrors.value = false
+  prevStep()
+}
+
+function reset() {
+  Object.assign(form, { email: '', password: '', name: '', username: '' })
+  currentStep.value = 1
+  showErrors.value = false
+  submitted.value = false
+}
+
+const fieldClass = 'h-9 w-full rounded-lg border border-muted bg-background px-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-primary/40'
+</script>
+
+<template>
+  <DialogRoot
+    v-model:open="open"
+    @update:open="$event && reset()"
+  >
+    <DialogTrigger class="inline-flex h-9 items-center rounded-lg border border-muted bg-card px-4 text-sm font-medium text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40">
+      Create account
+    </DialogTrigger>
+
+    <DialogPortal>
+      <DialogOverlay class="fixed inset-0 z-30 bg-background/80 data-[state=open]:animate-overlayShow" />
+      <DialogContent class="fixed left-1/2 top-1/2 z-[100] w-[90vw] max-w-[28rem] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-muted bg-card p-6 focus:outline-none data-[state=open]:animate-contentShow">
+        <DialogTitle class="text-base font-semibold text-foreground">
+          Create account
+        </DialogTitle>
+        <DialogDescription class="mt-1 text-sm text-muted-foreground">
+          Three short steps. You can go back at any point.
+        </DialogDescription>
+
+        <div
+          v-if="submitted"
+          class="mt-6 flex flex-col items-center gap-3 py-8 text-center"
+        >
+          <Icon
+            icon="lucide:circle-check"
+            class="size-8 text-primary"
+          />
+          <p class="text-sm text-foreground">
+            Welcome, {{ form.name }}.
+          </p>
+          <DialogClose class="mt-2 inline-flex h-9 items-center rounded-lg border border-muted px-4 text-sm text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40">
+            Done
+          </DialogClose>
+        </div>
+
+        <StepperRoot
+          v-else
+          v-slot="{ nextStep, prevStep, isFirstStep, isLastStep }"
+          v-model="currentStep"
+          class="mt-6"
+          linear
+        >
+          <div class="flex w-full">
+            <StepperItem
+              v-for="item in steps"
+              :key="item.step"
+              v-slot="{ state }"
+              class="group relative flex flex-1 flex-col items-center gap-2"
+              :step="item.step"
+              :disabled="!canReach(item.step)"
+            >
+              <StepperTrigger class="z-10 inline-flex size-8 shrink-0 items-center justify-center rounded-full border-2 border-muted bg-card text-xs font-semibold text-muted-foreground group-data-[state=active]:border-primary group-data-[state=active]:text-primary group-data-[state=completed]:border-primary group-data-[state=completed]:bg-primary group-data-[state=completed]:text-primary-foreground group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-50 focus:outline-none focus:ring-2 focus:ring-primary/40">
+                <StepperIndicator>
+                  <Icon
+                    v-if="state === 'completed'"
+                    icon="lucide:check"
+                    class="size-4"
+                  />
+                  <template v-else>
+                    {{ item.step }}
+                  </template>
+                </StepperIndicator>
+              </StepperTrigger>
+
+              <StepperSeparator
+                v-if="item.step !== steps.length"
+                class="absolute left-[calc(50%+1.25rem)] right-[calc(-50%+1.25rem)] top-4 h-0.5 rounded-full bg-muted group-data-[state=completed]:bg-primary"
+              />
+
+              <StepperTitle class="text-xs text-muted-foreground group-data-[state=active]:font-semibold group-data-[state=active]:text-foreground">
+                {{ item.title }}
+              </StepperTitle>
+            </StepperItem>
+          </div>
+
+          <form
+            class="mt-6 flex min-h-[9.5rem] flex-col gap-3"
+            @submit.prevent="isLastStep ? (submitted = true) : goNext(nextStep)"
+          >
+            <template v-if="currentStep === 1">
+              <label class="flex flex-col gap-1.5 text-sm">
+                <span class="font-medium text-foreground">Email</span>
+                <input
+                  v-model="form.email"
+                  type="email"
+                  autocomplete="email"
+                  :class="fieldClass"
+                >
+                <span
+                  v-if="showErrors && errors.email"
+                  class="text-xs text-destructive"
+                >{{ errors.email }}</span>
+              </label>
+              <label class="flex flex-col gap-1.5 text-sm">
+                <span class="font-medium text-foreground">Password</span>
+                <input
+                  v-model="form.password"
+                  type="password"
+                  autocomplete="new-password"
+                  :class="fieldClass"
+                >
+                <span
+                  v-if="showErrors && errors.password"
+                  class="text-xs text-destructive"
+                >{{ errors.password }}</span>
+              </label>
+            </template>
+
+            <template v-else-if="currentStep === 2">
+              <label class="flex flex-col gap-1.5 text-sm">
+                <span class="font-medium text-foreground">Full name</span>
+                <input
+                  v-model="form.name"
+                  autocomplete="name"
+                  :class="fieldClass"
+                >
+                <span
+                  v-if="showErrors && errors.name"
+                  class="text-xs text-destructive"
+                >{{ errors.name }}</span>
+              </label>
+              <label class="flex flex-col gap-1.5 text-sm">
+                <span class="font-medium text-foreground">Username</span>
+                <input
+                  v-model="form.username"
+                  autocomplete="username"
+                  :class="fieldClass"
+                >
+                <span
+                  v-if="showErrors && errors.username"
+                  class="text-xs text-destructive"
+                >{{ errors.username }}</span>
+              </label>
+            </template>
+
+            <dl
+              v-else
+              class="grid grid-cols-[7rem_1fr] gap-y-2 text-sm"
+            >
+              <dt class="text-muted-foreground">
+                Email
+              </dt>
+              <dd class="truncate text-foreground">
+                {{ form.email }}
+              </dd>
+              <dt class="text-muted-foreground">
+                Name
+              </dt>
+              <dd class="truncate text-foreground">
+                {{ form.name }}
+              </dd>
+              <dt class="text-muted-foreground">
+                Username
+              </dt>
+              <dd class="truncate text-foreground">
+                {{ form.username }}
+              </dd>
+            </dl>
+
+            <div class="mt-auto flex items-center justify-between pt-4">
+              <button
+                type="button"
+                class="inline-flex h-9 items-center rounded-lg px-3 text-sm text-muted-foreground hover:text-foreground disabled:invisible focus:outline-none focus:ring-2 focus:ring-primary/40"
+                :disabled="isFirstStep"
+                @click="goPrev(prevStep)"
+              >
+                Back
+              </button>
+              <button
+                type="submit"
+                class="inline-flex h-9 items-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary/40"
+              >
+                {{ isLastStep ? 'Create account' : 'Next' }}
+              </button>
+            </div>
+          </form>
+        </StepperRoot>
+      </DialogContent>
+    </DialogPortal>
+  </DialogRoot>
+</template>

--- a/docs/components/examples/StepperFormWizard/schema.ts
+++ b/docs/components/examples/StepperFormWizard/schema.ts
@@ -1,0 +1,36 @@
+export interface WizardForm {
+  email: string
+  password: string
+  name: string
+  username: string
+}
+
+export type Errors = Partial<Record<keyof WizardForm, string>>
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const USERNAME_RE = /^\w{3,}$/
+
+/**
+ * One validator per step, each returning the errors for *its own* fields.
+ * Keeping them separate is what lets the wizard gate `Next` on the current step
+ * while still checking every earlier step before allowing a jump forward.
+ */
+export const validators: Record<number, (form: WizardForm) => Errors> = {
+  1: (form) => {
+    const errors: Errors = {}
+    if (!EMAIL_RE.test(form.email))
+      errors.email = 'Enter a valid email address'
+    if (form.password.length < 8)
+      errors.password = 'Use at least 8 characters'
+    return errors
+  },
+  2: (form) => {
+    const errors: Errors = {}
+    if (!form.name.trim())
+      errors.name = 'Name is required'
+    if (!USERNAME_RE.test(form.username))
+      errors.username = 'At least 3 letters, numbers or underscores'
+    return errors
+  },
+  3: () => ({}),
+}

--- a/docs/components/examples/ToastUndo/index.vue
+++ b/docs/components/examples/ToastUndo/index.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { ToastAction, ToastClose, ToastDescription, ToastProvider, ToastRoot, ToastTitle, ToastViewport } from 'reka-ui'
+import { ref } from 'vue'
+
+interface Mail {
+  id: number
+  from: string
+  subject: string
+  /** Stands in for a server that rejects the write — the row comes back. */
+  locked?: boolean
+}
+
+interface Notification {
+  id: number
+  kind: 'undo' | 'error'
+  mail: Mail
+  open: boolean
+  paused: boolean
+  undone: boolean
+}
+
+const DURATION = 5000
+
+const INBOX: Mail[] = [
+  { id: 1, from: 'Ada Lovelace', subject: 'Analytical engine notes' },
+  { id: 2, from: 'Grace Hopper', subject: 'Compiler review, round two' },
+  { id: 3, from: 'Billing', subject: 'Invoice #4821', locked: true },
+  { id: 4, from: 'Radia Perlman', subject: 'Spanning tree rollout' },
+]
+
+const inbox = ref<Mail[]>([...INBOX])
+const notifications = ref<Notification[]>([])
+let nextId = 0
+
+function notify(kind: Notification['kind'], mail: Mail) {
+  notifications.value.push({ id: ++nextId, kind, mail, open: true, paused: false, undone: false })
+}
+
+function restore(mail: Mail) {
+  inbox.value = [...inbox.value, mail].sort((a, b) => a.id - b.id)
+}
+
+function archive(mail: Mail) {
+  // Optimistic: the row leaves immediately and the toast owns the rollback.
+  inbox.value = inbox.value.filter(item => item.id !== mail.id)
+  notify('undo', mail)
+}
+
+function undo(notification: Notification) {
+  // `ToastAction` closes the toast itself, so this only has to record that the
+  // rollback happened — `handleOpenChange` reads the flag a tick later.
+  notification.undone = true
+  restore(notification.mail)
+}
+
+async function commit(mail: Mail) {
+  await new Promise(resolve => setTimeout(resolve, 600))
+  if (mail.locked) {
+    restore(mail)
+    notify('error', mail)
+  }
+}
+
+function handleOpenChange(notification: Notification, open: boolean) {
+  notification.open = open
+  if (open)
+    return
+
+  // Deferred so the decision does not depend on whether this handler or the
+  // Undo button's own click handler ran first — by now `undone` is settled.
+  // It also lets the exit animation finish before the node is dropped.
+  setTimeout(() => {
+    // The toast closing without an undo *is* the commit signal.
+    if (notification.kind === 'undo' && !notification.undone)
+      commit(notification.mail)
+
+    notifications.value = notifications.value.filter(item => item.id !== notification.id)
+  }, 200)
+}
+</script>
+
+<template>
+  <ToastProvider
+    :duration="DURATION"
+    swipe-direction="right"
+  >
+    <div class="w-[340px] rounded-xl border border-muted bg-card p-2">
+      <ul
+        v-if="inbox.length"
+        class="flex flex-col"
+      >
+        <li
+          v-for="mail in inbox"
+          :key="mail.id"
+          class="group flex items-center gap-3 rounded-lg px-3 py-2.5 hover:bg-muted"
+        >
+          <span class="min-w-0 flex-1">
+            <span class="block truncate text-sm font-medium text-foreground">{{ mail.subject }}</span>
+            <span class="block truncate text-xs text-muted-foreground">{{ mail.from }}</span>
+          </span>
+          <button
+            type="button"
+            class="shrink-0 rounded-md p-1.5 text-muted-foreground opacity-0 transition hover:bg-background hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-primary/40 group-hover:opacity-100"
+            :aria-label="`Archive ${mail.subject}`"
+            @click="archive(mail)"
+          >
+            <Icon
+              icon="lucide:archive"
+              class="size-4"
+            />
+          </button>
+        </li>
+      </ul>
+      <div
+        v-else
+        class="flex flex-col items-center gap-3 px-3 py-8 text-sm text-muted-foreground"
+      >
+        Inbox zero.
+        <button
+          type="button"
+          class="rounded-md border border-muted px-3 py-1.5 text-xs text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40"
+          @click="inbox = [...INBOX]"
+        >
+          Refill inbox
+        </button>
+      </div>
+    </div>
+
+    <ToastRoot
+      v-for="notification in notifications"
+      :key="notification.id"
+      class="ToastRoot relative grid grid-cols-[auto_max-content] items-center gap-x-3 overflow-hidden rounded-lg border border-muted bg-card p-3.5 shadow-lg data-[state=open]:animate-slideIn data-[state=closed]:animate-hide data-[swipe=move]:translate-x-[var(--reka-toast-swipe-move-x)] data-[swipe=cancel]:translate-x-0 data-[swipe=cancel]:transition-[transform_200ms_ease-out] data-[swipe=end]:animate-swipeOut"
+      :open="notification.open"
+      :type="notification.kind === 'error' ? 'foreground' : 'background'"
+      :data-paused="notification.paused || undefined"
+      :style="{ '--toast-duration': `${DURATION}ms` }"
+      @update:open="handleOpenChange(notification, $event)"
+      @pause="notification.paused = true"
+      @resume="notification.paused = false"
+    >
+      <ToastTitle class="text-sm font-medium text-foreground">
+        {{ notification.kind === 'error' ? 'Could not archive' : 'Archived' }}
+      </ToastTitle>
+      <ToastDescription class="col-start-1 text-xs text-muted-foreground">
+        {{ notification.mail.subject }}
+      </ToastDescription>
+
+      <ToastAction
+        v-if="notification.kind === 'undo'"
+        class="col-start-2 row-span-2 row-start-1"
+        as-child
+        alt-text="Undo archiving this message"
+      >
+        <button
+          class="rounded-md border border-muted px-2.5 py-1.5 text-xs font-medium text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40"
+          @click="undo(notification)"
+        >
+          Undo
+        </button>
+      </ToastAction>
+      <ToastClose
+        v-else
+        class="col-start-2 row-span-2 row-start-1 rounded-md p-1.5 text-muted-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/40"
+        aria-label="Dismiss"
+      >
+        <Icon
+          icon="lucide:x"
+          class="size-4"
+        />
+      </ToastClose>
+
+      <!-- The bar is a plain CSS animation over the same duration, so it never
+           drifts from the dismiss timer. `@pause`/`@resume` fire when the pointer
+           enters the viewport or the window blurs — freezing both together. -->
+      <span
+        class="ToastCountdown absolute inset-x-0 bottom-0 h-0.5 origin-left"
+        :class="notification.kind === 'error' ? 'bg-destructive' : 'bg-primary'"
+      />
+    </ToastRoot>
+
+    <ToastViewport class="ToastViewport fixed bottom-0 right-0 z-[2147483647] m-0 flex w-[380px] max-w-[100vw] list-none flex-col gap-2.5 p-6 outline-none" />
+  </ToastProvider>
+</template>
+
+<style scoped>
+.ToastCountdown {
+  animation: toast-countdown var(--toast-duration) linear forwards;
+}
+
+.ToastRoot[data-paused] .ToastCountdown {
+  animation-play-state: paused;
+}
+
+@keyframes toast-countdown {
+  from { transform: scaleX(1); }
+  to { transform: scaleX(0); }
+}
+
+/* `--viewport-padding` is read by the slideIn/swipeOut keyframes. */
+.ToastViewport {
+  --viewport-padding: 24px;
+}
+</style>

--- a/docs/components/examples/ToastUndo/index.vue
+++ b/docs/components/examples/ToastUndo/index.vue
@@ -38,6 +38,10 @@ function notify(kind: Notification['kind'], mail: Mail) {
 }
 
 function restore(mail: Mail) {
+  // "Refill inbox" can put a message back while its undo toast is still up, so
+  // a later rollback must not append a second row with the same id.
+  if (inbox.value.some(item => item.id === mail.id))
+    return
   inbox.value = [...inbox.value, mail].sort((a, b) => a.id - b.id)
 }
 

--- a/docs/components/examples/ToolbarRichText/index.vue
+++ b/docs/components/examples/ToolbarRichText/index.vue
@@ -26,6 +26,16 @@ const activeMarks = ref<string[]>(['bold'])
 const alignment = ref('left')
 const block = ref('p')
 
+/**
+ * A single-mode ToggleGroup clears its value when the active item is clicked
+ * again. Text is always aligned somehow, so the empty state is dropped rather
+ * than left to fall through to `previewClass`.
+ */
+function setAlignment(value: string | undefined) {
+  if (value)
+    alignment.value = value
+}
+
 // The preview is what turns a toolbar of toggles into something you can read
 // the state off — every control here changes the paragraph below it.
 const previewClass = computed(() => [
@@ -123,10 +133,11 @@ const itemClass = 'inline-flex size-8 shrink-0 items-center justify-center round
         <ToolbarSeparator class="mx-1 h-6 w-px bg-muted" />
 
         <ToolbarToggleGroup
-          v-model="alignment"
+          :model-value="alignment"
           type="single"
           aria-label="Text alignment"
           class="flex items-center gap-1"
+          @update:model-value="setAlignment($event as string | undefined)"
         >
           <TooltipRoot
             v-for="align in alignments"

--- a/docs/components/examples/ToolbarRichText/index.vue
+++ b/docs/components/examples/ToolbarRichText/index.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { DropdownMenuContent, DropdownMenuItemIndicator, DropdownMenuPortal, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuRoot, DropdownMenuTrigger, ToolbarButton, ToolbarRoot, ToolbarSeparator, ToolbarToggleGroup, ToolbarToggleItem, TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger } from 'reka-ui'
+import { computed, ref } from 'vue'
+
+const marks = [
+  { value: 'bold', label: 'Bold', icon: 'lucide:bold', shortcut: '⌘B', class: 'font-bold' },
+  { value: 'italic', label: 'Italic', icon: 'lucide:italic', shortcut: '⌘I', class: 'italic' },
+  { value: 'underline', label: 'Underline', icon: 'lucide:underline', shortcut: '⌘U', class: 'underline underline-offset-4' },
+]
+
+const alignments = [
+  { value: 'left', label: 'Align left', icon: 'lucide:align-left', class: 'text-left' },
+  { value: 'center', label: 'Align centre', icon: 'lucide:align-center', class: 'text-center' },
+  { value: 'right', label: 'Align right', icon: 'lucide:align-right', class: 'text-right' },
+]
+
+const blocks = [
+  { value: 'p', label: 'Paragraph', class: 'text-sm leading-relaxed' },
+  { value: 'h1', label: 'Heading 1', class: 'text-2xl font-bold' },
+  { value: 'h2', label: 'Heading 2', class: 'text-lg font-semibold' },
+  { value: 'quote', label: 'Quote', class: 'text-sm italic border-l-2 border-primary pl-3' },
+]
+
+const activeMarks = ref<string[]>(['bold'])
+const alignment = ref('left')
+const block = ref('p')
+
+// The preview is what turns a toolbar of toggles into something you can read
+// the state off — every control here changes the paragraph below it.
+const previewClass = computed(() => [
+  blocks.find(item => item.value === block.value)!.class,
+  alignments.find(item => item.value === alignment.value)!.class,
+  ...marks.filter(mark => activeMarks.value.includes(mark.value)).map(mark => mark.class),
+])
+
+const activeBlockLabel = computed(() => blocks.find(item => item.value === block.value)!.label)
+
+const itemClass = 'inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/40 data-[state=on]:bg-muted data-[state=on]:text-foreground'
+</script>
+
+<template>
+  <TooltipProvider :delay-duration="200">
+    <div class="w-full max-w-[560px] overflow-hidden rounded-xl border border-muted bg-card">
+      <ToolbarRoot
+        class="flex flex-wrap items-center gap-1 border-b border-muted p-1.5"
+        aria-label="Formatting options"
+      >
+        <DropdownMenuRoot>
+          <!-- `as-child` keeps the trigger inside the toolbar's roving focus,
+               so arrow keys still walk past it. -->
+          <DropdownMenuTrigger as-child>
+            <ToolbarButton class="inline-flex h-8 items-center gap-1.5 rounded-md px-2.5 text-xs text-foreground outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-primary/40">
+              {{ activeBlockLabel }}
+              <Icon
+                icon="lucide:chevron-down"
+                class="size-3.5 text-muted-foreground"
+              />
+            </ToolbarButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuContent
+              class="z-[100] min-w-[10rem] rounded-lg border border-muted bg-card p-1 shadow-lg data-[side=bottom]:animate-slideUpAndFade data-[side=top]:animate-slideDownAndFade"
+              align="start"
+              :side-offset="6"
+            >
+              <DropdownMenuRadioGroup v-model="block">
+                <DropdownMenuRadioItem
+                  v-for="item in blocks"
+                  :key="item.value"
+                  :value="item.value"
+                  class="relative flex cursor-default select-none items-center gap-2 rounded-md py-1.5 pl-7 pr-2 text-sm text-foreground outline-none data-[highlighted]:bg-muted"
+                >
+                  <DropdownMenuItemIndicator class="absolute left-2">
+                    <Icon
+                      icon="lucide:check"
+                      class="size-3.5"
+                    />
+                  </DropdownMenuItemIndicator>
+                  {{ item.label }}
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenuPortal>
+        </DropdownMenuRoot>
+
+        <ToolbarSeparator class="mx-1 h-6 w-px bg-muted" />
+
+        <ToolbarToggleGroup
+          v-model="activeMarks"
+          type="multiple"
+          aria-label="Text formatting"
+          class="flex items-center gap-1"
+        >
+          <TooltipRoot
+            v-for="mark in marks"
+            :key="mark.value"
+          >
+            <TooltipTrigger as-child>
+              <ToolbarToggleItem
+                :value="mark.value"
+                :class="itemClass"
+                :aria-label="mark.label"
+              >
+                <Icon
+                  :icon="mark.icon"
+                  class="size-4"
+                />
+              </ToolbarToggleItem>
+            </TooltipTrigger>
+            <TooltipPortal>
+              <TooltipContent
+                class="z-[100] flex items-center gap-2 rounded-md bg-foreground px-2 py-1 text-xs text-background"
+                :side-offset="6"
+              >
+                {{ mark.label }}
+                <kbd class="font-mono opacity-60">{{ mark.shortcut }}</kbd>
+              </TooltipContent>
+            </TooltipPortal>
+          </TooltipRoot>
+        </ToolbarToggleGroup>
+
+        <ToolbarSeparator class="mx-1 h-6 w-px bg-muted" />
+
+        <ToolbarToggleGroup
+          v-model="alignment"
+          type="single"
+          aria-label="Text alignment"
+          class="flex items-center gap-1"
+        >
+          <TooltipRoot
+            v-for="align in alignments"
+            :key="align.value"
+          >
+            <TooltipTrigger as-child>
+              <ToolbarToggleItem
+                :value="align.value"
+                :class="itemClass"
+                :aria-label="align.label"
+              >
+                <Icon
+                  :icon="align.icon"
+                  class="size-4"
+                />
+              </ToolbarToggleItem>
+            </TooltipTrigger>
+            <TooltipPortal>
+              <TooltipContent
+                class="z-[100] rounded-md bg-foreground px-2 py-1 text-xs text-background"
+                :side-offset="6"
+              >
+                {{ align.label }}
+              </TooltipContent>
+            </TooltipPortal>
+          </TooltipRoot>
+        </ToolbarToggleGroup>
+      </ToolbarRoot>
+
+      <div class="p-5">
+        <p
+          class="text-foreground"
+          :class="previewClass"
+        >
+          Headless components give you the behaviour and the accessibility, and leave every pixel to you.
+        </p>
+      </div>
+    </div>
+  </TooltipProvider>
+</template>

--- a/docs/content/examples/combobox-async.md
+++ b/docs/content/examples/combobox-async.md
@@ -1,0 +1,23 @@
+---
+title: Combobox Async
+tags:
+  - Combobox
+---
+
+# Combobox Async
+
+<Description>
+
+Search a remote endpoint from a Combobox, with debounced requests, a loading state, and out-of-order responses discarded.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="ComboboxAsync" />
+
+<ExampleSection>
+
+### Combobox Async
+
+</ExampleSection>

--- a/docs/content/examples/combobox-virtualized.md
+++ b/docs/content/examples/combobox-virtualized.md
@@ -1,0 +1,23 @@
+---
+title: Combobox Virtualized
+tags:
+  - Combobox
+---
+
+# Combobox Virtualized
+
+<Description>
+
+Render a Combobox over 10,000 options by mounting only the rows in view with `ComboboxVirtualizer`.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="ComboboxVirtualized" />
+
+<ExampleSection>
+
+### Combobox Virtualized
+
+</ExampleSection>

--- a/docs/content/examples/data-table.md
+++ b/docs/content/examples/data-table.md
@@ -1,0 +1,25 @@
+---
+title: Data Table
+tags:
+  - Checkbox
+  - DropdownMenu
+  - Pagination
+---
+
+# Data Table
+
+<Description>
+
+Compose Checkbox, DropdownMenu, ContextMenu, ScrollArea and Pagination into a sortable, selectable table.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="DataTable" />
+
+<ExampleSection>
+
+### Data Table
+
+</ExampleSection>

--- a/docs/content/examples/data-table.md
+++ b/docs/content/examples/data-table.md
@@ -2,8 +2,10 @@
 title: Data Table
 tags:
   - Checkbox
+  - ContextMenu
   - DropdownMenu
   - Pagination
+  - ScrollArea
 ---
 
 # Data Table

--- a/docs/content/examples/date-range-presets.md
+++ b/docs/content/examples/date-range-presets.md
@@ -1,0 +1,24 @@
+---
+title: Date Range Presets
+tags:
+  - RangeCalendar
+  - Popover
+---
+
+# Date Range Presets
+
+<Description>
+
+Pair a RangeCalendar with the analytics presets people actually reach for — last 7 days, month to date, year to date.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="DateRangePresets" />
+
+<ExampleSection>
+
+### Date Range Presets
+
+</ExampleSection>

--- a/docs/content/examples/dialog-responsive-drawer.md
+++ b/docs/content/examples/dialog-responsive-drawer.md
@@ -1,0 +1,24 @@
+---
+title: Responsive Dialog Drawer
+tags:
+  - Dialog
+  - Drawer
+---
+
+# Responsive Dialog Drawer
+
+<Description>
+
+Present the same content as a centred Dialog on desktop and a swipeable Drawer on small screens, driven by one media query.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="DialogResponsiveDrawer" />
+
+<ExampleSection>
+
+### Responsive Dialog Drawer
+
+</ExampleSection>

--- a/docs/content/examples/pin-input-otp.md
+++ b/docs/content/examples/pin-input-otp.md
@@ -1,0 +1,23 @@
+---
+title: Pin Input OTP
+tags:
+  - PinInput
+---
+
+# Pin Input OTP
+
+<Description>
+
+A one-time-code field that verifies on complete, handles paste, reports failure, and throttles resends.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="PinInputOtp" />
+
+<ExampleSection>
+
+### Pin Input OTP
+
+</ExampleSection>

--- a/docs/content/examples/splitter-ide-layout.md
+++ b/docs/content/examples/splitter-ide-layout.md
@@ -1,0 +1,23 @@
+---
+title: Splitter IDE Layout
+tags:
+  - Splitter
+---
+
+# Splitter IDE Layout
+
+<Description>
+
+Nest Splitter groups into an editor layout with collapsible panels and sizes persisted across reloads.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="SplitterIdeLayout" />
+
+<ExampleSection>
+
+### Splitter IDE Layout
+
+</ExampleSection>

--- a/docs/content/examples/stepper-form-wizard.md
+++ b/docs/content/examples/stepper-form-wizard.md
@@ -1,0 +1,24 @@
+---
+title: Stepper Form Wizard
+tags:
+  - Stepper
+  - Dialog
+---
+
+# Stepper Form Wizard
+
+<Description>
+
+Gate each step of a multi-step form on its own validation, so Next and the step triggers stay in sync.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="StepperFormWizard" />
+
+<ExampleSection>
+
+### Stepper Form Wizard
+
+</ExampleSection>

--- a/docs/content/examples/toast-undo.md
+++ b/docs/content/examples/toast-undo.md
@@ -1,0 +1,23 @@
+---
+title: Toast Undo
+tags:
+  - Toast
+---
+
+# Toast Undo
+
+<Description>
+
+Archive optimistically and let a Toast own the rollback, with a countdown bar that pauses whenever the dismiss timer does.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="ToastUndo" />
+
+<ExampleSection>
+
+### Toast Undo
+
+</ExampleSection>

--- a/docs/content/examples/toolbar-rich-text.md
+++ b/docs/content/examples/toolbar-rich-text.md
@@ -1,0 +1,25 @@
+---
+title: Toolbar Rich Text
+tags:
+  - Toolbar
+  - ToggleGroup
+  - Tooltip
+---
+
+# Toolbar Rich Text
+
+<Description>
+
+A formatting toolbar combining ToggleGroup, DropdownMenu and Tooltip under one roving focus ring.
+
+</Description>
+
+<Tags />
+
+<ComponentPreview type="example"  name="ToolbarRichText" />
+
+<ExampleSection>
+
+### Toolbar Rich Text
+
+</ExampleSection>


### PR DESCRIPTION
Adds ten composition recipes to [/examples](https://reka-ui.com/examples). Each one combines several primitives into a pattern that is awkward to derive from the per-component docs alone.

| Example | Composes | What it shows |
| --- | --- | --- |
| Combobox Async | Combobox | Debounced remote search, loading vs. empty state, superseded responses dropped with `AbortController` |
| Combobox Virtualized | Combobox | 10,000 options through `ComboboxVirtualizer` with `ignore-filter` |
| Responsive Dialog Drawer | Dialog, Drawer | One sheet rendered as a centred dialog on desktop and a swipeable drawer on small screens |
| Date Range Presets | RangeCalendar, Popover | Last 7 days / month to date / year to date, with the placeholder moved so presets change the view |
| Toast Undo | Toast | Optimistic archive with rollback, plus a countdown bar that pauses with the dismiss timer |
| Stepper Form Wizard | Stepper, Dialog | Per-step validation gating both `Next` and the step triggers |
| Data Table | Checkbox, DropdownMenu, ContextMenu, ScrollArea, Pagination | Tri-state select-all, sorting, shared row actions across both menus |
| Splitter IDE Layout | Splitter | Nested groups, collapsible panels driven by panel refs, sizes persisted via `auto-save-id` |
| Pin Input OTP | PinInput | Verify on `@complete`, failure state, resend throttle |
| Toolbar Rich Text | Toolbar, ToggleGroup, DropdownMenu, Tooltip | Menus and tooltips kept inside one roving focus ring, with a live preview |

Also wires all ten into the Examples sidebar in `docs/.vitepress/config.ts`.

## Checks

- `pnpm lint` — clean for all new files
- `vue-tsc --noEmit` over the docs project — no errors in the new examples
- `pnpm docs:build` — completes, and all ten pages SSR-render their content

Visual/interaction review still wants a pass in `pnpm docs:dev`; I had no browser available to drive them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive examples for async and virtualized Comboboxes, date-range presets, responsive Dialog/Drawer layouts, OTP verification, IDE-style Splitter layouts, stepper form wizards, data tables, undoable Toasts, and rich-text Toolbars.
  - Examples demonstrate searching, loading states, virtualization, validation, responsive behavior, selection, pagination, resizing, formatting, and undo workflows.

- **Documentation**
  - Added dedicated documentation pages, previews, metadata, tags, and navigation links for all new examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->