### PR TITLE
fix(v3): port missed v2 fixes and resolve regressions found in the v3 review

### DIFF
--- a/packages/core/src/DismissableLayer/DismissableLayer.bench.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.bench.ts
@@ -7,7 +7,7 @@ import { resetLayerStack } from './layerStack'
 // NOTE: jsdom benchmarks measure JS-only cost (no layout/paint) and are
 // DIRECTIONAL. The definitive proof of the listener consolidation is the
 // structural assertion in `DismissableLayer.listeners.test.ts` (one shared
-// document listener + one `querySelectorAll` per event, independent of layer
+// document listener + one registry snapshot per event, independent of layer
 // count). Render count is unchanged (parity), not reduced — under Vue >= 3.4
 // an open layer does not re-render on sibling membership churn either way.
 //

--- a/packages/core/src/DismissableLayer/DismissableLayer.bench.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.bench.ts
@@ -11,7 +11,20 @@ import { resetLayerStack } from './layerStack'
 // count). Render count is unchanged (parity), not reduced — under Vue >= 3.4
 // an open layer does not re-render on sibling membership churn either way.
 //
-// Run: `pnpm --filter reka-ui bench`
+// What each bench measures:
+// 1. mount + unmount of N layers — registration/teardown cost of the manager.
+// 2. ONE outside `pointerdown` against N already-mounted, ARMED layers — the
+//    shared dispatch path (`layerStack.handlePointerDown` → N subscribers).
+//    Subscribers only arm a macrotask after registration
+//    (`registerOutsideSubscriber`), so mounting + arming happens in `setup`
+//    (once per warmup/run phase) and the measured body is the dispatch alone.
+// 3. ONE bubbling Escape `keydown` from the top layer against N layers — the
+//    shared `window` keydown listener routing to the top present layer.
+//
+// Absolute numbers are meaningless on their own: run the same file against the
+// v2 baseline (per-layer listeners) and compare the RATIO per bench.
+//
+// Run: `pnpm --filter reka-ui exec vitest bench src/DismissableLayer`
 
 function mountLayers(n: number) {
   return mount(defineComponent({
@@ -28,20 +41,40 @@ describe('dismissableLayer', () => {
     wrapper.unmount()
   })
 
-  bench('mount 20 layers + one outside pointerdown + unmount', () => {
-    resetLayerStack()
-    const wrapper = mountLayers(20)
-    const outside = document.createElement('div')
-    document.body.appendChild(outside)
+  let wrapper: ReturnType<typeof mountLayers>
+  let outside: HTMLElement
+  let topLayer: Element
+
+  bench('one outside pointerdown against 20 armed layers', () => {
     outside.dispatchEvent(new Event('pointerdown', { bubbles: true }))
-    outside.remove()
-    wrapper.unmount()
+  }, {
+    async setup() {
+      resetLayerStack()
+      wrapper = mountLayers(20)
+      outside = document.createElement('div')
+      document.body.appendChild(outside)
+      await new Promise(r => setTimeout(r, 0)) // let the subscribers arm
+    },
+    teardown() {
+      outside.remove()
+      wrapper.unmount()
+      resetLayerStack()
+    },
   })
 
-  bench('escape dispatch against 20 open layers', () => {
-    resetLayerStack()
-    const wrapper = mountLayers(20)
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
-    wrapper.unmount()
+  bench('one escape keydown against 20 open layers', () => {
+    // Bubbles element → document → window, where the shared listener lives.
+    // Dispatching a non-bubbling event on `document` never reaches it.
+    topLayer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+  }, {
+    setup() {
+      resetLayerStack()
+      wrapper = mountLayers(20)
+      topLayer = wrapper.element.lastElementChild as Element
+    },
+    teardown() {
+      wrapper.unmount()
+      resetLayerStack()
+    },
   })
 })

--- a/packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.listeners.test.ts
@@ -36,14 +36,16 @@ describe('dismissableLayer listener consolidation', () => {
     wrapper.unmount()
   })
 
-  it('runs querySelectorAll once per outside pointerdown regardless of layer count', async () => {
+  it('runs no document-wide querySelectorAll on outside pointerdown regardless of layer count', async () => {
+    // Layer order comes from the manager's registry (shadow-root safe), not a
+    // `querySelectorAll('[data-dismissable-layer]')` snapshot per event.
     const wrapper = mountLayers(5)
     await new Promise(r => setTimeout(r, 0)) // let the subscribers arm
     const outside = document.createElement('div')
     document.body.appendChild(outside)
     const qsa = vi.spyOn(document, 'querySelectorAll')
     await fireEvent.pointerDown(outside)
-    expect(count(qsa as any, '[data-dismissable-layer]')).toBe(1)
+    expect(count(qsa as any, '[data-dismissable-layer]')).toBe(0)
     qsa.mockRestore()
     wrapper.unmount()
   })

--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -608,7 +608,11 @@ describe('nested layers inside a shadow root', () => {
     }), { attachTo: mountTarget })
     await sleep(1)
     childOpen.value = true
-    await sleep(1) // child registers above the parent, then arms
+    // Flush the render first: the child's outside subscriber arms on a macrotask
+    // scheduled during setup, which would otherwise be queued *after* a `sleep`
+    // started on this line and leave the first pointerdown below unarmed.
+    await nextTick()
+    await sleep(1) // child registered above the parent; its subscriber is armed
 
     // Neither layer is reachable through the document.
     expect(document.querySelectorAll('[data-dismissable-layer]')).toHaveLength(0)

--- a/packages/core/src/DismissableLayer/DismissableLayer.test.ts
+++ b/packages/core/src/DismissableLayer/DismissableLayer.test.ts
@@ -1,8 +1,10 @@
 import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
 import { fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
+import { createShadowHost } from '@/shared/test/shadowDom'
+import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 import { sleep } from '@/test'
 import { DismissableLayer as DismissableLayerPrimitive } from '.'
 import { resetLayerStack } from './layerStack'
@@ -133,6 +135,173 @@ describe('nested layers with disableOutsidePointerEvents (#2674)', () => {
   })
 })
 
+describe('sibling layers with disableOutsidePointerEvents', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.body.style.pointerEvents = ''
+    // Module-level manager state: keep this suite order-independent even if a
+    // failing test skipped its unmounts.
+    resetLayerStack()
+  })
+
+  // The mirrored direction of the #2674 tests above: the OLDER disabling
+  // layer leaves the stack while a NEWER sibling is still present. This is the
+  // layer-registry half of the #2784 scenario (a closing animated Popover
+  // whose layer unmounts after a Dialog has already opened).
+  function mountSiblings() {
+    const popoverOpen = ref(true)
+    const dialogOpen = ref(false)
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => h('div', [
+          popoverOpen.value
+            ? h(DismissableLayerPrimitive, { 'disableOutsidePointerEvents': true, 'data-testid': 'popover' }, () => 'Popover')
+            : null,
+          dialogOpen.value
+            ? h(DismissableLayerPrimitive, { 'disableOutsidePointerEvents': true, 'data-testid': 'dialog' }, () => 'Dialog')
+            : null,
+        ])
+      },
+    }), { attachTo: document.body })
+
+    return { wrapper, popoverOpen, dialogOpen }
+  }
+
+  it('should keep body pointer-events none after the older layer unmounts while a newer one is open', async () => {
+    const { wrapper, popoverOpen, dialogOpen } = mountSiblings()
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Dialog mounts while the popover is still animating out (still mounted)
+    dialogOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Popover's exit animation ends -> its layer unmounts; dialog still open
+    popoverOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Closing the dialog restores the body
+    dialogOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('should keep body pointer-events none when the handoff happens in the same tick', async () => {
+    const { wrapper, popoverOpen, dialogOpen } = mountSiblings()
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // "Pick" action: close the popover and open the dialog in the same tick
+    popoverOpen.value = false
+    dialogOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    dialogOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    wrapper.unmount()
+  })
+})
+
+describe('scroll-lock handoff to a modal layer without its own scroll lock (#2784)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.body.style.pointerEvents = ''
+    resetLayerStack()
+  })
+
+  // Mimics `PopoverContentModal`: a modal layer that also holds a body scroll
+  // lock, released when the content unmounts (for an animated popover that is
+  // the end of the exit animation).
+  const ModalLayerWithScrollLock = defineComponent({
+    setup() {
+      useBodyScrollLock(true)
+      return () => h(DismissableLayerPrimitive, { disableOutsidePointerEvents: true }, () => 'popover')
+    },
+  })
+
+  // Mimics an overlay-less modal `DialogContent`: disables outside pointer
+  // events but registers no scroll lock (that lives on `DialogOverlayImpl`).
+  function mountHandoff() {
+    const popoverOpen = ref(false)
+    const dialogOpen = ref(false)
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => h('div', [
+          popoverOpen.value ? h(ModalLayerWithScrollLock) : null,
+          dialogOpen.value
+            ? h(DismissableLayerPrimitive, { disableOutsidePointerEvents: true }, () => 'dialog')
+            : null,
+        ])
+      },
+    }), { attachTo: document.body })
+
+    return { wrapper, popoverOpen, dialogOpen }
+  }
+
+  it('should keep body pointer-events none when the scroll-lock holder unmounts while a modal layer remains open', async () => {
+    const { wrapper, popoverOpen, dialogOpen } = mountHandoff()
+
+    // Modal popover opens: dismissable layer + scroll lock
+    popoverOpen.value = true
+    await nextTick() // scroll lock applies its own pointer-events on next tick
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Modal dialog (no overlay -> no scroll lock) opens while the popover
+    // is still mounted (e.g. animating out)
+    dialogOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Popover unmounts: the last scroll lock releases and must not clear the
+    // body pointer-events still owned by the dialog's dismissable layer
+    popoverOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // Closing the dialog restores the body
+    dialogOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('should keep body pointer-events none when a scroll-locking layer opens and closes over a modal layer', async () => {
+    const { wrapper, popoverOpen, dialogOpen } = mountHandoff()
+
+    // Overlay-less modal dialog open first
+    dialogOpen.value = true
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    // A modal popover (scroll-lock holder) opens on top, then closes
+    popoverOpen.value = true
+    await nextTick()
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    popoverOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    dialogOpen.value = false
+    await sleep(1)
+    expect(document.body.style.pointerEvents).toBe('')
+
+    wrapper.unmount()
+  })
+})
+
 describe('given a default DismissableLayer', () => {
   let wrapper: VueWrapper<InstanceType<typeof DismissableLayer>>
   let trigger: DOMWrapper<HTMLElement>
@@ -192,6 +361,87 @@ describe('given a default DismissableLayer', () => {
         expect(document.body.innerHTML).toContain(CLOSE_LABEL)
       })
     })
