### PR TITLE
fix(Tree): leave keyboard events alone when they come from a text field

### DIFF
--- a/packages/core/src/Tree/Tree.test.ts
+++ b/packages/core/src/Tree/Tree.test.ts
@@ -428,9 +428,13 @@ describe('given a Tree with a text field inside an item', () => {
             h(
               TreeItem,
               { key: item._id, ...item.bind },
-              () => item.value.title === 'app.vue'
-                ? h('input', { 'data-testid': 'rename' })
-                : h('span', item.value.title),
+              () => {
+                if (item.value.title === 'app.vue')
+                  return h('input', { 'data-testid': 'rename' })
+                if (item.value.title === 'Card.vue')
+                  return h('select', { 'data-testid': 'picker' }, [h('option', 'components'), h('option', 'other')])
+                return h('span', item.value.title)
+              },
             ),
           ),
         },
@@ -478,6 +482,18 @@ describe('given a Tree with a text field inside an item', () => {
     await nextTick()
 
     expect(document.activeElement).toBe(input.element)
+  })
+
+  it('does not run typeahead while a select inside an item is focused', async () => {
+    // A native select owns character keys for its own option typeahead.
+    const picker = wrapper.find('[data-testid=picker]').element as HTMLSelectElement
+    picker.focus()
+    await nextTick()
+
+    pressIn(picker, 'c')
+    await nextTick()
+
+    expect(document.activeElement).toBe(picker)
   })
 
   it('still walks the tree when the key lands on the item itself', async () => {

--- a/packages/core/src/Tree/Tree.test.ts
+++ b/packages/core/src/Tree/Tree.test.ts
@@ -406,3 +406,86 @@ describe('given a Tree with disabled items', () => {
     expect(items()[0].attributes('aria-selected')).toBe('false')
   })
 })
+
+describe('given a Tree with a text field inside an item', () => {
+  let wrapper: VueWrapper<any>
+  let input: DOMWrapper<HTMLInputElement>
+
+  // An inline rename is the common shape: the row stays a tree item, but while
+  // it is being edited the keys belong to the input.
+  const Fixture = defineComponent({
+    setup() {
+      const items = [
+        { title: 'components', children: [{ title: 'Card.vue' }, { title: 'Button.vue' }] },
+        { title: 'app.vue' },
+      ]
+
+      return () => h(
+        TreeRoot,
+        { items, getKey: (item: any) => item.title, defaultExpanded: ['components'] },
+        {
+          default: ({ flattenItems }: any) => flattenItems.map((item: any) =>
+            h(
+              TreeItem,
+              { key: item._id, ...item.bind },
+              () => item.value.title === 'app.vue'
+                ? h('input', { 'data-testid': 'rename' })
+                : h('span', item.value.title),
+            ),
+          ),
+        },
+      )
+    },
+  })
+
+  function pressIn(target: HTMLElement, key: string) {
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+    target.dispatchEvent(event)
+    return event
+  }
+
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    wrapper = mount(Fixture, { attachTo: document.body })
+    input = wrapper.find('[data-testid=rename]') as DOMWrapper<HTMLInputElement>
+    input.element.focus()
+    await nextTick()
+  })
+
+  it('leaves ArrowRight to the caret instead of walking the tree', async () => {
+    const rowsBefore = wrapper.findAll('[role=treeitem]').length
+    const event = pressIn(input.element, kbd.ARROW_RIGHT)
+    await nextTick()
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(document.activeElement).toBe(input.element)
+    expect(wrapper.findAll('[role=treeitem]')).toHaveLength(rowsBefore)
+  })
+
+  it('leaves ArrowLeft to the caret instead of jumping to the parent row', async () => {
+    const rowsBefore = wrapper.findAll('[role=treeitem]').length
+    const event = pressIn(input.element, kbd.ARROW_LEFT)
+    await nextTick()
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(document.activeElement).toBe(input.element)
+    expect(wrapper.findAll('[role=treeitem]')).toHaveLength(rowsBefore)
+  })
+
+  it('does not run typeahead while typing', async () => {
+    // 'c' matches both "components" and "Card.vue"; typeahead would focus one.
+    pressIn(input.element, 'c')
+    await nextTick()
+
+    expect(document.activeElement).toBe(input.element)
+  })
+
+  it('still walks the tree when the key lands on the item itself', async () => {
+    const items = wrapper.findAll('[role=treeitem]')
+    const folder = items[0]
+    await folder.trigger('keydown', { key: kbd.ARROW_LEFT })
+
+    // "components" was expanded, so ArrowLeft on the row collapses it.
+    expect(wrapper.findAll('[role=treeitem]').length).toBeLessThan(items.length)
+  })
+})

