### PR TITLE
ci: auto-review PRs against the v3 branch with CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit only auto-reviews PRs targeting the default branch (`v2`) unless
+# extra base branches are listed here. `v3` is the long-lived major-version
+# branch, so its PRs need review too.
+language: en-US
+reviews:
+  profile: chill
+  auto_review:
+    enabled: true
+    base_branches:
+      - v3


### PR DESCRIPTION
### 🔗 Linked issue

Supports the v3 roadmap #2721: every PR against the `v3` branch so far has been skipped by CodeRabbit ("Auto reviews are disabled on base/target branches other than the default branch").

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a root `.coderabbit.yaml` that lists `v3` under `reviews.auto_review.base_branches`, so PRs targeting the long-lived major-version branch get the same automatic review as PRs targeting `v2`. Everything else stays at CodeRabbit's defaults (`chill` profile, auto review enabled).

The identical file is also on the `v3` branch via #2910. Whether CodeRabbit resolves the config from the PR's base branch or from the repository default branch could not be confirmed from the docs in the authoring environment, so it is added to both; the copies are byte-identical and one of them is redundant by design.

### 📸 Screenshots (if appropriate)

n/a

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request reviews with English-language feedback.
  * Enabled the “chill” review profile.
  * Added support for reviewing pull requests targeting the `v3` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->