+  })
+})
+
+describe('given a DismissableLayer after a cancelled touch tap outside', () => {
+  beforeEach(() => {
+    resetLayerStack()
+    document.body.innerHTML = ''
+  })
+
+  // jsdom has no `PointerEvent`, so `fireEvent.pointerDown` loses `pointerType`
+  // and would take the mouse path instead of the deferred touch one.
+  function touchPointerDown(target: EventTarget) {
+    const event = new MouseEvent('pointerdown', { bubbles: true })
+    Object.defineProperty(event, 'pointerType', { value: 'touch' })
+    target.dispatchEvent(event)
+  }
+
+  // Regression: on touch, `pointerDownOutside` is deferred to the next `click`.
+  // When the outside tap turns into a scroll or drag no `click` follows, so the
+  // deferred dispatch stays pending. The next tap INSIDE the layer (or a nested
+  // layer above it) must drop that stale deferral instead of letting its own
+  // `click` dismiss the layer. Mirrors radix-ui/primitives#2171.
+  it('should not dismiss on the next tap inside a nested layer', async () => {
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => h('div', [
+          h(DismissableLayerPrimitive, { 'data-testid': 'outer' }, () => 'Outer'),
+          h(DismissableLayerPrimitive, { 'data-testid': 'inner' }, () => [
+            h('button', { 'data-testid': 'inner-button' }, 'Inner'),
+          ]),
+        ])
+      },
+    }), { attachTo: document.body })
+    await sleep(1)
+
+    const outer = wrapper.findComponent('[data-testid="outer"]') as VueWrapper
+    const innerButton = wrapper.find('[data-testid="inner-button"]').element
+
+    // Outside touch that is cancelled: no `click` follows the `pointerdown`.
+    touchPointerDown(document.body)
+    await sleep(1)
+
+    // Next tap lands inside the nested layer.
+    touchPointerDown(innerButton)
+    await fireEvent.click(innerButton)
+    await sleep(1)
+
+    expect(outer.emitted('pointerDownOutside')).toBeUndefined()
+    expect(outer.emitted('dismiss')).toBeUndefined()
+
+    // A completed tap outside still dismisses the outer layer.
+    touchPointerDown(document.body)
+    await fireEvent.click(document.body)
+    await sleep(1)
+
+    expect(outer.emitted('pointerDownOutside')?.length).toBe(1)
+    expect(outer.emitted('dismiss')?.length).toBe(1)
+
+    wrapper.unmount()
+  })
+
+  it('should not dismiss on the next tap inside the layer itself', async () => {
+    const wrapper = mount(DismissableLayerPrimitive, {
+      attachTo: document.body,
+      slots: { default: () => h('button', { 'data-testid': 'inside' }, 'Inside') },
+    })
+    await sleep(1)
+
+    const inside = wrapper.find('[data-testid="inside"]').element
+
+    touchPointerDown(document.body)
+    await sleep(1)
+
+    touchPointerDown(inside)
+    await fireEvent.click(inside)
+    await sleep(1)
+
+    expect(wrapper.emitted('pointerDownOutside')).toBeUndefined()
+    expect(wrapper.emitted('dismiss')).toBeUndefined()
+
+    wrapper.unmount()
   })
 })
 