--- a/packages/core/src/Tree/TreeItem.vue
+++ b/packages/core/src/Tree/TreeItem.vue
@@ -195,8 +195,8 @@ defineExpose({
       :data-expanded="isExpanded ? '' : undefined"
       :data-disabled="isDisabled ? '' : undefined"
       @keydown.enter.space.self.prevent="handleSelectCustomEvent"
-      @keydown.right.prevent="(ev: KeyboardEvent) => rootContext.dir.value === 'ltr' ? handleKeydownRight(ev) : handleKeydownLeft(ev)"
-      @keydown.left.prevent="(ev: KeyboardEvent) => rootContext.dir.value === 'ltr' ? handleKeydownLeft(ev) : handleKeydownRight(ev)"
+      @keydown.right.self.prevent="(ev: KeyboardEvent) => rootContext.dir.value === 'ltr' ? handleKeydownRight(ev) : handleKeydownLeft(ev)"
+      @keydown.left.self.prevent="(ev: KeyboardEvent) => rootContext.dir.value === 'ltr' ? handleKeydownLeft(ev) : handleKeydownRight(ev)"
       @click.stop="(ev: PointerEvent) => {
         handleSelectCustomEvent(ev)
         handleToggleCustomEvent(ev)

--- a/packages/core/src/Tree/TreeRoot.vue
+++ b/packages/core/src/Tree/TreeRoot.vue
@@ -168,19 +168,25 @@ const expandedItems = computed(() => {
 })
 
 /**
- * An input rendered inside a tree item — an inline rename, a filter — owns its
- * own keys. Without this, typing into it drives typeahead and selection, moving
- * focus to another row mid-edit. Mirrors the guard in `MenuContentImpl`.
+ * A form control rendered inside a tree item — an inline rename, a per-row
+ * filter or picker — owns its own keys. Without this, typing into it drives
+ * tree typeahead and selection, moving focus to another row mid-edit. `select`
+ * counts too: it consumes character keys for its own option typeahead and
+ * Shift+Arrow to extend a multiple selection.
+ *
+ * Same idea as the guard in `MenuContentImpl`, widened past `input`/`textarea`.
  */
-function isKeyDownInTextField(event: KeyboardEvent) {
+const KEY_OWNING_TAGS = ['input', 'textarea', 'select']
+
+function isKeyDownInFormField(event: KeyboardEvent) {
   const target = event.target as HTMLElement | null
   if (!target)
     return false
-  return ['input', 'textarea'].includes(target.tagName.toLowerCase()) || target.isContentEditable
+  return KEY_OWNING_TAGS.includes(target.tagName.toLowerCase()) || target.isContentEditable
 }
 
 function handleKeydown(event: KeyboardEvent) {
-  if (isKeyDownInTextField(event))
+  if (isKeyDownInFormField(event))
     return
 
   if (isVirtual.value) {
@@ -193,7 +199,7 @@ function handleKeydown(event: KeyboardEvent) {
 }
 
 function handleKeydownNavigation(event: KeyboardEvent) {
-  if (isVirtual.value || isKeyDownInTextField(event))
+  if (isVirtual.value || isKeyDownInFormField(event))
     return
 
   const intent = MAP_KEY_TO_FOCUS_INTENT[event.key]

--- a/packages/core/src/Tree/TreeRoot.vue
+++ b/packages/core/src/Tree/TreeRoot.vue
@@ -167,7 +167,22 @@ const expandedItems = computed(() => {
   return flattenItems(items ?? [])
 })
 
+/**
+ * An input rendered inside a tree item — an inline rename, a filter — owns its
+ * own keys. Without this, typing into it drives typeahead and selection, moving
+ * focus to another row mid-edit. Mirrors the guard in `MenuContentImpl`.
+ */
+function isKeyDownInTextField(event: KeyboardEvent) {
+  const target = event.target as HTMLElement | null
+  if (!target)
+    return false
+  return ['input', 'textarea'].includes(target.tagName.toLowerCase()) || target.isContentEditable
+}
+
 function handleKeydown(event: KeyboardEvent) {
+  if (isKeyDownInTextField(event))
+    return
+
   if (isVirtual.value) {
     virtualKeydownHook.trigger(event)
   }
@@ -178,7 +193,7 @@ function handleKeydown(event: KeyboardEvent) {
 }
 
 function handleKeydownNavigation(event: KeyboardEvent) {
-  if (isVirtual.value)
+  if (isVirtual.value || isKeyDownInTextField(event))
     return
 
   const intent = MAP_KEY_TO_FOCUS_INTENT[event.key]


### PR DESCRIPTION
An input rendered inside a tree item — an inline rename, a per-row filter — cannot be typed into today. Two handlers claim keys that were never theirs.

## What's wrong

**1. `TreeItem` prevents arrows from descendants**

```vue
@keydown.right.prevent="…"
@keydown.left.prevent="…"
```

No `.self`, so Left/Right from a descendant input are `preventDefault()`ed and walk the tree instead of moving the caret. The `@keydown.enter.space.self.prevent` binding directly above already guards this way.

Modifier order matters here: Vue runs guards in source order, so `.prevent.self` would still cancel the event before bailing out. It has to be `.self.prevent`.

**2. `TreeRoot` runs typeahead on every keystroke**

`handleKeydown` has no text-field guard, so typing a filename matches a row, moves focus to it, and unmounts the input mid-edit. `handleKeydownNavigation` has the same gap for Shift+Arrow, which is text selection inside a field.

`MenuContentImpl` already guards typeahead with exactly this check — Tree now matches it, and additionally covers `contenteditable`.

**No change needed in `RovingFocusItem`** — it already returns early on `event.target !== event.currentTarget`.

## Tests

Four cases added to `Tree.test.ts`, using a fixture with an `<input>` inside one item:

- ArrowRight is not prevented, focus stays in the input, no row expands
- ArrowLeft likewise, and focus does not jump to the parent row
- typing a character that matches other rows does not move focus
- regression guard: a key landing on the item itself still walks the tree

All three behaviour tests fail on `v2` and pass with this change. The fourth passes either way, by design.

## Verification

- `vitest run` across `packages/core` — 2045 tests, 97 files, all passing
- `pnpm --filter reka-ui type-check` — clean
- `pnpm lint` — clean
- Rebuilt the package and re-ran the Tree File Explorer docs example (held back from #2900 over this bug) with its `@keydown.stop` workaround removed: renaming, caret movement and Enter-to-commit all work.

## Compatibility

Adding `.self` narrows when the handler fires: a Left/Right keydown originating from a focusable descendant of a tree item no longer expands or collapses that row. Any UI where the item itself takes focus — the normal case, and what roving focus gives you — is unaffected. Worth a maintainer's eye on whether that warrants a patch or a minor.

Follow-up: with this in, the Tree File Explorer example can return to the docs without a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tree keyboard navigation interfering with text fields and editable content.
  * Typing in input, textarea, select, and content-editable fields no longer triggers tree typeahead or changes focus.
  * Shift+Arrow and other field-specific keyboard interactions now remain within the active form control.
  * Preserved expand, collapse, parent/child navigation, and arrow-key behavior when events originate directly on tree item rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->