### PR TITLE
feat!: ship ESM-only, drop the CJS build

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,36 +31,29 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.js",
-      "require": "./dist/internal.cjs"
+      "import": "./dist/internal.js"
     },
     "./constant": {
-      "import": "./dist/constant.js",
-      "require": "./dist/constant.cjs"
+      "import": "./dist/constant.js"
     },
     "./date": {
-      "import": "./dist/date.js",
-      "require": "./dist/date.cjs"
+      "import": "./dist/date.js"
     },
     "./namespaced": {
-      "import": "./dist/namespaced/index.mjs",
-      "require": "./dist/namespaced/index.cjs"
+      "import": "./dist/namespaced/index.mjs"
     },
     "./nuxt": {
-      "import": "./dist/nuxt/index.mjs",
-      "require": "./dist/nuxt/index.cjs"
+      "import": "./dist/nuxt/index.mjs"
     },
     "./resolver": {
-      "import": "./dist/resolver/index.mjs",
-      "require": "./dist/resolver/index.cjs"
+      "import": "./dist/resolver/index.mjs"
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -42,17 +42,20 @@ export default defineConfig({
   },
   fromVite: true,
   platform: 'neutral',
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   tsconfig: './tsconfig.app.json',
   dts: { vue: true, sourcemap: true },
   sourcemap: true,
   hash: false,
 
   /**
-   * Quick fix for tsdown not convert "import.meta" for non-esm output.
-   * When tsdown resolves the issue, this can be removed.
-   *
-   * @see https://github.com/rolldown/tsdown/issues/370
+   * The dist output makes no bundler assumption: `import.meta.env` is only
+   * populated by Vite-style bundlers and is `undefined` in plain Node ESM,
+   * Vitest-externalised deps and browser `<script type="module">` usage, where
+   * `import.meta.env.DEV` would throw a TypeError. Replace the few dev-only
+   * `import.meta.env.*` reads in `src` with `undefined` so they are inert.
+   * Dev-only warnings that must survive in dist use `process.env.NODE_ENV`
+   * instead (same convention as Vue's own esm-bundler build).
    */
   define: {
     'import.meta.env.DEV': 'undefined',

--- a/packages/plugins/build.config.ts
+++ b/packages/plugins/build.config.ts
@@ -10,9 +10,6 @@ export default defineBuildConfig([
     externals: [
       '@nuxt/schema',
     ],
-    rollup: {
-      emitCJS: true,
-    },
   },
   {
     name: 'Unplugin-vue-component Resolver',
@@ -23,9 +20,6 @@ export default defineBuildConfig([
     externals: [
       'unplugin-vue-components',
     ],
-    rollup: {
-      emitCJS: true,
-    },
   },
   {
     name: 'Namespaced',
@@ -36,8 +30,5 @@ export default defineBuildConfig([
     externals: [
       'reka-ui',
     ],
-    rollup: {
-      emitCJS: true,
-    },
   },
 ])


### PR DESCRIPTION
### 🔗 Linked issue

Closes #2733. Part of the v3 roadmap #2721.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Ships `reka-ui` as ESM only.

- `packages/core/tsdown.config.ts`: `format: ['esm']`.
- `packages/core/package.json`: every `require` condition removed from `exports` (`.`, `./internal`, `./constant`, `./date`, `./namespaced`, `./nuxt`, `./resolver`); `main` now points at `./dist/index.js`.
- `packages/plugins/build.config.ts`: the three `rollup.emitCJS` blocks removed, so unbuild emits only `index.mjs` + `.d.mts` for the `nuxt`, `resolver` and `namespaced` entries, matching the remaining `import` conditions.

Two deliberate departures from the ticket text:

- **`main` is kept, not deleted.** `moduleResolution: node` (which `packages/plugins/tsconfig.json` itself uses), jiti/unbuild in Nuxt, and older bundlers fall back to `main` when they ignore `exports`. Pointing it at the ESM entry gives them a real file; on Node ≥ 20.19 / ≥ 22.12 `require()` of it works via `require(esm)`, and older Node gets a clear `ERR_REQUIRE_ESM` instead of a missing-file error.
- **The `import.meta.env` `define` block is kept.** The ticket assumes it exists only because tsdown could not convert `import.meta` for CJS. It is actually what keeps the dev-only reads in shipped source (`Splitter/utils/validation.ts`, `useWindowSplitterPanelGroupBehavior.ts`, `ColorSwatch.vue`, `shared/useHideOthers.ts`) from throwing where `import.meta.env` is `undefined`: plain Node ESM (Nuxt/Nitro with reka-ui externalised on the server), consumers' Vitest runs, and a bare `<script type="module">`. The comment is rewritten to say so. `process.env.NODE_ENV` sites are left as they are, consistent with Vue's own `esm-bundler` build.

Audited and unchanged because they carry no CJS references: `.size-limit.json`, all workflows, `CONTRIBUTING.md`, docs content, playgrounds, and `packages/plugins/src`. Nothing in `packages/` or `docs/` imports a dist file by path.

**Migration note for the v3 changelog:**

> **ESM-only package.** `reka-ui` v3 ships ESM only. The `.cjs` bundles and the `require` export conditions for `reka-ui`, `reka-ui/internal`, `reka-ui/constant`, `reka-ui/date`, `reka-ui/namespaced`, `reka-ui/nuxt` and `reka-ui/resolver` are gone; `main` now points at `dist/index.js` (ESM). Vite, Nuxt, webpack 5, Rollup, esbuild and TypeScript `bundler`/`node16` users are unaffected. If you `require('reka-ui')` from CommonJS, switch to `import` (or `await import()`), or run Node ≥ 20.19 / ≥ 22.12 where `require(esm)` is supported. Jest users must transform `reka-ui` or run in ESM mode.

**Validation note:** the authoring environment blocks the npm registry, so the build could not be run locally. CI's build job is the first execution; a `publint`/`attw` check would be a good follow-up but needs a new dev dependency, which could not be added without regenerating the lockfile.

### 📸 Screenshots (if appropriate)

n/a

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu)_