@@ -269,6 +519,44 @@ describe('given a not-present DismissableLayer (e.g. unmountOnHide hidden)', () 
     expect(wrapper.emitted('dismiss')).toBeUndefined()
   })
 
+  // Regression: on touch, `pointerDownOutside` is deferred to the `click` event.
+  // A layer listening while not present captures the `pointerdown` of the tap that
+  // opens it, and dismisses itself when that tap's `click` arrives.
+  it('should not dismiss on the tap that made it present', async () => {
+    // jsdom has no `PointerEvent`, so `fireEvent.pointerDown` loses `pointerType`
+    // and would take the mouse path instead of the deferred touch one.
+    function touchPointerDown() {
+      const event = new MouseEvent('pointerdown', { bubbles: true })
+      Object.defineProperty(event, 'pointerType', { value: 'touch' })
+      document.body.dispatchEvent(event)
+    }
+
+    const wrapper = mount(DismissableLayerPrimitive, {
+      attachTo: document.body,
+      props: { present: false },
+    })
+    await sleep(1)
+
+    touchPointerDown()
+    await wrapper.setProps({ present: true })
+    await sleep(1) // let the freshly-registered subscriber arm
+    await fireEvent.click(document.body)
+    await sleep(1)
+
+    expect(wrapper.emitted('pointerDownOutside')).toBeUndefined()
+    expect(wrapper.emitted('dismiss')).toBeUndefined()
+
+    // a later tap outside still dismisses it
+    touchPointerDown()
+    await fireEvent.click(document.body)
+    await sleep(1)
+
+    expect(wrapper.emitted('pointerDownOutside')?.length).toBe(1)
+    expect(wrapper.emitted('dismiss')?.length).toBe(1)
+
+    wrapper.unmount()
+  })
+
   it('should emit escapeKeyDown and dismiss on Escape once present', async () => {
     const wrapper = mount(DismissableLayerPrimitive, {
       attachTo: document.body,
@@ -281,6 +569,68 @@ describe('given a not-present DismissableLayer (e.g. unmountOnHide hidden)', () 
 
     expect(wrapper.emitted('escapeKeyDown')?.length).toBe(1)
     expect(wrapper.emitted('dismiss')?.length).toBe(1)
+  })
+})
+
+describe('nested layers inside a shadow root', () => {
+  beforeEach(() => {
+    resetLayerStack()
+    document.body.innerHTML = ''
+  })
+
+  function pointerDown(target: EventTarget) {
+    // `composed` so the event reaches the shared document listener from inside
+    // the shadow root (jsdom has no `PointerEvent`; a plain mouse path is fine).
+    target.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, composed: true }))
+  }
+
+  // Regression: layer order used to come from a document-wide
+  // `querySelectorAll('[data-dismissable-layer]')`, which does not pierce shadow
+  // roots. Two layers inside one shadow root both indexed `-1`, so a pointerdown
+  // inside the child layer was treated as outside its parent and dismissed it.
+  it('should treat a pointerdown inside the child layer as inside the parent, and dismiss only the top layer on outside', async () => {
+    const { shadowRoot, mountTarget, cleanup } = createShadowHost()
+    const childOpen = ref(false)
+    const onParentDismiss = vi.fn()
+    const onChildDismiss = vi.fn()
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        return () => h('div', [
+          h(DismissableLayerPrimitive, { onDismiss: onParentDismiss }, () => 'Parent'),
+          childOpen.value
+            ? h(DismissableLayerPrimitive, { disableOutsidePointerEvents: true, onDismiss: onChildDismiss }, () => [
+                h('button', { 'data-testid': 'child-button' }, 'Child'),
+              ])
+            : null,
+        ])
+      },
+    }), { attachTo: mountTarget })
+    await sleep(1)
+    childOpen.value = true
+    await sleep(1) // child registers above the parent, then arms
+
+    // Neither layer is reachable through the document.
+    expect(document.querySelectorAll('[data-dismissable-layer]')).toHaveLength(0)
+    expect(shadowRoot.querySelectorAll('[data-dismissable-layer]')).toHaveLength(2)
+    const childButton = shadowRoot.querySelector('[data-testid="child-button"]') as HTMLElement
+
+    pointerDown(childButton)
+    await sleep(1)
+    expect(onParentDismiss).not.toHaveBeenCalled()
+    expect(onChildDismiss).not.toHaveBeenCalled()
+
+    // Outside both: only the top (child) layer dismisses; the child disables
+    // outside pointer events, so the parent's are off and it stays put.
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    pointerDown(outside)
+    await sleep(1)
+    expect(onChildDismiss).toHaveBeenCalledOnce()
+    expect(onParentDismiss).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+    cleanup()
   })
 })
 

