### PR TITLE
fix(Listbox): include $attrs in ListboxItem v-memo deps

### DIFF
--- a/packages/core/src/Listbox/Listbox.test.ts
+++ b/packages/core/src/Listbox/Listbox.test.ts
@@ -523,6 +523,31 @@ describe('given ListboxItem with reactive fallthrough attrs', () => {
     expect(items[0].attributes('data-testid')).toBe('option-b')
   })
 
+  it('should update DOM attributes when an attr key changes while its value stays the same', async () => {
+    const attrName = ref('data-variant-a')
+    const ReactiveAttrKeyListbox = defineComponent({
+      setup() {
+        return () =>
+          h(ListboxRoot, null, {
+            default: () => [
+              h(ListboxItem, { value: { id: 1 }, [attrName.value]: 'same' }, () => 'first'),
+              h(ListboxItem, { value: { id: 2 } }, () => 'other'),
+            ],
+          })
+      },
+    })
+
+    const wrapper = mount(ReactiveAttrKeyListbox, { attachTo: document.body })
+    const items = wrapper.findAll('[role=option]')
+    expect(items[0].attributes('data-variant-a')).toBe('same')
+
+    attrName.value = 'data-variant-b'
+    await nextTick()
+
+    expect(items[0].attributes('data-variant-a')).toBeUndefined()
+    expect(items[0].attributes('data-variant-b')).toBe('same')
+  })
+
   it('should re-render a surviving virtualizer row when filtering shrinks the options', async () => {
     const originalGetBoundingClientRect = window.HTMLElement.prototype.getBoundingClientRect
     window.HTMLElement.prototype.getBoundingClientRect = function () {

--- a/packages/core/src/Listbox/Listbox.test.ts
+++ b/packages/core/src/Listbox/Listbox.test.ts
@@ -492,6 +492,80 @@ describe('given ListboxItem with reactive `disabled` prop', () => {
   })
 })
 
+// Regression test for https://github.com/unovue/reka-ui/issues/2904
+// The VNode memoized by ListboxItem's `v-memo` spreads `$attrs`, so the memo
+// must also invalidate when a fallthrough attribute changes. Otherwise a
+// surviving virtualizer row whose `option` changes after filtering keeps the
+// previous option's attributes (`data-testid`, `aria-setsize`, ...) while its
+// slot content updates.
+describe('given ListboxItem with reactive fallthrough attrs', () => {
+  it('should update DOM attributes when an attr changes without highlight/selection change', async () => {
+    const testId = ref('option-a')
+    const ReactiveAttrListbox = defineComponent({
+      setup() {
+        return () =>
+          h(ListboxRoot, null, {
+            default: () => [
+              h(ListboxItem, { 'value': { id: 1 }, 'data-testid': testId.value }, () => 'first'),
+              h(ListboxItem, { value: { id: 2 } }, () => 'other'),
+            ],
+          })
+      },
+    })
+
+    const wrapper = mount(ReactiveAttrListbox, { attachTo: document.body })
+    const items = wrapper.findAll('[role=option]')
+    expect(items[0].attributes('data-testid')).toBe('option-a')
+
+    testId.value = 'option-b'
+    await nextTick()
+
+    expect(items[0].attributes('data-testid')).toBe('option-b')
+  })
+
+  it('should re-render a surviving virtualizer row when filtering shrinks the options', async () => {
+    const originalGetBoundingClientRect = window.HTMLElement.prototype.getBoundingClientRect
+    window.HTMLElement.prototype.getBoundingClientRect = function () {
+      return { width: 200, height: 200, top: 0, left: 0, right: 200, bottom: 200, x: 0, y: 0, toJSON() {} } as DOMRect
+    }
+
+    try {
+      const options = ref([
+        { label: 'cdi', value: 'cdi' },
+        { label: 'alpha', value: 'alpha' },
+        { label: 'default', value: 'default' },
+      ])
+      const VirtualFilterListbox = defineComponent({
+        setup() {
+          return () =>
+            h(ListboxRoot, null, () =>
+              h(ListboxContent, { style: 'height: 200px; overflow: auto' }, () =>
+                h(ListboxVirtualizer, { options: options.value, textContent: (o: any) => o.label }, {
+                  default: ({ option }: any) =>
+                    h(ListboxItem, { 'value': option, 'data-testid': `option-${option.label}` }, () => option.label),
+                })))
+        },
+      })
+
+      const wrapper = mount(VirtualFilterListbox, { attachTo: document.body })
+      await nextTick()
+      expect(wrapper.find('[data-index="0"]').attributes('data-testid')).toBe('option-cdi')
+
+      // a filter that keeps only the last option: index 0 survives but maps to a different option
+      options.value = [{ label: 'default', value: 'default' }]
+      await nextTick()
+
+      const survivor = wrapper.find('[data-index="0"]')
+      expect(survivor.text()).toBe('default')
+      expect(survivor.attributes('data-testid')).toBe('option-default')
+      expect(survivor.attributes('aria-setsize')).toBe('1')
+    }
+    finally {
+      window.HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    }
+  })
+})
+
 describe('given Listbox in a form', async () => {
   let items: DOMWrapper<Element>[]
 

--- a/packages/core/src/Listbox/ListboxItem.vue
+++ b/packages/core/src/Listbox/ListboxItem.vue
@@ -76,7 +76,7 @@ provideListboxItemContext({
       :id="id"
       v-bind="$attrs"
       :ref="forwardRef"
-      v-memo="[isHighlighted, isSelected, disabled, rootContext.focusable.value]"
+      v-memo="[isHighlighted, isSelected, disabled, rootContext.focusable.value, ...Object.values($attrs)]"
       role="option"
       :tabindex="rootContext.focusable.value ? isHighlighted ? '0' : '-1' : -1"
       :aria-selected="isSelected"

--- a/packages/core/src/Listbox/ListboxItem.vue
+++ b/packages/core/src/Listbox/ListboxItem.vue
@@ -76,7 +76,7 @@ provideListboxItemContext({
       :id="id"
       v-bind="$attrs"
       :ref="forwardRef"
-      v-memo="[isHighlighted, isSelected, disabled, rootContext.focusable.value, ...Object.values($attrs)]"
+      v-memo="[isHighlighted, isSelected, disabled, rootContext.focusable.value, ...Object.entries($attrs).flat()]"
       role="option"
       :tabindex="rootContext.focusable.value ? isHighlighted ? '0' : '-1' : -1"
       :aria-selected="isSelected"


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2904

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`ListboxItem`'s `v-memo` lists `[isHighlighted, isSelected, disabled, rootContext.focusable.value]`, but the memoized `Primitive` VNode also spreads `$attrs`. When a fallthrough attribute changes while none of the listed deps change, the memo reuses the cached VNode and the DOM element keeps the previous attributes.

This bites hardest in virtualized lists: `ListboxVirtualizer`/`ComboboxVirtualizer` key rows by virtual index, so when external filtering shrinks the `options` array a surviving index maps to a different option. The row's slot content and registered `value` update, but every attribute on the option element goes stale — consumer attrs like `data-testid`, and the virtualizer's own `aria-setsize`/`aria-posinset` — so assistive tech announces "1 of 37" on a one-option list and attribute-based lookups find the wrong option. Nothing re-invalidates the memo until the row's highlight/selection/disabled state happens to change.

The fix flattens `...Object.entries($attrs)` into the dep list so both attribute keys and values participate in the memo comparison (values alone cannot see a key being replaced by another key with the same value). This is the same gap-in-deps class as #2644 / #2653, which added `disabled` and `focusable` to this list. `ComboboxItem`'s `v-memo` already tracks `...Object.values($attrs)`; it retains the values-only key-swap blind spot, left untouched here to keep the change scoped — happy to align it in this PR if preferred.

Three regression tests, all failing on `main` without the fix:

- a plain `ListboxItem` whose fallthrough attr changes without any highlight/selection change
- a plain `ListboxItem` whose fallthrough attr *key* is replaced by another key carrying the same value
- a virtualized listbox whose options shrink so the surviving row maps to a different option (asserts `data-testid`, text, and `aria-setsize`)

Trade-off note: for virtualizer rows the injected `style` object has a fresh identity per compute, so the memo no longer short-circuits there — matching `ComboboxItem`, which already pays this cost. Static lists keep full memoization benefits since their attrs are stable primitives.

### 📸 Screenshots (if appropriate)

DOM observed after filtering 37 options down to 1 in a virtualized combobox (before the fix):

```html
<button role="option"
        data-testid="...-option-cdi"   <!-- stale: previous option at index 0 -->
        aria-setsize="37"              <!-- stale: list has 1 option -->
        aria-posinset="1">
  <p>default</p>                       <!-- fresh: slot content updated -->
</button>
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Listbox items so dynamic attributes update correctly when their values or keys change.
  * Improved virtualized Listbox rows to refresh attributes and displayed content after filtering options.
  * Added regression coverage for reactive attributes and filtering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