--- a/packages/core/src/DismissableLayer/DismissableLayer.vue
+++ b/packages/core/src/DismissableLayer/DismissableLayer.vue
@@ -57,6 +57,7 @@ import type { StackLayer } from './layerStack'
 import {
   useRender,
 } from '@/Primitive'
+import { containsComposed } from '@/shared'
 import {
   acquireBodyPointerEventsLock,
   branches,
@@ -120,9 +121,15 @@ const isBodyPointerEventsDisabled = computed(() => highestDisabledIndex() >= 0)
 
 const isPointerEventsEnabled = computed(() => index.value >= highestDisabledIndex())
 
+// A layer that stays mounted while hidden (e.g. a Dialog with `unmountOnHide: false`)
+// must not listen while it is not present, hence the `present` guard passed as
+// `enabled` (it unsubscribes from the shared manager, which also cancels any
+// pending touch deferral). On touch the dispatch is deferred to the `click`
+// event, so a `pointerdown` captured while hidden would be delivered right after
+// the layer opened and dismiss it on the very interaction that opened it.
 const pointerDownOutside = usePointerDownOutside(async (event) => {
   const isPointerDownOnBranch = [...branches].some(branch =>
-    branch?.contains(event.target as HTMLElement),
+    containsComposed(branch, event.target as Node),
   )
 
   if (!props.present || !isPointerEventsEnabled.value || isPointerDownOnBranch)
@@ -132,11 +139,11 @@ const pointerDownOutside = usePointerDownOutside(async (event) => {
   await nextTick()
   if (!event.defaultPrevented)
     emits('dismiss')
-}, layerElement)
+}, layerElement, () => props.present)
 
 const focusOutside = useFocusOutside((event) => {
   const isFocusInBranch = [...branches].some(branch =>
-    branch?.contains(event.target as HTMLElement),
+    containsComposed(branch, event.target as Node),
   )
 
   if (!props.present || isFocusInBranch)
@@ -145,7 +152,7 @@ const focusOutside = useFocusOutside((event) => {
   emits('interactOutside', event)
   if (!event.defaultPrevented)
     emits('dismiss')
-}, layerElement)
+}, layerElement, () => props.present)
 
 // Body pointer-events lock (#2674). `watch` with explicit sources (not
 // `watchEffect`) so it re-runs only when this layer's `element` /

--- a/packages/core/src/DismissableLayer/layerStack.ts
+++ b/packages/core/src/DismissableLayer/layerStack.ts
@@ -13,7 +13,7 @@ import { shallowReactive } from 'vue'
  *   `isEditing` lifetime for Editable). Never affect Escape/index accounting.
  *
  * The manager owns exactly one shared listener of each kind (installed lazily,
- * torn down when its driving registry empties), the per-event query snapshot,
+ * torn down when its driving registry empties), the per-event layer snapshot,
  * arming, and the touch-click deferral. It does NOT re-implement dismissal
  * logic — each composable ports its `handlePointerDown`/`handleFocus` body into
  * a subscriber closure invoked here with a `DispatchContext`.
@@ -29,9 +29,9 @@ export interface StackLayer {
 export interface DispatchContext {
   /** Composed (shadow-safe) event target, captured synchronously before any await. */
   target: EventTarget | null
-  /** One hoisted `querySelectorAll('[data-dismissable-layer]')` per event. */
+  /** One hoisted `layerElements()` snapshot per event ([0] = bottom, last = top). */
   nodeList: Element[]
-  /** O(1) document-order index of a layer element within `nodeList` (-1 if absent). */
+  /** O(1) stack index of a layer element within `nodeList` (-1 if absent). */
   layerIndex: (el: Element) => number
   branches: HTMLElement[]
   /** Touch: defer this subscriber's dispatch to the next `click` (replaces = re-arm). */
@@ -136,9 +136,7 @@ function cancelTouch(sub: OutsideSubscriber) {
 // --- dispatch ---
 function buildContext(event: Event): DispatchContext {
   const target = (event.composedPath?.()[0] ?? event.target) as EventTarget | null
-  const nodeList = isClient
-    ? Array.from(document.querySelectorAll('[data-dismissable-layer]'))
-    : []
+  const nodeList = layerElements()
   const indexMap = new Map<Element, number>()
   nodeList.forEach((el, i) => indexMap.set(el, i))
   return {
@@ -251,10 +249,34 @@ export function releaseBodyPointerEventsLock(doc: Document): void {
   if (bodyLockCount === 0 && bodyPointerEvents.original !== undefined)
     doc.body.style.pointerEvents = bodyPointerEvents.original
 }
+/**
+ * Whether the manager currently owns body `pointer-events` (at least one present
+ * `disableOutsidePointerEvents` layer holds the lock). Consulted by
+ * `useBodyScrollLock` before it clears the style both share (#2784).
+ */
+export function hasBodyPointerEventsLock(): boolean {
+  return bodyLockCount > 0
+}
 
 // --- queries ---
 export function indexOfLayer(layer: StackLayer): number {
   return layers.indexOf(layer)
+}
+/**
+ * Elements of the present layers in stack order ([0] = bottom, last = top).
+ * Read from the registry rather than a document-wide
+ * `querySelectorAll('[data-dismissable-layer]')`, which cannot see layers
+ * rendered inside shadow roots (they would all index `-1`). Registration order
+ * is stack order — the same order Escape routing and pointer-events use.
+ */
+export function layerElements(): HTMLElement[] {
+  const elements: HTMLElement[] = []
+  for (const layer of layers) {
+    const element = layer.element()
+    if (element)
+      elements.push(element)
+  }
+  return elements
 }
 export function isTopLayer(layer: StackLayer): boolean {
   return layers.length > 0 && layers.at(-1) === layer

--- a/packages/core/src/DismissableLayer/utils.ts
+++ b/packages/core/src/DismissableLayer/utils.ts
@@ -2,8 +2,8 @@ import type { MaybeRefOrGetter, Ref } from 'vue'
 import type { OutsideSubscriber } from './layerStack'
 import { isClient } from '@vueuse/shared'
 import { nextTick, toValue, watchEffect } from 'vue'
-import { handleAndDispatchCustomEvent } from '@/shared'
-import { registerOutsideSubscriber } from './layerStack'
+import { containsComposed, handleAndDispatchCustomEvent } from '@/shared'
+import { layerElements, registerOutsideSubscriber } from './layerStack'
 
 export type PointerDownOutsideEvent = CustomEvent<{
   originalEvent: PointerEvent
@@ -14,38 +14,63 @@ export const DISMISSABLE_LAYER_NAME = 'DismissableLayer'
 export const POINTER_DOWN_OUTSIDE = 'dismissableLayer.pointerDownOutside'
 export const FOCUS_OUTSIDE = 'dismissableLayer.focusOutside'
 
+/**
+ * Whether `targetElement` counts as "inside" `layerElement`: within its own
+ * subtree, or within a layer stacked ABOVE it. Stack order comes from the
+ * manager's `layers` registry (see `layerElements`) rather than a document-wide
+ * `querySelectorAll`, so layers rendered inside shadow roots order like
+ * light-DOM ones; containment is composed for the same reason.
+ */
 export function isLayerExist(
   layerElement: HTMLElement,
   targetElement: HTMLElement,
-  // Optional pre-computed `[data-dismissable-layer]` snapshot. The manager hoists
-  // ONE snapshot per pointerdown event and passes it here so N subscribers share
-  // a single `querySelectorAll` (the synchronous pointer path — see layerStack).
-  // Omitted (focus path / direct callers) → a fresh query, matching prior behavior.
+  // Optional pre-computed `layerElements()` snapshot. The manager builds ONE per
+  // pointerdown event and passes it here so N subscribers share it (the
+  // synchronous pointer path — see layerStack). Omitted (focus path / direct
+  // callers) → the live registry is read.
   snapshot?: Element[],
 ) {
   if (!(targetElement instanceof Element))
     return false
 
-  const targetLayer = targetElement.closest(
-    '[data-dismissable-layer]',
-  )
-
-  const mainLayer = layerElement.dataset.dismissableLayer === ''
+  const mainLayer = (layerElement.dataset.dismissableLayer === ''
     ? layerElement
-    : layerElement.querySelector(
-      '[data-dismissable-layer]',
-    ) as HTMLElement
+    : layerElement.querySelector('[data-dismissable-layer]')) ?? layerElement
 
-  const nodeList = snapshot ?? Array.from(
-    layerElement.ownerDocument.querySelectorAll('[data-dismissable-layer]'),
-  )
-
-  if (targetLayer && (mainLayer === targetLayer || nodeList.indexOf(mainLayer) < nodeList.indexOf(targetLayer))) {
+  // Inside the layer's own subtree (a target in a nested shadow tree counts).
+  if (containsComposed(mainLayer, targetElement))
     return true
+
+  // Otherwise the target must sit inside a layer stacked above this one.
+  const nodeList = snapshot ?? layerElements()
+  const mainIndex = nodeList.indexOf(mainLayer)
+
+  // An unregistered `mainLayer` (e.g. an Editable, which only subscribes and
+  // never registers a `StackLayer`) has no stack index, so fall back to the
+  // document-order rule the `querySelectorAll` snapshot used to encode: a layer
+  // that FOLLOWS it in the document counts as above it. This keeps an Editable
+  // inside a Dialog ending its edit on a click elsewhere in that Dialog.
+  if (mainIndex === -1) {
+    const domTargetLayer = targetElement.closest('[data-dismissable-layer]')
+    return !!domTargetLayer
+      && !!(mainLayer.compareDocumentPosition(domTargetLayer) & Node.DOCUMENT_POSITION_FOLLOWING)
   }
-  else {
-    return false
+
+  const targetLayer = closestStackLayer(targetElement, nodeList)
+  return !!targetLayer && mainIndex < nodeList.indexOf(targetLayer)
+}
+
+/** Nearest composed ancestor of `node` (inclusive) that is one of `nodeList`. */
+function closestStackLayer(node: Node, nodeList: Element[]): Element | null {
+  const members = new Set<Node>(nodeList)
+  let current: Node | null = node
+  while (current) {
+    if (members.has(current))
+      return current as Element
+    // Cross a shadow boundary: a shadow root has no parent, but a host.
+    current = current.parentNode ?? (current as ShadowRoot).host ?? null
   }
+  return null
 }
 
 /**
@@ -75,6 +100,12 @@ export function usePointerDownOutside(
         return
 
       if (isLayerExist(element.value, target, ctx.nodeList)) {
+        // A touch `pointerdown` outside defers the dispatch to the next `click`,
+        // which never comes when the tap becomes a scroll/drag. Drop the stale
+        // deferral here so the next tap inside this layer (or a layer above it)
+        // cannot trigger it (mirrors Radix's inside-tree branch,
+        // radix-ui/primitives#2171).
+        ctx.cancelTouch(subscriber)
         subscriber.isPointerInside = false
         return
       }
@@ -111,7 +142,6 @@ export function usePointerDownOutside(
       else {
         // Cancel a pending deferred dispatch when the outside click was canceled.
         // See: https://github.com/radix-ui/primitives/issues/2171
-        // NB: only here, NOT on the isLayerExist early-return above (parity).
         ctx.cancelTouch(subscriber)
       }
       subscriber.isPointerInside = false
@@ -151,8 +181,8 @@ export function useFocusOutside(
     // Ported from the previous `handleFocus` body. Keeps the double `nextTick`
     // so focus-driven DOM updates settle before the gate reads. Uses the
     // composed `ctx.target` (captured synchronously by the manager) but a FRESH
-    // `isLayerExist` query AFTER the awaits — the DOM may have changed, and a
-    // stale snapshot would diverge from today's behavior.
+    // `isLayerExist` registry read AFTER the awaits — the stack may have
+    // changed, and a stale snapshot would diverge from today's behavior.
     handleFocus: async (event, ctx) => {
       if (!element?.value)
         return

--- a/packages/core/src/Label/Label.test.ts
+++ b/packages/core/src/Label/Label.test.ts
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/vue'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { defineComponent, h, nextTick } from 'vue'
 import Label from './Label.vue'
@@ -74,5 +75,58 @@ describe('test label functionalities', () => {
     container.getElementsByTagName('label')[0].click()
     await nextTick()
     expect(container.querySelector('input')).not.toBe(document.activeElement)
+  })
+})
+
+// Label sets `inheritAttrs: false` and folds attrs into `renderProps`, so they
+// must reach the element exactly once on both the default and `#render` paths.
+describe('label attrs forwarding', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('forwards class / id / aria-label on the default path and chains a consumer @mousedown after its own', async () => {
+    const onMousedown = vi.fn()
+    const wrapper = mount(Label, {
+      attrs: { 'class': 'x', 'id': 'lbl', 'aria-label': 'Name', onMousedown },
+    })
+    const label = wrapper.find('label')
+    expect(label.classes()).toContain('x')
+    expect(label.attributes('id')).toBe('lbl')
+    expect(label.attributes('aria-label')).toBe('Name')
+
+    await label.trigger('mousedown', { detail: 2 })
+    expect(onMousedown).toHaveBeenCalledTimes(1)
+    // Label's own handler ran first (double-click text-selection prevention).
+    expect(onMousedown.mock.calls[0][0].defaultPrevented).toBe(true)
+  })
+
+  it('forwards attrs and listeners to the consumer element on the #render path', async () => {
+    const onClick = vi.fn()
+    const wrapper = mount(Label, {
+      props: { for: 'input' },
+      attrs: { 'class': 'x', 'id': 'lbl', 'data-testid': 'lbl', onClick },
+      slots: { render: `<template #render="{ props }"><span v-bind="props">Name</span></template>` },
+    })
+    expect(wrapper.find('label').exists()).toBe(false)
+    const span = wrapper.find('span')
+    expect(span.exists()).toBe(true)
+    expect(span.classes()).toContain('x')
+    expect(span.attributes('id')).toBe('lbl')
+    expect(span.attributes('data-testid')).toBe('lbl')
+    expect(span.attributes('for')).toBe('input')
+
+    await span.trigger('click')
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not warn about extraneous non-props attributes on the #render path', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mount(Label, {
+      attrs: { class: 'x', id: 'lbl' },
+      slots: { render: `<template #render="{ props }"><span v-bind="props">Name</span></template>` },
+    })
+    expect(spy.mock.calls.flat().some(arg => typeof arg === 'string' && arg.includes('Extraneous non-props attributes'))).toBe(false)
+    spy.mockRestore()
   })
 })

--- a/packages/core/src/Label/Label.test.ts
+++ b/packages/core/src/Label/Label.test.ts
@@ -95,7 +95,9 @@ describe('label attrs forwarding', () => {
     expect(label.attributes('id')).toBe('lbl')
     expect(label.attributes('aria-label')).toBe('Name')
 
-    await label.trigger('mousedown', { detail: 2 })
+    // VTU's `trigger` cannot set `detail` (getter-only on UIEvent in jsdom).
+    label.element.dispatchEvent(new MouseEvent('mousedown', { detail: 2, bubbles: true, cancelable: true }))
+    await nextTick()
     expect(onMousedown).toHaveBeenCalledTimes(1)
     // Label's own handler ran first (double-click text-selection prevention).
     expect(onMousedown.mock.calls[0][0].defaultPrevented).toBe(true)

--- a/packages/core/src/Label/Label.vue
+++ b/packages/core/src/Label/Label.vue
@@ -8,11 +8,20 @@ export interface LabelProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
+import { mergeProps, useAttrs } from 'vue'
 import { useRender } from '@/Primitive'
+
+// Attrs are folded into `renderProps` below so they reach the element on both
+// the default path and the `#render` path (where the root is a fragment and Vue
+// cannot apply fallthrough attrs). Disabling inheritance keeps them applied once.
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = withDefaults(defineProps<LabelProps>(), {
   as: 'label',
 })
+const attrs = useAttrs()
 
 function onMousedown(event: MouseEvent) {
   // prevent text selection when double clicking label
@@ -24,7 +33,8 @@ const { tag, renderProps, state, elementRef } = useRender({
   defaultTagName: 'label',
   as: () => props.as,
   asChild: () => props.asChild,
-  props: () => ({ for: props.for, onMousedown }),
+  // Consumer attrs merge last so their listeners chain after Label's own.
+  props: () => mergeProps({ for: props.for, onMousedown }, attrs),
 })
 </script>
 

--- a/packages/core/src/RadioGroup/Radio.vue
+++ b/packages/core/src/RadioGroup/Radio.vue
@@ -55,7 +55,7 @@ const isFormControl = useFormControl(triggerElement)
 // `nested-interactive` a11y violation; forward the parent scope id for scoped styles.
 const scopeIdAttrs = useForwardScopeId()
 
-const ariaLabel = computed(() => props.id && triggerElement.value ? (getRootNode(triggerElement.value).querySelector(`[for="${props.id}"]`) as HTMLLabelElement)?.innerText ?? props.value : undefined)
+const ariaLabel = computed(() => props.id && triggerElement.value ? (getRootNode(triggerElement.value).querySelector(`[for="${props.id}"]`) as HTMLLabelElement)?.innerText : undefined)
 
 function handleClick(event: MouseEvent) {
   if (props.disabled)

--- a/packages/core/src/RadioGroup/RadioGroup.test.ts
+++ b/packages/core/src/RadioGroup/RadioGroup.test.ts
@@ -3,8 +3,9 @@ import { fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { nextTick } from 'vue'
 import { handleSubmit, sleep } from '@/test'
-import { RadioGroupItem } from '..'
+import { RadioGroupItem, RadioGroupRoot } from '..'
 import Radio from './story/_Radio.vue'
 import RadioGroup from './story/_RadioGroup.vue'
 
@@ -90,6 +91,47 @@ describe('given disabled RadioGroup', () => {
   it.each([[0], [1], [2]])('should have disabled attribute on item', async (input) => {
     expect(radios[input].attributes('disabled')).toBe('')
     expect(radios[input].attributes('data-disabled')).toBe('')
+  })
+})
+
+describe('given a RadioGroupItem whose label is not found', () => {
+  it('should not fall back to the value as the accessible name', async () => {
+    document.body.innerHTML = ''
+    const wrapper = mount({
+      components: { RadioGroupItem, RadioGroupRoot },
+      template: '<RadioGroupRoot><RadioGroupItem id="r1" value="event_type" /></RadioGroupRoot>',
+    }, { attachTo: document.body })
+    await nextTick()
+
+    expect(wrapper.find('[role=radio]').attributes('aria-label')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('should resolve aria-label from an associated [for] label', async () => {
+    document.body.innerHTML = '<label for="r2">Event type</label>'
+    // jsdom has no real `innerText`; mock it so the `[for]` lookup is exercised.
+    Object.defineProperty(document.querySelector('[for="r2"]'), 'innerText', { value: 'Event type', configurable: true })
+    const wrapper = mount({
+      components: { RadioGroupItem, RadioGroupRoot },
+      template: '<RadioGroupRoot><RadioGroupItem id="r2" value="event_type" /></RadioGroupRoot>',
+    }, { attachTo: document.body })
+    await nextTick()
+
+    expect(wrapper.find('[role=radio]').attributes('aria-label')).toBe('Event type')
+    wrapper.unmount()
+  })
+
+  it('should prefer an explicit aria-label over the [for] label', async () => {
+    document.body.innerHTML = '<label for="r3">Event type</label>'
+    Object.defineProperty(document.querySelector('[for="r3"]'), 'innerText', { value: 'Event type', configurable: true })
+    const wrapper = mount({
+      components: { RadioGroupItem, RadioGroupRoot },
+      template: '<RadioGroupRoot><RadioGroupItem id="r3" value="event_type" aria-label="Explicit" /></RadioGroupRoot>',
+    }, { attachTo: document.body })
+    await nextTick()
+
+    expect(wrapper.find('[role=radio]').attributes('aria-label')).toBe('Explicit')
+    wrapper.unmount()
   })
 })
 

--- a/packages/core/src/Switch/Switch.test.ts
+++ b/packages/core/src/Switch/Switch.test.ts
@@ -84,12 +84,37 @@ describe('switchRoot characterization (pre-refactor contract)', () => {
     wrapper.unmount()
   })
 
-  it('chains a consumer @click with the internal toggle (both fire)', async () => {
-    const onClick = vi.fn()
-    const wrapper = mount(SwitchRoot as any, { attrs: { onClick } })
+  // Controlled model: the toggle emits synchronously, so the consumer listener
+  // running first means it sees the pre-toggle state (v2 `v-bind` / `@click` order).
+  it('runs a consumer @click before the internal toggle (both fire, consumer first)', async () => {
+    const order: string[] = []
+    const onClick = vi.fn(() => order.push('consumer'))
+    const wrapper = mount(SwitchRoot as any, {
+      props: { 'modelValue': false, 'onUpdate:modelValue': () => order.push('update') },
+      attrs: { onClick },
+    })
     await wrapper.find('button').trigger('click')
     expect(onClick).toHaveBeenCalledTimes(1)
     expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([true])
+    expect(order).toEqual(['consumer', 'update'])
+  })
+
+  it('runs a consumer @keydown before the internal Enter toggle', async () => {
+    const order: string[] = []
+    const onKeydown = vi.fn(() => order.push('consumer'))
+    const wrapper = mount(SwitchRoot as any, {
+      props: { 'modelValue': false, 'onUpdate:modelValue': () => order.push('update') },
+      attrs: { onKeydown },
+    })
+    await wrapper.find('button').trigger('keydown', { key: 'Enter' })
+    expect(onKeydown).toHaveBeenCalledTimes(1)
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([true])
+    expect(order).toEqual(['consumer', 'update'])
+  })
+
+  it('lets a consumer attribute override the component\'s own (v2 precedence)', () => {
+    const wrapper = mount(SwitchRoot as any, { attrs: { role: 'menuitemcheckbox' } })
+    expect(wrapper.find('button').attributes('role')).toBe('menuitemcheckbox')
   })
 
   it('does not toggle when disabled', async () => {

--- a/packages/core/src/Switch/SwitchRoot.vue
+++ b/packages/core/src/Switch/SwitchRoot.vue
@@ -93,6 +93,16 @@ const { checked, root, context } = useSwitch<T>({
 })
 
 provideSwitchRootContext(context)
+
+// Listener order is part of the v2 contract: `v-bind="$attrs"` sat AFTER the
+// component's `role` / `aria-*` / `data-*` bindings (a consumer attribute wins)
+// but BEFORE `@click` / `@keydown` (a consumer listener runs first and observes
+// the pre-toggle model). `mergeProps` chains same-named listeners in argument
+// order, so the composable's handlers are bound separately below, after `$attrs`.
+const rootAttrs = computed(() => {
+  const { onClick: _onClick, onKeydown: _onKeydown, ...attrs } = root.props.value
+  return attrs
+})
 </script>
 
 <template>
@@ -103,7 +113,9 @@ provideSwitchRootContext(context)
     :aria-label="$attrs['aria-label'] || ariaLabel"
     :as-child="asChild"
     :as="as"
-    v-bind="mergeProps(root.props.value, stateToDataAttrs(root.state.value), scopeIdAttrs, $attrs)"
+    v-bind="mergeProps(rootAttrs, stateToDataAttrs(root.state.value), scopeIdAttrs, $attrs)"
+    @click="root.props.value.onClick"
+    @keydown="root.props.value.onKeydown"
   >
     <slot
       :model-value="modelValue"

--- a/packages/core/src/shared/useBodyScrollLock.test.ts
+++ b/packages/core/src/shared/useBodyScrollLock.test.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
+import { acquireBodyPointerEventsLock, releaseBodyPointerEventsLock } from '@/DismissableLayer/layerStack'
 import { useBodyScrollLock } from './useBodyScrollLock'
 
 function createWrapper(initialState: boolean) {
@@ -104,6 +105,24 @@ describe('useBodyScrollLock', () => {
 
     await nextTick()
     expect(document.body.style.overflow).toBe('')
+    expect(document.body.style.pointerEvents).toBe('')
+  })
+
+  // #2784: body `pointer-events` is shared with `DismissableLayer`. The last
+  // scroll lock releasing must not clear it while a layer still holds the lock.
+  it('should keep body pointer-events none while a DismissableLayer still owns the lock', async () => {
+    acquireBodyPointerEventsLock(document)
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    const locked = useBodyScrollLock(true)
+    await nextTick()
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    locked.value = false
+    await nextTick()
+    expect(document.body.style.pointerEvents).toBe('none')
+
+    releaseBodyPointerEventsLock(document)
     expect(document.body.style.pointerEvents).toBe('')
   })
 

--- a/packages/core/src/shared/useBodyScrollLock.ts
+++ b/packages/core/src/shared/useBodyScrollLock.ts
@@ -7,6 +7,9 @@ import { isClient, isIOS, tryOnBeforeUnmount } from '@vueuse/shared'
 import { defu } from 'defu'
 import { computed, nextTick, ref, watch } from 'vue'
 import { injectConfigProviderContext } from '@/ConfigProvider/ConfigProvider.vue'
+// Imported from the plain module (not the `@/DismissableLayer` barrel) so the
+// component's own `@/shared` import cannot form a cycle.
+import { hasBodyPointerEventsLock } from '@/DismissableLayer/layerStack'
 
 const useBodyLockStackCount = createSharedComposable(() => {
   const map = ref<Map<string, boolean>>(new Map())
@@ -29,7 +32,11 @@ const useBodyLockStackCount = createSharedComposable(() => {
   const resetBodyStyle = () => {
     document.body.style.paddingRight = ''
     document.body.style.marginRight = ''
-    document.body.style.pointerEvents = ''
+    // Body `pointer-events` is shared with `DismissableLayer`: a modal layer
+    // without its own scroll lock (e.g. a Dialog rendered without an Overlay)
+    // may still own it when the last scroll lock releases (#2784).
+    if (!hasBodyPointerEventsLock())
+      document.body.style.pointerEvents = ''
     document.documentElement.style.removeProperty('--scrollbar-width')
     document.body.style.overflow = initialOverflow.value ?? ''
     isIOS && stopTouchMoveListener?.()


### PR DESCRIPTION
### 🔗 Linked issue

Part of the v3 roadmap #2721. Touches #2722 (useRender), #2723 (Switch composable), #2724 (layer stack), #2725 (shadow DOM). Ports v2 fixes #2863, #2892, #2832, #2861 that never reached the `v3` branch.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A code review of the PRs merged to `v3` (#2788, #2790, #2791, #2792, #2793, #2794, #2795, #2796) against the `v2` branch found four regressions introduced on `v3` and four `v2` fixes that patched code `v3` had already rewritten, so they were never carried over. One commit per fix:

**Regressions on `v3`**

- **Label `#render` slot dropped every fallthrough attr** (from #2788). Label kept default `inheritAttrs`, and the `#render` root is a fragment, so class/id/aria/listeners vanished with an "Extraneous non-props attributes" warning. Now mirrors the `Primitive` shim: `inheritAttrs: false` plus `useAttrs()` folded into the props handed to `useRender`, applied exactly once on both paths.
- **Switch ran the internal toggle before consumer listeners** (from #2791). `mergeProps` chains same-named listeners in argument order, and `root.props` came before `$attrs`. v2 had `v-bind="$attrs"` before `@click`, so a consumer `@click` saw the pre-toggle model. The composable's handlers are now bound as directives after `v-bind`, restoring v2 precedence on both axes: consumer attribute wins, consumer listener runs first. The characterization tests now assert order rather than only that both fire.
- **Nested layers inside a shadow root lost ordering** (from #2790). The per-event snapshot was `document.querySelectorAll('[data-dismissable-layer]')`, which does not pierce shadow roots, so both layers indexed `-1` and a pointerdown inside the child dismissed the parent. Ordering now comes from the manager's registry with composed containment; subscribers that never register a stack layer (Editable) keep the previous document-order rule.
- **Two of three DismissableLayer benchmarks never reached the code they measure.** The pointerdown bench dispatched before subscribers armed and the Escape bench dispatched a non-bubbling keydown on `document` while the listener is on `window`. Mount and arm now happen in `setup`; the measured body is the dispatch alone.

**v2 fixes ported into the rewritten code**

- #2863 ignore outside pointerdown while not present: `() => props.present` is passed as `enabled` to the outside subscribers.
- #2892 drop stale deferred click on inside pointerdown: the inside-tree branch of `handlePointerDown` now calls `cancelTouch`.
- #2832 keep body `pointer-events` locked when the last scroll lock releases: `layerStack` exports `hasBodyPointerEventsLock()` and `useBodyScrollLock` consults it before clearing the style. The v2 patch imported the removed `context.ts`, so it could not be applied as-is.
- #2861 RadioGroup no longer falls back to the item value for `aria-label`, on top of the v3 `getRootNode` lookup.

Tests from the v2 commits are ported and adapted to `resetLayerStack()`; new tests cover the Label attrs paths, Switch listener order, and the shadow-root ordering case.

**Validation note:** the environment this was authored in blocks the npm registry, so the test suite and lint could not be run locally. Every change was verified by reading the diff against v2 and CI on this PR is the first execution. Please treat a red run as expected feedback rather than a surprise.

### 📸 Screenshots (if appropriate)

n/a

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu)_