### PR TITLE
feat(v3)!: normalize data-state to the open/closed and checked/unchecked axes

### DIFF
--- a/docs/.vitepress/components/HeroCodeGroup.vue
+++ b/docs/.vitepress/components/HeroCodeGroup.vue
@@ -69,7 +69,7 @@ watch(open, () => {
             :key="index"
             :value="tab.label"
             tabindex="-1"
-            class="text-white/70 py-2.5 px-4 border-box data-[state=active]:shadow-[0_1px_0_#10b981] data-[state=active]:font-medium data-[state=active]:text-white"
+            class="text-white/70 py-2.5 px-4 border-box data-[state=checked]:shadow-[0_1px_0_#10b981] data-[state=checked]:font-medium data-[state=checked]:text-white"
           >
             {{ tab.label }}
           </TabsTrigger>

--- a/docs/.vitepress/components/InstallationTabs.vue
+++ b/docs/.vitepress/components/InstallationTabs.vue
@@ -17,7 +17,7 @@ import { store } from '../store'
             :key="index"
             :value="pkg"
             tabindex="-1"
-            class="text-white/70 py-2.5 px-4 data-[state=active]:shadow-[0_1px_0_#10b981] data-[state=active]:font-medium data-[state=active]:text-white hover:text-white"
+            class="text-white/70 py-2.5 px-4 data-[state=checked]:shadow-[0_1px_0_#10b981] data-[state=checked]:font-medium data-[state=checked]:text-white hover:text-white"
           >
             {{ pkg }}
           </TabsTrigger>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -134,6 +134,10 @@ export default defineConfig({
             text: `Migration ${BadgeHTML('New')}`,
             link: '/docs/guides/migration',
           },
+          {
+            text: `Migration to v3 ${BadgeHTML('New')}`,
+            link: '/docs/guides/migration-v3',
+          },
 
           { text: `llms.txt ${BadgeHTML('New')}`, link: '/llms.txt' },
         ],

--- a/docs/components/Tooltip.vue
+++ b/docs/components/Tooltip.vue
@@ -16,7 +16,7 @@ defineProps<{
     </TooltipTrigger>
     <TooltipPortal>
       <TooltipContent
-        class="border border-muted data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-foreground select-none rounded-md bg-background px-[15px] py-[10px] text-xs leading-none will-change-[transform,opacity]"
+        class="border border-muted data-[state=open]:data-[delayed]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[delayed]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[delayed]:data-[side=left]:animate-slideRightAndFade data-[state=open]:data-[delayed]:data-[side=bottom]:animate-slideUpAndFade text-foreground select-none rounded-md bg-background px-[15px] py-[10px] text-xs leading-none will-change-[transform,opacity]"
         :side-offset="6"
       >
         <span

--- a/docs/components/demo/NavigationMenu/css/styles.css
+++ b/docs/components/demo/NavigationMenu/css/styles.css
@@ -99,10 +99,10 @@ p {
   z-index: 1;
   transition: width, transform 250ms ease;
 }
-.NavigationMenuIndicator[data-state='visible'] {
+.NavigationMenuIndicator[data-state='open'] {
   animation: fadeIn 200ms ease;
 }
-.NavigationMenuIndicator[data-state='hidden'] {
+.NavigationMenuIndicator[data-state='closed'] {
   animation: fadeOut 200ms ease;
 }
 

--- a/docs/components/demo/NavigationMenu/tailwind/index.vue
+++ b/docs/components/demo/NavigationMenu/tailwind/index.vue
@@ -136,7 +136,7 @@ const currentTrigger = ref('')
       </NavigationMenuItem>
 
       <NavigationMenuIndicator
-        class="absolute data-[state=hidden]:opacity-0 duration-200 data-[state=visible]:animate-fadeIn data-[state=hidden]:animate-fadeOut top-full w-[--reka-navigation-menu-indicator-size] translate-x-[--reka-navigation-menu-indicator-position] mt-[1px] z-[100] flex h-[10px] items-end justify-center overflow-hidden transition-[all,transform_250ms_ease]"
+        class="absolute data-[state=closed]:opacity-0 duration-200 data-[state=open]:animate-fadeIn data-[state=closed]:animate-fadeOut top-full w-[--reka-navigation-menu-indicator-size] translate-x-[--reka-navigation-menu-indicator-position] mt-[1px] z-[100] flex h-[10px] items-end justify-center overflow-hidden transition-[all,transform_250ms_ease]"
       >
         <div class="relative top-[70%] h-[12px] w-[12px] rotate-[45deg] bg-white border" />
       </NavigationMenuIndicator>

--- a/docs/components/demo/Rating/css/styles.css
+++ b/docs/components/demo/Rating/css/styles.css
@@ -26,7 +26,7 @@
   z-index: var(--reka-rating-item-step-z-index);
 }
 
-.RatingItemIndicator[data-state="active"] {
+.RatingItemIndicator[data-state="checked"] {
   color: hsl(142.1 70.6% 45.3%);
   filter: drop-shadow(0 1px 4px hsl(142.1 70.6% 45.3% / 0.5));
 }

--- a/docs/components/demo/Rating/tailwind/index.vue
+++ b/docs/components/demo/Rating/tailwind/index.vue
@@ -24,7 +24,7 @@ const rating = ref(3)
         :key="step"
         :step="step"
         :aria-label="`Rate ${step}`"
-        class="absolute overflow-hidden text-stone-200 transition-colors duration-150 data-[state=active]:text-[hsl(142.1_70.6%_45.3%)] data-[state=active]:drop-shadow-[0_1px_4px_hsl(142.1_70.6%_45.3%/0.5)] w-[var(--reka-rating-item-step-width)] opacity-[var(--reka-rating-item-step-opacity)] z-[var(--reka-rating-item-step-z-index)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(142.1_70.6%_45.3%)] rounded"
+        class="absolute overflow-hidden text-stone-200 transition-colors duration-150 data-[state=checked]:text-[hsl(142.1_70.6%_45.3%)] data-[state=checked]:drop-shadow-[0_1px_4px_hsl(142.1_70.6%_45.3%/0.5)] w-[var(--reka-rating-item-step-width)] opacity-[var(--reka-rating-item-step-opacity)] z-[var(--reka-rating-item-step-z-index)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(142.1_70.6%_45.3%)] rounded"
       >
         <Icon
           icon="material-symbols:star-rounded"

--- a/docs/components/demo/Tabs/css/styles.css
+++ b/docs/components/demo/Tabs/css/styles.css
@@ -66,7 +66,7 @@ input {
 .TabsTrigger:hover {
   color: var(--grass-11);
 }
-.TabsTrigger[data-state='active'] {
+.TabsTrigger[data-state='checked'] {
   color: var(--grass-11);
   box-shadow: inset 0 -1px 0 0 currentColor, 0 1px 0 0 currentColor;
 }

--- a/docs/components/demo/Tabs/tailwind/index.vue
+++ b/docs/components/demo/Tabs/tailwind/index.vue
@@ -15,13 +15,13 @@ import { TabsContent, TabsIndicator, TabsList, TabsRoot, TabsTrigger } from 'rek
         <div class="bg-grass8 w-full h-full" />
       </TabsIndicator>
       <TabsTrigger
-        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-sm leading-none text-mauve11 select-none  rounded-tl-md  hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-black"
+        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-sm leading-none text-mauve11 select-none  rounded-tl-md  hover:text-grass11 data-[state=checked]:text-grass11 outline-none cursor-default focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-black"
         value="tab1"
       >
         Account
       </TabsTrigger>
       <TabsTrigger
-        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-sm leading-none text-mauve11 select-none  rounded-tr-md hover:text-grass11 data-[state=active]:text-grass11 outline-none cursor-default focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-black"
+        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-sm leading-none text-mauve11 select-none  rounded-tr-md hover:text-grass11 data-[state=checked]:text-grass11 outline-none cursor-default focus-visible:relative focus-visible:shadow-[0_0_0_2px] focus-visible:shadow-black"
         value="tab2"
       >
         Password

--- a/docs/components/demo/Toggle/css/styles.css
+++ b/docs/components/demo/Toggle/css/styles.css
@@ -23,7 +23,7 @@ button {
 .Toggle:hover {
   background-color: var(--grass-3);
 }
-.Toggle[data-state='on'] {
+.Toggle[data-state='checked'] {
   background-color: var(--grass-6);
   color: var(--grass-12);
 }

--- a/docs/components/demo/Toggle/tailwind/index.vue
+++ b/docs/components/demo/Toggle/tailwind/index.vue
@@ -10,7 +10,7 @@ const toggleState = ref(false)
   <Toggle
     v-model="toggleState"
     aria-label="Toggle italic"
-    class="hover:bg-stone-50 text-stone-700 data-[state=on]:bg-stone-100 shadow-sm flex h-[35px] w-[35px] items-center justify-center rounded-lg border bg-white text-base leading-4 focus-within:outline-none focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
+    class="hover:bg-stone-50 text-stone-700 data-[state=checked]:bg-stone-100 shadow-sm flex h-[35px] w-[35px] items-center justify-center rounded-lg border bg-white text-base leading-4 focus-within:outline-none focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
   >
     <Icon
       icon="radix-icons:font-italic"

--- a/docs/components/demo/ToggleGroup/css/styles.css
+++ b/docs/components/demo/ToggleGroup/css/styles.css
@@ -38,7 +38,7 @@ button {
 .ToggleGroupItem:hover {
   background-color: var(--grass-3);
 }
-.ToggleGroupItem[data-state='on'] {
+.ToggleGroupItem[data-state='checked'] {
   background-color: var(--grass-5);
   color: var(--grass-11);
 }

--- a/docs/components/demo/ToggleGroup/tailwind/index.vue
+++ b/docs/components/demo/ToggleGroup/tailwind/index.vue
@@ -7,7 +7,7 @@ const toggleStateSingle = ref('left')
 const toggleStateMultiple = ref(['italic'])
 
 const toggleGroupItemClasses
-  = 'hover:bg-stone-50 text-mauve11 data-[state=on]:bg-stone-100 flex h-[35px] w-[35px] items-center justify-center bg-white text-base leading-4 first:rounded-l-[7px] last:rounded-r-[7px] focus:z-10 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none'
+  = 'hover:bg-stone-50 text-mauve11 data-[state=checked]:bg-stone-100 flex h-[35px] w-[35px] items-center justify-center bg-white text-base leading-4 first:rounded-l-[7px] last:rounded-r-[7px] focus:z-10 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none'
 </script>
 
 <template>

--- a/docs/components/demo/Toolbar/css/styles.css
+++ b/docs/components/demo/Toolbar/css/styles.css
@@ -52,7 +52,7 @@ button {
 .ToolbarToggleItem:first-child {
   margin-left: 0;
 }
-.ToolbarToggleItem[data-state='on'] {
+.ToolbarToggleItem[data-state='checked'] {
   background-color: var(--grass-5);
   color: var(--grass-11);
 }

--- a/docs/components/demo/Toolbar/tailwind/index.vue
+++ b/docs/components/demo/Toolbar/tailwind/index.vue
@@ -25,7 +25,7 @@ const toggleStateMultiple = ref([])
       aria-label="Text formatting"
     >
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=on]:bg-green5 data-[state=on]:text-grass11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=checked]:bg-green5 data-[state=checked]:text-grass11"
         value="bold"
         aria-label="Bold"
       >
@@ -35,7 +35,7 @@ const toggleStateMultiple = ref([])
         />
       </ToolbarToggleItem>
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=on]:bg-green5 data-[state=on]:text-grass11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=checked]:bg-green5 data-[state=checked]:text-grass11"
         value="italic"
         aria-label="Italic"
       >
@@ -45,7 +45,7 @@ const toggleStateMultiple = ref([])
         />
       </ToolbarToggleItem>
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=on]:bg-green5 data-[state=on]:text-grass11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=checked]:bg-green5 data-[state=checked]:text-grass11"
         value="strikethrough"
         aria-label="Strike through"
       >
@@ -62,7 +62,7 @@ const toggleStateMultiple = ref([])
       aria-label="Text Alignment"
     >
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=on]:bg-green5 data-[state=on]:text-grass11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=checked]:bg-green5 data-[state=checked]:text-grass11"
         value="left"
         aria-label="Left Aligned"
       >
@@ -72,7 +72,7 @@ const toggleStateMultiple = ref([])
         />
       </ToolbarToggleItem>
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=on]:bg-green5 data-[state=on]:text-grass11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=checked]:bg-green5 data-[state=checked]:text-grass11"
         value="center"
         aria-label="Center Aligned"
       >
@@ -82,7 +82,7 @@ const toggleStateMultiple = ref([])
         />
       </ToolbarToggleItem>
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=on]:bg-green5 data-[state=on]:text-grass11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-xs leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=checked]:bg-green5 data-[state=checked]:text-grass11"
         value="right"
         aria-label="Right Aligned"
       >
@@ -94,7 +94,7 @@ const toggleStateMultiple = ref([])
     </ToolbarToggleGroup>
     <ToolbarSeparator class="w-[1px] bg-mauve6 mx-[10px]" />
     <ToolbarLink
-      class="bg-transparent !font-normal !text-mauve11 inline-flex justify-center items-center hover:bg-transparent hover:cursor-pointer flex-shrink-0 flex-grow-0 basis-auto h-[25px] px-[5px] rounded text-xs leading-none bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=on]:bg-green5 data-[state=on]:text-grass11"
+      class="bg-transparent !font-normal !text-mauve11 inline-flex justify-center items-center hover:bg-transparent hover:cursor-pointer flex-shrink-0 flex-grow-0 basis-auto h-[25px] px-[5px] rounded text-xs leading-none bg-white ml-0.5 outline-none hover:bg-green3 hover:text-grass11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-green7 first:ml-0 data-[state=checked]:bg-green5 data-[state=checked]:text-grass11"
       href="#"
       target="_blank"
       style="margin-right: 10"

--- a/docs/components/demo/Tooltip/css/styles.css
+++ b/docs/components/demo/Tooltip/css/styles.css
@@ -19,16 +19,16 @@ button {
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;
 }
-.TooltipContent[data-state='delayed-open'][data-side='top'] {
+.TooltipContent[data-state='open'][data-delayed][data-side='top'] {
   animation-name: slideDownAndFade;
 }
-.TooltipContent[data-state='delayed-open'][data-side='right'] {
+.TooltipContent[data-state='open'][data-delayed][data-side='right'] {
   animation-name: slideLeftAndFade;
 }
-.TooltipContent[data-state='delayed-open'][data-side='bottom'] {
+.TooltipContent[data-state='open'][data-delayed][data-side='bottom'] {
   animation-name: slideUpAndFade;
 }
-.TooltipContent[data-state='delayed-open'][data-side='left'] {
+.TooltipContent[data-state='open'][data-delayed][data-side='left'] {
   animation-name: slideRightAndFade;
 }
 

--- a/docs/components/demo/Tooltip/tailwind/index.vue
+++ b/docs/components/demo/Tooltip/tailwind/index.vue
@@ -13,7 +13,7 @@ import { TooltipArrow, TooltipContent, TooltipPortal, TooltipProvider, TooltipRo
       </TooltipTrigger>
       <TooltipPortal>
         <TooltipContent
-          class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-grass11 select-none rounded-md bg-white px-[15px] py-[10px] text-sm leading-none shadow-sm border will-change-[transform,opacity]"
+          class="data-[state=open]:data-[delayed]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[delayed]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[delayed]:data-[side=left]:animate-slideRightAndFade data-[state=open]:data-[delayed]:data-[side=bottom]:animate-slideUpAndFade text-grass11 select-none rounded-md bg-white px-[15px] py-[10px] text-sm leading-none shadow-sm border will-change-[transform,opacity]"
           :side-offset="5"
         >
           Add to library

--- a/docs/content/docs/components/navigation-menu.md
+++ b/docs/content/docs/components/navigation-menu.md
@@ -208,7 +208,7 @@ An optional indicator element that renders below the list, is used to highlight 
   :data="[
     {
       attribute: '[data-state]',
-      values: ['visible', 'hidden'],
+      values: ['open', 'closed'],
     },
     {
       attribute: '[data-orientation]',
@@ -242,7 +242,7 @@ An optional viewport element that is used to render active content outside of th
   :data="[
     {
       attribute: '[data-state]',
-      values: ['visible', 'hidden'],
+      values: ['open', 'closed'],
     },
     {
       attribute: '[data-orientation]',

--- a/docs/content/docs/components/rating.md
+++ b/docs/content/docs/components/rating.md
@@ -98,7 +98,7 @@ The interactive indicator rendered for each step of an item. It reflects whether
   :data="[
     {
       attribute: '[data-state]',
-      values: ['active'],
+      values: ['checked', 'unchecked'],
     },
     {
       attribute: '[data-disabled]',
@@ -179,7 +179,7 @@ Use the `clearable` prop to let users reset the rating to `0` by clicking the cu
 
 ### Hover preview
 
-Use the `hoverable` prop to preview the value under the pointer before committing to it. The `RatingItemIndicator` exposes `data-state="active"` for every step at or below the hovered value.
+Use the `hoverable` prop to preview the value under the pointer before committing to it. The `RatingItemIndicator` exposes `data-state="checked"` for every step at or below the hovered value.
 
 ```vue line=4
 <template>

--- a/docs/content/docs/components/scroll-area.md
+++ b/docs/content/docs/components/scroll-area.md
@@ -79,7 +79,7 @@ The vertical scrollbar. Add a second `Scrollbar` with an `orientation` prop to e
   :data="[
     {
       attribute: '[data-state]',
-      values: ['visible', 'hidden'],
+      values: ['open', 'closed'],
     },
     {
       attribute: '[data-orientation]',
@@ -98,7 +98,7 @@ The thumb to be used in `ScrollAreaScrollbar`.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['visible', 'hidden'],
+      values: ['open', 'closed'],
     },
   ]"
 />

--- a/docs/content/docs/components/splitter.md
+++ b/docs/content/docs/components/splitter.md
@@ -66,7 +66,7 @@ Contains all the parts of a Splitter.
     },
     {
       attribute: '[data-state]',
-      values: ['collapsed', 'expanded', 'Present when collapsbile'],
+      values: ['open', 'closed'],
     },
   ]"
 />

--- a/docs/content/docs/components/tabs.md
+++ b/docs/content/docs/components/tabs.md
@@ -93,7 +93,7 @@ The button that activates its associated content.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['active', 'inactive'],
+      values: ['checked', 'unchecked'],
     },
     {
       attribute: '[data-disabled]',
@@ -141,7 +141,7 @@ Contains the content associated with each trigger.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['active', 'inactive'],
+      values: ['checked', 'unchecked'],
     },
     {
       attribute: '[data-orientation]',

--- a/docs/content/docs/components/tags-input.md
+++ b/docs/content/docs/components/tags-input.md
@@ -87,7 +87,7 @@ The component that contains the tag.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['active', 'inactive'],
+      values: ['checked', 'unchecked'],
     },
     {
       attribute: '[data-disabled]',
@@ -112,7 +112,7 @@ The button that delete the associate tag.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['active', 'inactive'],
+      values: ['checked', 'unchecked'],
     },
     {
       attribute: '[data-disabled]',

--- a/docs/content/docs/components/toggle-group.md
+++ b/docs/content/docs/components/toggle-group.md
@@ -74,7 +74,7 @@ An item in the group.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['on', 'off'],
+      values: ['checked', 'unchecked'],
     },
     {
       attribute: '[data-disabled]',

--- a/docs/content/docs/components/toggle.md
+++ b/docs/content/docs/components/toggle.md
@@ -52,7 +52,7 @@ The toggle.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['on', 'off'],
+      values: ['checked', 'unchecked'],
     },
     {
       attribute: '[data-disabled]',

--- a/docs/content/docs/components/toolbar.md
+++ b/docs/content/docs/components/toolbar.md
@@ -116,7 +116,7 @@ An item in the group.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['on', 'off'],
+      values: ['checked', 'unchecked'],
     },
     {
       attribute: '[data-disabled]',

--- a/docs/content/docs/components/tooltip.md
+++ b/docs/content/docs/components/tooltip.md
@@ -70,7 +70,11 @@ The button that toggles the tooltip. By default, the `TooltipContent` will posit
   :data="[
     {
       attribute: '[data-state]',
-      values: ['closed', 'delayed-open', 'instant-open'],
+      values: ['open', 'closed'],
+    },
+    {
+      attribute: '[data-delayed]',
+      values: 'Present when the tooltip opened after the delay',
     },
   ]"
 />
@@ -93,7 +97,11 @@ The component that pops out when the tooltip is open.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['closed', 'delayed-open', 'instant-open'],
+      values: ['open', 'closed'],
+    },
+    {
+      attribute: '[data-delayed]',
+      values: 'Present when the tooltip opened after the delay',
     },
     {
       attribute: '[data-side]',

--- a/docs/content/docs/guides/migration-v3.md
+++ b/docs/content/docs/guides/migration-v3.md
@@ -1,0 +1,69 @@
+---
+title: Migration - v2 to v3
+description: This guide collects the breaking changes between Reka UI v2 and v3, with search-and-replace instructions for each of them.
+---
+
+# Migration - v2 to v3
+
+<Description>
+This guide collects the breaking changes between Reka UI v2 and v3, with search-and-replace instructions for each of them.
+</Description>
+
+Reka UI v3 is still in progress. This page collects the breaking changes as they land on the `v3` branch, so it will keep growing until the release is finalized. Each section describes what changed and the mechanical rewrite needed to move an existing v2 codebase over.
+
+## `data-state` vocabulary
+
+In v3, `data-state` answers exactly one of two questions: disclosure ("is this surface revealed?") is reported as `open` or `closed`, and selection ("is this control in its affirmative state?") is reported as `checked` or `unchecked`, with `indeterminate` reserved for tri-state controls that also emit `aria-checked="mixed"`. Both values are always emitted—`data-state` is never absent—and qualifiers such as *how* a surface came to be open live in their own `data-*` attribute rather than in `data-state`.
+
+Parts that were already on `open` / `closed` or `checked` / `unchecked` / `indeterminate` are unchanged. Genuine multi-value machines keep their vocabulary: [Progress](../components/progress) (`indeterminate` / `loading` / `complete`), [Stepper](../components/stepper) (`completed` / `active` / `inactive`) and the [Splitter](../components/splitter) resize handle (`drag` / `hover` / `inactive`) are untouched.
+
+| Part | v2 | v3 |
+| --- | --- | --- |
+| `Toggle`, `ToggleGroupItem`, `ToolbarToggleItem` | `on` / `off` | `checked` / `unchecked` |
+| `TabsTrigger`, `TabsContent` | `active` / `inactive` | `checked` / `unchecked` |
+| `TagsInputItem`, `TagsInputItemDelete` | `active` / `inactive` | `checked` / `unchecked` |
+| `RatingItemIndicator` | `active` / (absent) | `checked` / `unchecked` |
+| `ScrollAreaScrollbar`, `ScrollAreaThumb`, `NavigationMenuIndicator` | `visible` / `hidden` | `open` / `closed` |
+| `SplitterPanel` | `expanded` / `collapsed` / (absent when not collapsible) | `open` / `closed` (non-collapsible panels are always `open`) |
+| `CollapsibleContent` | `open` / `closed` / (absent on the initial animated mount) | `open` / `closed` |
+| `TooltipTrigger`, `TooltipContent` | `closed` / `delayed-open` / `instant-open` | `open` / `closed`, plus a boolean `data-delayed` attribute present while open when the open was delayed |
+| Everything already on `open` / `closed` or `checked` / `unchecked` / `indeterminate` | unchanged | unchanged |
+
+### Search and replace
+
+The rewrites are mechanical. In Tailwind variants:
+
+- `data-[state=on]:` → `data-[state=checked]:`, `data-[state=off]:` → `data-[state=unchecked]:`
+- `data-[state=active]:` → `data-[state=checked]:`, `data-[state=inactive]:` → `data-[state=unchecked]:` — for **Tabs and TagsInput only**. Stepper keeps `active` / `inactive` / `completed`, so leave selectors on `StepperItem` alone.
+- `data-[state=visible]:` → `data-[state=open]:`, `data-[state=hidden]:` → `data-[state=closed]:`
+- `data-[state=expanded]:` → `data-[state=open]:`, `data-[state=collapsed]:` → `data-[state=closed]:`
+- `data-[state=delayed-open]:` → `data-[state=open]:data-[delayed]:`
+- `data-[state=instant-open]:` → `data-[state=open]:` (combine with `:not([data-delayed])` in plain CSS if you need to target instant opens specifically)
+
+In plain CSS the same rewrites apply to attribute selectors:
+
+- `[data-state='on']` → `[data-state='checked']`, `[data-state='off']` → `[data-state='unchecked']`
+- `[data-state='active']` → `[data-state='checked']`, `[data-state='inactive']` → `[data-state='unchecked']` — Tabs and TagsInput only, not Stepper.
+- `[data-state='visible']` → `[data-state='open']`, `[data-state='hidden']` → `[data-state='closed']`
+- `[data-state='expanded']` → `[data-state='open']`, `[data-state='collapsed']` → `[data-state='closed']`
+- `[data-state='delayed-open']` → `[data-state='open'][data-delayed]`
+- `[data-state='instant-open']` → `[data-state='open']:not([data-delayed])`
+
+Because both values are now always emitted, any styles that relied on the attribute being *absent* (for example `.RatingItemIndicator:not([data-state])`, or a `SplitterPanel` without `data-state` because it is not collapsible) should target the explicit `unchecked` / `open` value instead.
+
+```css
+.Toggle[data-state='on'] { /* [!code --] */
+.Toggle[data-state='checked'] { /* [!code ++] */
+  background-color: var(--green-5);
+}
+
+.TabsTrigger[data-state='active'] { /* [!code --] */
+.TabsTrigger[data-state='checked'] { /* [!code ++] */
+  color: var(--grass-11);
+}
+
+.TooltipContent[data-state='delayed-open'][data-side='top'] { /* [!code --] */
+.TooltipContent[data-state='open'][data-delayed][data-side='top'] { /* [!code ++] */
+  animation-name: slideDownAndFade;
+}
+```

--- a/docs/content/docs/guides/styling.md
+++ b/docs/content/docs/guides/styling.md
@@ -28,6 +28,24 @@ Some elements, such as modals or popovers, are teleported to the `body`. When us
 
 When components are stateful, their state will be exposed in a `data-state` attribute. For example, when an [Accordion Item](../components/accordion) is opened, it includes a `data-state="open"` attribute.
 
+#### The `data-state` vocabulary
+
+`data-state` answers exactly one of two questions. For disclosure ("is this surface revealed?") the value is `open` or `closed`—an [Accordion Item](../components/accordion) that is expanded has `data-state="open"`. For selection ("is this control in its affirmative state?") the value is `checked` or `unchecked`—a pressed [Toggle](../components/toggle) has `data-state="checked"`. The only third value is `indeterminate`, emitted by tri-state controls such as [Checkbox](../components/checkbox) alongside `aria-checked="mixed"`. Qualifiers that describe *how* a state was reached live in their own attribute rather than in `data-state`: a [Tooltip](../components/tooltip) that opened after its delay is `data-state="open"` with an additional `data-delayed` attribute.
+
+```css
+.AccordionItem[data-state="open"] {
+  /* revealed */
+}
+
+.Toggle[data-state="checked"] {
+  /* affirmative */
+}
+
+.TooltipContent[data-state="open"][data-delayed] {
+  /* opened after the delay */
+}
+```
+
 ## Styling with CSS
 
 ### Styling a part

--- a/packages/core/src/Accordion/AccordionItem.vue
+++ b/packages/core/src/Accordion/AccordionItem.vue
@@ -1,13 +1,9 @@
 <script lang="ts">
 import type { ComputedRef, VNodeRef } from 'vue'
 import type { CollapsibleRootProps } from '../Collapsible'
-import { createContext, useArrowNavigation, useForwardExpose } from '@/shared'
+import type { DisclosureState } from '@/shared'
+import { createContext, disclosureState, useArrowNavigation, useForwardExpose } from '@/shared'
 import { injectAccordionRootContext } from './AccordionRoot.vue'
-
-enum AccordionItemState {
-  Open = 'open',
-  Closed = 'closed',
-}
 
 export interface AccordionItemProps
   extends Omit<CollapsibleRootProps, 'open' | 'defaultOpen' | 'onOpenChange'> {
@@ -26,7 +22,7 @@ export interface AccordionItemProps
 
 interface AccordionItemContext {
   open: ComputedRef<boolean>
-  dataState: ComputedRef<AccordionItemState>
+  dataState: ComputedRef<DisclosureState>
   disabled: ComputedRef<boolean>
   dataDisabled: ComputedRef<'' | undefined>
   triggerId: string
@@ -72,9 +68,7 @@ const disabled = computed(() => {
 
 const dataDisabled = computed(() => (disabled.value ? '' : undefined))
 
-const dataState = computed(() =>
-  open.value ? AccordionItemState.Open : AccordionItemState.Closed,
-)
+const dataState = computed(() => disclosureState(open.value))
 
 defineExpose({ open, dataDisabled })
 const { currentRef, currentElement } = useForwardExpose()

--- a/packages/core/src/Checkbox/CheckboxIndicator.vue
+++ b/packages/core/src/Checkbox/CheckboxIndicator.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { selectionState, useForwardExpose } from '@/shared'
 
 export interface CheckboxIndicatorProps extends PrimitiveProps {
   /**
@@ -15,7 +15,7 @@ export interface CheckboxIndicatorProps extends PrimitiveProps {
 import { Presence } from '@/Presence'
 import { Primitive } from '@/Primitive'
 import { injectCheckboxRootContext } from './CheckboxRoot.vue'
-import { getState, isIndeterminate } from './utils'
+import { isIndeterminate } from './utils'
 
 withDefaults(defineProps<CheckboxIndicatorProps>(), {
   as: 'span',
@@ -31,7 +31,7 @@ const rootContext = injectCheckboxRootContext()
   >
     <Primitive
       :ref="forwardRef"
-      :data-state="getState(rootContext.state.value)"
+      :data-state="selectionState(rootContext.state.value)"
       :data-disabled="rootContext.disabled.value ? '' : undefined"
       :style="{ pointerEvents: 'none' }"
       :as-child="asChild"

--- a/packages/core/src/Checkbox/CheckboxRoot.vue
+++ b/packages/core/src/Checkbox/CheckboxRoot.vue
@@ -4,7 +4,7 @@ import type { CheckedState } from './utils'
 import type { PrimitiveProps } from '@/Primitive'
 import type { AcceptableValue, FormFieldProps } from '@/shared/types'
 import { useVModel } from '@vueuse/core'
-import { createContext, getRootNode, isNullish, isValueEqualOrExist, useFormControl, useForwardExpose, useForwardScopeId } from '@/shared'
+import { createContext, getRootNode, isNullish, isValueEqualOrExist, selectionState, useFormControl, useForwardExpose, useForwardScopeId } from '@/shared'
 import { injectCheckboxGroupRootContext } from './CheckboxGroupRoot.vue'
 
 export interface CheckboxRootProps<T = boolean> extends PrimitiveProps, FormFieldProps {
@@ -51,7 +51,7 @@ import { computed, useAttrs } from 'vue'
 import { Primitive } from '@/Primitive'
 import { RovingFocusItem } from '@/RovingFocus'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
-import { getState, isIndeterminate } from './utils'
+import { isIndeterminate } from './utils'
 
 defineOptions({
   inheritAttrs: false,
@@ -156,7 +156,7 @@ provideCheckboxRootContext({
     :aria-checked="isIndeterminate(checkboxState) ? 'mixed' : checkboxState"
     :aria-required="required"
     :aria-label="$attrs['aria-label'] || ariaLabel"
-    :data-state="getState(checkboxState)"
+    :data-state="selectionState(checkboxState)"
     :data-disabled="disabled ? '' : undefined"
     :disabled="disabled"
     :focusable="checkboxGroupContext?.rovingFocus.value ? !disabled : undefined"

--- a/packages/core/src/Checkbox/utils.ts
+++ b/packages/core/src/Checkbox/utils.ts
@@ -3,7 +3,3 @@ export type CheckedState = boolean | 'indeterminate'
 export function isIndeterminate(checked?: CheckedState): checked is 'indeterminate' {
   return checked === 'indeterminate'
 }
-
-export function getState(checked: CheckedState) {
-  return isIndeterminate(checked) ? 'indeterminate' : checked ? 'checked' : 'unchecked'
-}

--- a/packages/core/src/Collapsible/CollapsibleContent.vue
+++ b/packages/core/src/Collapsible/CollapsibleContent.vue
@@ -21,7 +21,7 @@ import { Presence } from '@/Presence'
 import {
   Primitive,
 } from '@/Primitive'
-import { useForwardExpose, useId } from '@/shared'
+import { disclosureState, useForwardExpose, useId } from '@/shared'
 import { injectCollapsibleRootContext } from './CollapsibleRoot.vue'
 
 defineOptions({
@@ -77,8 +77,6 @@ watch(
   },
 )
 
-const skipAnimation = computed(() => isMountAnimationPrevented.value && rootContext.open.value)
-
 onMounted(() => {
   requestAnimationFrame(() => {
     isMountAnimationPrevented.value = false
@@ -107,7 +105,7 @@ useEventListener(currentElement, 'beforematch', (ev) => {
       :as-child="props.asChild"
       :as="as"
       :hidden="!present ? rootContext.unmountOnHide.value ? '' : 'until-found' : undefined"
-      :data-state="skipAnimation ? undefined : rootContext.open.value ? 'open' : 'closed'"
+      :data-state="disclosureState(rootContext.open.value)"
       :data-disabled="rootContext.disabled?.value ? '' : undefined"
       :style="{
         [`--reka-collapsible-content-height`]: `${height}px`,

--- a/packages/core/src/Collapsible/CollapsibleRoot.vue
+++ b/packages/core/src/Collapsible/CollapsibleRoot.vue
@@ -2,7 +2,7 @@
 import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
 import { toRefs } from 'vue'
-import { createContext, useForwardExpose } from '@/shared'
+import { createContext, disclosureState, useForwardExpose } from '@/shared'
 
 export interface CollapsibleRootProps extends PrimitiveProps {
   /** The open state of the collapsible when it is initially rendered. <br> Use when you do not need to control its open state. */
@@ -79,7 +79,7 @@ useForwardExpose()
   <Primitive
     :as="as"
     :as-child="props.asChild"
-    :data-state="open ? 'open' : 'closed'"
+    :data-state="disclosureState(open)"
     :data-disabled="disabled ? '' : undefined"
   >
     <slot :open="open" />

--- a/packages/core/src/Collapsible/CollapsibleTrigger.vue
+++ b/packages/core/src/Collapsible/CollapsibleTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 
 export interface CollapsibleTriggerProps extends PrimitiveProps {}
 </script>
@@ -24,7 +24,7 @@ const rootContext = injectCollapsibleRootContext()
     :as-child="props.asChild"
     :aria-controls="rootContext.contentId"
     :aria-expanded="rootContext.open.value"
-    :data-state="rootContext.open.value ? 'open' : 'closed'"
+    :data-state="disclosureState(rootContext.open.value)"
     :data-disabled="rootContext.disabled?.value ? '' : undefined"
     :disabled="rootContext.disabled?.value"
     @click="rootContext.onOpenToggle"

--- a/packages/core/src/Combobox/ComboboxContentImpl.vue
+++ b/packages/core/src/Combobox/ComboboxContentImpl.vue
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import type { DismissableLayerEmits, DismissableLayerProps } from '@/DismissableLayer'
 import type { PopperContentProps } from '@/Popper'
 
-import { createContext, getActiveElement, useFocusGuards, useForwardExpose, useForwardProps, useHideOthers } from '@/shared'
+import { createContext, disclosureState, getActiveElement, useFocusGuards, useForwardExpose, useForwardProps, useHideOthers } from '@/shared'
 import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 
 export type ComboboxContentImplEmits = DismissableLayerEmits
@@ -144,7 +144,7 @@ function isEventTargetWithinCombobox(target: EventTarget | null) {
           :memo-dependencies="position === 'popper'
             ? [rootContext.filterSearch.value, rootContext.filterState.value]
             : undefined"
-          :data-state="rootContext.open.value ? 'open' : 'closed'"
+          :data-state="disclosureState(rootContext.open.value)"
           :data-empty="isEmpty ? '' : undefined"
           :style="{
             // flex layout so we can place the scroll buttons properly

--- a/packages/core/src/Combobox/ComboboxTrigger.vue
+++ b/packages/core/src/Combobox/ComboboxTrigger.vue
@@ -10,7 +10,7 @@ export interface ComboboxTriggerProps extends PrimitiveProps {
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
 import { Primitive } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { injectComboboxRootContext } from './ComboboxRoot.vue'
 
 const props = withDefaults(defineProps<ComboboxTriggerProps>(), {
@@ -37,7 +37,7 @@ onMounted(() => {
     aria-haspopup="listbox"
     :aria-expanded="rootContext.open.value"
     :aria-controls="rootContext.contentId"
-    :data-state="rootContext.open.value ? 'open' : 'closed'"
+    :data-state="disclosureState(rootContext.open.value)"
     :disabled="disabled"
     :data-disabled="disabled ? '' : undefined"
     :aria-disabled="disabled ?? undefined"

--- a/packages/core/src/ContextMenu/ContextMenuTrigger.vue
+++ b/packages/core/src/ContextMenu/ContextMenuTrigger.vue
@@ -16,7 +16,7 @@ export interface ContextMenuTriggerProps extends PrimitiveProps {
 import { computed, nextTick, onMounted, ref, toRefs } from 'vue'
 import { MenuAnchor } from '@/Menu'
 import { Primitive } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { injectContextMenuRootContext } from './ContextMenuRoot.vue'
 import { isTouchOrPen } from './utils'
 
@@ -104,7 +104,7 @@ onMounted(() => {
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"
-    :data-state="rootContext.open.value ? 'open' : 'closed'"
+    :data-state="disclosureState(rootContext.open.value)"
     :data-disabled="disabled ? '' : undefined"
     :style="{
       WebkitTouchCallout: 'none',

--- a/packages/core/src/Dialog/DialogContentImpl.vue
+++ b/packages/core/src/Dialog/DialogContentImpl.vue
@@ -3,7 +3,7 @@ import type {
   DismissableLayerEmits,
   DismissableLayerProps,
 } from '@/DismissableLayer'
-import { getActiveElement, useForwardExpose, useId } from '@/shared'
+import { disclosureState, getActiveElement, useForwardExpose, useId } from '@/shared'
 
 export type DialogContentImplEmits = DismissableLayerEmits & {
   /**
@@ -37,7 +37,6 @@ export interface DialogContentImplProps extends DismissableLayerProps {
 import { onMounted } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { FocusScope } from '@/FocusScope'
-import { getOpenState } from '@/Menu/utils'
 import { injectDialogRootContext } from './DialogRoot.vue'
 import { useWarning } from './utils'
 
@@ -94,7 +93,7 @@ if (process.env.NODE_ENV !== 'production') {
       role="dialog"
       :aria-describedby="rootContext.descriptionId"
       :aria-labelledby="rootContext.titleId"
-      :data-state="getOpenState(rootContext.open.value)"
+      :data-state="disclosureState(rootContext.open.value)"
       v-bind="$attrs"
       @dismiss="rootContext.onOpenChange(false)"
       @escape-key-down="emits('escapeKeyDown', $event)"

--- a/packages/core/src/Dialog/DialogOverlayImpl.vue
+++ b/packages/core/src/Dialog/DialogOverlayImpl.vue
@@ -7,7 +7,7 @@ export interface DialogOverlayImplProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { watch } from 'vue'
 import { Primitive } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 import { injectDialogRootContext } from './DialogRoot.vue'
 
@@ -26,7 +26,7 @@ useForwardExpose()
   <Primitive
     :as="as"
     :as-child="asChild"
-    :data-state="rootContext.open.value ? 'open' : 'closed'"
+    :data-state="disclosureState(rootContext.open.value)"
     style="pointer-events: auto"
     @pointerdown.left.self.prevent
   >

--- a/packages/core/src/Dialog/DialogTrigger.vue
+++ b/packages/core/src/Dialog/DialogTrigger.vue
@@ -7,7 +7,7 @@ export interface DialogTriggerProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { Primitive } from '@/Primitive'
-import { useForwardExpose, useId } from '@/shared'
+import { disclosureState, useForwardExpose, useId } from '@/shared'
 import { injectDialogRootContext } from './DialogRoot.vue'
 
 const props = withDefaults(defineProps<DialogTriggerProps>(), {
@@ -30,7 +30,7 @@ onMounted(() => {
     aria-haspopup="dialog"
     :aria-expanded="rootContext.open.value || false"
     :aria-controls="rootContext.open.value ? rootContext.contentId : undefined"
-    :data-state="rootContext.open.value ? 'open' : 'closed'"
+    :data-state="disclosureState(rootContext.open.value)"
     @click="rootContext.onOpenToggle"
   >
     <slot />

--- a/packages/core/src/Drawer/DrawerContentImpl.vue
+++ b/packages/core/src/Drawer/DrawerContentImpl.vue
@@ -34,7 +34,7 @@ import { useResizeObserver } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, watch } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { FocusScope } from '@/FocusScope'
-import { getElementByIdFrom, useForwardExpose } from '@/shared'
+import { disclosureState, getElementByIdFrom, useForwardExpose } from '@/shared'
 import { useDrawerSnapPoints } from './composables/useDrawerSnapPoints'
 import { useSwipeDismiss } from './composables/useSwipeDismiss'
 import { injectDrawerRootContext } from './DrawerRoot.vue'
@@ -294,7 +294,7 @@ watch(() => rootContext.open.value, (isOpen) => {
 // Data attributes
 const dataAttributes = computed(() => {
   const attrs: Record<string, string | undefined> = {
-    'data-state': rootContext.open.value ? 'open' : 'closed',
+    'data-state': disclosureState(rootContext.open.value),
     'data-swipe-direction': rootContext.swipeDirection.value,
   }
   if (isSwiping.value)

--- a/packages/core/src/Drawer/DrawerHandle.vue
+++ b/packages/core/src/Drawer/DrawerHandle.vue
@@ -6,7 +6,7 @@ export interface DrawerHandleProps extends PrimitiveProps {}
 
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { injectDrawerRootContext } from './DrawerRoot.vue'
 
 const props = withDefaults(defineProps<DrawerHandleProps>(), { as: 'div' })
@@ -18,7 +18,7 @@ const rootContext = injectDrawerRootContext()
   <Primitive
     v-bind="props"
     aria-hidden="true"
-    :data-state="rootContext.open.value ? 'open' : 'closed'"
+    :data-state="disclosureState(rootContext.open.value)"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Drawer/DrawerOverlayImpl.vue
+++ b/packages/core/src/Drawer/DrawerOverlayImpl.vue
@@ -7,7 +7,7 @@ export interface DrawerOverlayImplProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { Primitive } from '@/Primitive'
-import { useBodyScrollLock, useForwardExpose } from '@/shared'
+import { disclosureState, useBodyScrollLock, useForwardExpose } from '@/shared'
 import { injectDrawerRootContext } from './DrawerRoot.vue'
 import { DRAWER_CSS_VARS } from './utils'
 
@@ -28,7 +28,7 @@ useForwardExpose()
 // downstream CSS can target `[data-swiping] [data-slot="drawer-backdrop"]`.
 const dataAttributes = computed(() => {
   const attrs: Record<string, string | undefined> = {
-    'data-state': rootContext.open.value ? 'open' : 'closed',
+    'data-state': disclosureState(rootContext.open.value),
     'data-swipe-direction': rootContext.swipeDirection.value,
   }
   if (rootContext.isSwiping.value)

--- a/packages/core/src/Drawer/DrawerSwipeArea.vue
+++ b/packages/core/src/Drawer/DrawerSwipeArea.vue
@@ -13,7 +13,7 @@ export interface DrawerSwipeAreaProps extends PrimitiveProps {
 <script setup lang="ts">
 import { computed } from 'vue'
 import { Primitive } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { useSwipeDismiss } from './composables/useSwipeDismiss'
 import { injectDrawerRootContext } from './DrawerRoot.vue'
 import { DRAWER_CSS_VARS } from './utils'
@@ -65,7 +65,7 @@ useSwipeDismiss({
   <Primitive
     v-bind="props"
     :ref="forwardRef"
-    :data-state="rootContext.open.value ? 'open' : 'closed'"
+    :data-state="disclosureState(rootContext.open.value)"
     :data-swipe-direction="openDirection"
   >
     <slot />

--- a/packages/core/src/Drawer/DrawerTrigger.vue
+++ b/packages/core/src/Drawer/DrawerTrigger.vue
@@ -7,7 +7,7 @@ export interface DrawerTriggerProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { onUnmounted, watch } from 'vue'
 import { Primitive } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { injectDrawerRootContext } from './DrawerRoot.vue'
 
 const props = withDefaults(defineProps<DrawerTriggerProps>(), { as: 'button' })
@@ -36,7 +36,7 @@ onUnmounted(() => {
     aria-haspopup="dialog"
     :aria-expanded="rootContext.open.value"
     :aria-controls="rootContext.open.value ? rootContext.contentId : undefined"
-    :data-state="rootContext.open.value ? 'open' : 'closed'"
+    :data-state="disclosureState(rootContext.open.value)"
     @click="rootContext.onOpenChange(true, 'trigger-press')"
   >
     <slot />

--- a/packages/core/src/Drawer/DrawerViewport.vue
+++ b/packages/core/src/Drawer/DrawerViewport.vue
@@ -6,7 +6,7 @@ export interface DrawerViewportProps extends PrimitiveProps {}
 
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { injectDrawerRootContext } from './DrawerRoot.vue'
 
 /**
@@ -27,7 +27,7 @@ const rootContext = injectDrawerRootContext()
     v-bind="props"
     :ref="forwardRef"
     data-drawer-viewport=""
-    :data-state="rootContext.open.value ? 'open' : 'closed'"
+    :data-state="disclosureState(rootContext.open.value)"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/DropdownMenu/DropdownMenuTrigger.vue
+++ b/packages/core/src/DropdownMenu/DropdownMenuTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { useForwardExpose, useId } from '@/shared'
+import { disclosureState, useForwardExpose, useId } from '@/shared'
 
 export interface DropdownMenuTriggerProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with item */
@@ -44,7 +44,7 @@ rootContext.triggerId ||= useId(undefined, 'reka-dropdown-menu-trigger')
       :aria-controls="rootContext.open.value ? rootContext.contentId : undefined"
       :data-disabled="disabled ? '' : undefined"
       :disabled="disabled"
-      :data-state="rootContext.open.value ? 'open' : 'closed'"
+      :data-state="disclosureState(rootContext.open.value)"
       @click="
         async (event: MouseEvent) => {
           // only call handler if it's the left button (mousedown gets triggered by all mouse buttons)

--- a/packages/core/src/HoverCard/HoverCardContentImpl.vue
+++ b/packages/core/src/HoverCard/HoverCardContentImpl.vue
@@ -2,7 +2,7 @@
 import type { DismissableLayerEmits } from '@/DismissableLayer'
 import type { PopperContentProps } from '@/Popper'
 import { syncRef } from '@vueuse/shared'
-import { useForwardExpose, useGraceArea } from '@/shared'
+import { disclosureState, useForwardExpose, useGraceArea } from '@/shared'
 
 export type HoverCardContentImplEmits = DismissableLayerEmits
 export interface HoverCardContentImplProps extends PopperContentProps {}
@@ -96,7 +96,7 @@ onUnmounted(() => {
     <PopperContent
       v-bind="{ ...forwarded, ...$attrs }"
       :ref="forwardRef"
-      :data-state="rootContext.open.value ? 'open' : 'closed'"
+      :data-state="disclosureState(rootContext.open.value)"
       :style="{
         'userSelect': containSelection ? 'text' : undefined,
         // Safari requires prefix

--- a/packages/core/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/core/src/HoverCard/HoverCardTrigger.vue
@@ -6,7 +6,7 @@ export interface HoverCardTriggerProps extends PopperAnchorProps {}
 import type { PopperAnchorProps } from '@/Popper'
 import { PopperAnchor } from '@/Popper'
 import { Primitive } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { injectHoverCardRootContext } from './HoverCardRoot.vue'
 import { excludeTouch } from './utils'
 
@@ -46,7 +46,7 @@ function handleTouch(event: PointerEvent) {
       :ref="forwardRef"
       :as-child="asChild"
       :as="as"
-      :data-state="rootContext.open.value ? 'open' : 'closed'"
+      :data-state="disclosureState(rootContext.open.value)"
       data-grace-area-trigger
       @pointerenter="excludeTouch(rootContext.onOpen)($event)"
       @pointerleave="excludeTouch(handleLeave)($event)"

--- a/packages/core/src/Listbox/ListboxItem.vue
+++ b/packages/core/src/Listbox/ListboxItem.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { createContext, handleAndDispatchCustomEvent, useForwardExpose, useId } from '@/shared'
+import { createContext, handleAndDispatchCustomEvent, selectionState, useForwardExpose, useId } from '@/shared'
 
 export interface ListboxItemProps<T = AcceptableValue> extends PrimitiveProps {
   /** The value given as data when submitted with a `name`. */
@@ -85,7 +85,7 @@ provideListboxItemContext({
       :disabled="disabled ? '' : undefined"
       :data-disabled="disabled ? '' : undefined"
       :data-highlighted="isHighlighted ? '' : undefined"
-      :data-state="isSelected ? 'checked' : 'unchecked'"
+      :data-state="selectionState(isSelected)"
       @click="handleSelectCustomEvent"
       @keydown.space.prevent="handleSelectCustomEvent"
       @pointermove="() => {

--- a/packages/core/src/Menu/MenuCheckboxItem.vue
+++ b/packages/core/src/Menu/MenuCheckboxItem.vue
@@ -4,7 +4,7 @@ import type {
   MenuItemProps,
 } from './MenuItem.vue'
 import type { CheckedState } from './utils'
-import { useForwardProps } from '@/shared'
+import { selectionState, useForwardProps } from '@/shared'
 
 export type MenuCheckboxItemEmits = MenuItemEmits & {
   /** Event handler called when the checked state changes. */
@@ -21,7 +21,7 @@ export interface MenuCheckboxItemProps extends MenuItemProps {
 import { reactiveOmit, useVModel } from '@vueuse/core'
 import MenuItem from './MenuItem.vue'
 import { provideMenuItemIndicatorContext } from './MenuItemIndicator.vue'
-import { getCheckedState, isIndeterminate } from './utils'
+import { isIndeterminate } from './utils'
 
 const props = withDefaults(defineProps<MenuCheckboxItemProps>(), {
   modelValue: false,
@@ -48,7 +48,7 @@ provideMenuItemIndicatorContext({ modelValue })
     role="menuitemcheckbox"
     v-bind="forwarded"
     :aria-checked="isIndeterminate(modelValue) ? 'mixed' : modelValue"
-    :data-state="getCheckedState(modelValue)"
+    :data-state="selectionState(modelValue)"
     @select="
       async (event) => {
         emits('select', event);

--- a/packages/core/src/Menu/MenuItemIndicator.vue
+++ b/packages/core/src/Menu/MenuItemIndicator.vue
@@ -2,7 +2,7 @@
 import type { Ref } from 'vue'
 import type { CheckedState } from './utils'
 import type { PrimitiveProps } from '@/Primitive'
-import { createContext } from '@/shared'
+import { createContext, selectionState } from '@/shared'
 
 interface MenuItemIndicatorContext {
   modelValue: Ref<CheckedState>
@@ -27,7 +27,7 @@ export const [injectMenuItemIndicatorContext, provideMenuItemIndicatorContext]
 import { ref } from 'vue'
 import { Presence } from '@/Presence'
 import { Primitive } from '@/Primitive'
-import { getCheckedState, isIndeterminate } from './utils'
+import { isIndeterminate } from './utils'
 
 withDefaults(defineProps<MenuItemIndicatorProps>(), {
   as: 'span',
@@ -49,7 +49,7 @@ const indicatorContext = injectMenuItemIndicatorContext({
     <Primitive
       :as="as"
       :as-child="asChild"
-      :data-state="getCheckedState(indicatorContext.modelValue.value)"
+      :data-state="selectionState(indicatorContext.modelValue.value)"
     >
       <slot />
     </Primitive>

--- a/packages/core/src/Menu/MenuRadioItem.vue
+++ b/packages/core/src/Menu/MenuRadioItem.vue
@@ -5,7 +5,7 @@ import type {
 } from './MenuItem.vue'
 import type { AcceptableValue } from '@/shared/types'
 import { reactiveOmit } from '@vueuse/shared'
-import { useForwardProps } from '@/shared'
+import { selectionState, useForwardProps } from '@/shared'
 
 export type MenuRadioItemEmits = MenuItemEmits
 
@@ -20,7 +20,6 @@ import { computed, toRefs } from 'vue'
 import MenuItem from './MenuItem.vue'
 import { provideMenuItemIndicatorContext } from './MenuItemIndicator.vue'
 import { injectMenuRadioGroupContext } from './MenuRadioGroup.vue'
-import { getCheckedState } from './utils'
 
 const props = defineProps<MenuRadioItemProps>()
 const emits = defineEmits<MenuRadioItemEmits>()
@@ -42,7 +41,7 @@ provideMenuItemIndicatorContext({ modelValue })
     role="menuitemradio"
     v-bind="forwarded"
     :aria-checked="modelValue"
-    :data-state="getCheckedState(modelValue)"
+    :data-state="selectionState(modelValue)"
     @select="
       async (event) => {
         emits('select', event);

--- a/packages/core/src/Menu/MenuSubTrigger.vue
+++ b/packages/core/src/Menu/MenuSubTrigger.vue
@@ -8,13 +8,13 @@ export interface MenuSubTriggerProps extends MenuItemImplProps {}
 <script setup lang="ts">
 import type { ComponentPublicInstance } from 'vue'
 import { nextTick, onUnmounted, ref, watch } from 'vue'
-import { useId } from '@/shared'
+import { disclosureState, useId } from '@/shared'
 import MenuAnchor from './MenuAnchor.vue'
 import { injectMenuContentContext } from './MenuContentImpl.vue'
 import MenuItemImpl from './MenuItemImpl.vue'
 import { injectMenuContext, injectMenuRootContext } from './MenuRoot.vue'
 import { injectMenuSubContext } from './MenuSub.vue'
-import { getOpenState, isMouseEvent, SELECTION_KEYS, SUB_OPEN_KEYS } from './utils'
+import { isMouseEvent, SELECTION_KEYS, SUB_OPEN_KEYS } from './utils'
 
 const props = defineProps<MenuSubTriggerProps>()
 
@@ -148,7 +148,7 @@ async function handleKeyDown(event: KeyboardEvent) {
       aria-haspopup="menu"
       :aria-expanded="menuContext.open.value"
       :aria-controls="subContext.contentId"
-      :data-state="getOpenState(menuContext.open.value)"
+      :data-state="disclosureState(menuContext.open.value)"
       @click="
         async (event: MouseEvent) => {
           if (props.disabled || event.defaultPrevented) return;

--- a/packages/core/src/Menu/utils.ts
+++ b/packages/core/src/Menu/utils.ts
@@ -18,22 +18,10 @@ export const SUB_CLOSE_KEYS: Record<Direction, string[]> = {
   rtl: ['ArrowRight'],
 }
 
-export function getOpenState(open: boolean) {
-  return open ? 'open' : 'closed'
-}
-
 export function isIndeterminate(
   checked?: CheckedState,
 ): checked is 'indeterminate' {
   return checked === 'indeterminate'
-}
-
-export function getCheckedState(checked: CheckedState) {
-  return isIndeterminate(checked)
-    ? 'indeterminate'
-    : checked
-      ? 'checked'
-      : 'unchecked'
 }
 
 export function focusFirst(candidates: HTMLElement[]) {

--- a/packages/core/src/Menubar/MenubarTrigger.vue
+++ b/packages/core/src/Menubar/MenubarTrigger.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
 import { useCollection } from '@/Collection'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 
 export interface MenubarTriggerProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with item */
@@ -56,7 +56,7 @@ onMounted(() => {
           :aria-expanded="open"
           :aria-controls="open ? menuContext.contentId : undefined"
           :data-highlighted="isFocused ? '' : undefined"
-          :data-state="open ? 'open' : 'closed'"
+          :data-state="disclosureState(open)"
           :data-disabled="disabled ? '' : undefined"
           :disabled="disabled"
           :data-value="menuContext.value"

--- a/packages/core/src/NavigationMenu/NavigationMenuContent.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuContent.vue
@@ -16,11 +16,11 @@ export interface NavigationMenuContentProps extends NavigationMenuContentImplPro
 import { isClient, reactiveOmit } from '@vueuse/shared'
 import { computed } from 'vue'
 import { Presence } from '@/Presence'
-import { useForwardExpose, useForwardPropsEmits } from '@/shared'
+import { disclosureState, useForwardExpose, useForwardPropsEmits } from '@/shared'
 import NavigationMenuContentImpl from './NavigationMenuContentImpl.vue'
 import { injectNavigationMenuItemContext } from './NavigationMenuItem.vue'
 import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
-import { getOpenState, whenMouse } from './utils'
+import { whenMouse } from './utils'
 
 defineOptions({
   inheritAttrs: false,
@@ -60,7 +60,7 @@ const isLastActiveValue = computed(() => {
     >
       <NavigationMenuContentImpl
         :ref="forwardRef"
-        :data-state="getOpenState(open)"
+        :data-state="disclosureState(open)"
         :style="{
           pointerEvents: !open && menuContext.isRootMenu ? 'none' : undefined,
         }"

--- a/packages/core/src/NavigationMenu/NavigationMenuContentImpl.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuContentImpl.vue
@@ -17,13 +17,12 @@ export interface NavigationMenuContentImplProps extends DismissableLayerProps {}
 <script setup lang="ts">
 import { computed, ref, watchEffect } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
-import { getActiveElement, useArrowNavigation, useForwardExpose } from '@/shared'
+import { disclosureState, getActiveElement, useArrowNavigation, useForwardExpose } from '@/shared'
 import { injectNavigationMenuItemContext } from './NavigationMenuItem.vue'
 import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
 import {
   EVENT_ROOT_CONTENT_DISMISS,
   focusFirst,
-  getOpenState,
   getTabbableCandidates,
   makeContentId,
   makeTriggerId,
@@ -197,7 +196,7 @@ function handleDismiss() {
     :ref="forwardRef"
     :aria-labelledby="triggerId"
     :data-motion="motionAttribute"
-    :data-state="getOpenState(menuContext.modelValue.value === itemContext.value)"
+    :data-state="disclosureState(menuContext.modelValue.value === itemContext.value)"
     :data-orientation="menuContext.orientation"
     v-bind="props"
     @keydown="handleKeydown"

--- a/packages/core/src/NavigationMenu/NavigationMenuIndicator.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuIndicator.vue
@@ -15,7 +15,7 @@ import { useResizeObserver } from '@vueuse/core'
 import { computed, ref, watchEffect } from 'vue'
 import { Presence } from '@/Presence'
 import { Primitive } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
 
 defineOptions({
@@ -67,7 +67,7 @@ useResizeObserver(menuContext.indicatorTrack, handlePositionChange)
       <Primitive
         :ref="forwardRef"
         aria-hidden="true"
-        :data-state="isVisible ? 'visible' : 'hidden'"
+        :data-state="disclosureState(isVisible)"
         :data-orientation="menuContext.orientation"
         :as-child="props.asChild"
         :as="as"

--- a/packages/core/src/NavigationMenu/NavigationMenuTrigger.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuTrigger.vue
@@ -2,7 +2,7 @@
 import type { ComponentPublicInstance } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
 import { useCollection } from '@/Collection'
-import { getElementByIdFrom, useForwardExpose } from '@/shared'
+import { disclosureState, getElementByIdFrom, useForwardExpose } from '@/shared'
 
 export interface NavigationMenuTriggerProps extends PrimitiveProps {
   /** When `true`, prevents the user from interacting with item */
@@ -19,7 +19,7 @@ import {
 import { VisuallyHidden } from '@/VisuallyHidden'
 import { injectNavigationMenuItemContext } from './NavigationMenuItem.vue'
 import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
-import { getOpenState, makeContentId, makeTriggerId } from './utils'
+import { makeContentId, makeTriggerId } from './utils'
 
 defineOptions({
   inheritAttrs: false,
@@ -146,7 +146,7 @@ function handleVisuallyHiddenFocus(ev: FocusEvent) {
       :ref="forwardRef"
       :disabled="disabled"
       :data-disabled="disabled ? '' : undefined"
-      :data-state="getOpenState(open)"
+      :data-state="disclosureState(open)"
       data-navigation-menu-trigger
       :aria-expanded="open"
       :aria-controls="contentId"

--- a/packages/core/src/NavigationMenu/NavigationMenuViewport.vue
+++ b/packages/core/src/NavigationMenu/NavigationMenuViewport.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 
 export interface NavigationMenuViewportProps extends PrimitiveProps {
   /**
@@ -24,7 +24,7 @@ import {
   Primitive,
 } from '@/Primitive'
 import { injectNavigationMenuContext } from './NavigationMenuRoot.vue'
-import { getOpenState, whenMouse } from './utils'
+import { whenMouse } from './utils'
 
 defineOptions({
   inheritAttrs: false,
@@ -169,7 +169,7 @@ useResizeObserver([globalThis.document?.body, rootNavigationMenu], () => {
       :ref="forwardRef"
       :as="as"
       :as-child="asChild"
-      :data-state="getOpenState(open)"
+      :data-state="disclosureState(open)"
       :data-orientation="menuContext.orientation"
       :style="{
         // Prevent interaction when animating out

--- a/packages/core/src/NavigationMenu/utils.ts
+++ b/packages/core/src/NavigationMenu/utils.ts
@@ -3,10 +3,6 @@ import { getActiveElement } from '@/shared'
 export type Orientation = 'vertical' | 'horizontal'
 export type Direction = 'ltr' | 'rtl'
 
-export function getOpenState(open: boolean) {
-  return open ? 'open' : 'closed'
-}
-
 export function makeTriggerId(baseId: string, value: string) {
   return `${baseId}-trigger-${value}`
 }

--- a/packages/core/src/Popover/PopoverContentImpl.vue
+++ b/packages/core/src/Popover/PopoverContentImpl.vue
@@ -35,7 +35,7 @@ interface PopoverContentImplPrivateProps extends PopoverContentImplProps {
 import { DismissableLayer } from '@/DismissableLayer'
 import { FocusScope } from '@/FocusScope'
 import { PopperContent } from '@/Popper'
-import { useFocusGuards, useForwardExpose, useForwardProps } from '@/shared'
+import { disclosureState, useFocusGuards, useForwardExpose, useForwardProps } from '@/shared'
 import { injectPopoverRootContext } from './PopoverRoot.vue'
 
 const props = defineProps<PopoverContentImplPrivateProps>()
@@ -69,7 +69,7 @@ useFocusGuards(currentElement)
         v-bind="forwarded"
         :id="rootContext.contentId"
         :ref="forwardRef"
-        :data-state="rootContext.open.value ? 'open' : 'closed'"
+        :data-state="disclosureState(rootContext.open.value)"
         :aria-labelledby="rootContext.triggerId"
         :style="{
           '--reka-popover-content-transform-origin':

--- a/packages/core/src/Popover/PopoverTrigger.vue
+++ b/packages/core/src/Popover/PopoverTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { useForwardExpose, useId } from '@/shared'
+import { disclosureState, useForwardExpose, useId } from '@/shared'
 
 export interface PopoverTriggerProps extends PrimitiveProps {}
 </script>
@@ -37,7 +37,7 @@ onMounted(() => {
       aria-haspopup="dialog"
       :aria-expanded="rootContext.open.value"
       :aria-controls="rootContext.contentId"
-      :data-state="rootContext.open.value ? 'open' : 'closed'"
+      :data-state="disclosureState(rootContext.open.value)"
       :as="as"
       :as-child="props.asChild"
       @click="rootContext.onOpenToggle"

--- a/packages/core/src/RadioGroup/Radio.vue
+++ b/packages/core/src/RadioGroup/Radio.vue
@@ -88,7 +88,7 @@ function handleClick(event: MouseEvent) {
     :aria-label="ariaLabel"
     :as-child="asChild"
     :disabled="disabled ? '' : undefined"
-    :data-state="selectionState(checked)"
+    :data-state="selectionState(checked ?? false)"
     :data-disabled="disabled ? '' : undefined"
     :value="value"
     :required="required"

--- a/packages/core/src/RadioGroup/Radio.vue
+++ b/packages/core/src/RadioGroup/Radio.vue
@@ -22,7 +22,7 @@ export interface RadioProps extends PrimitiveProps, FormFieldProps {
 import { useVModel } from '@vueuse/core'
 import { computed, toRefs } from 'vue'
 import { Primitive } from '@/Primitive'
-import { getRootNode, useFormControl, useForwardExpose, useForwardScopeId } from '@/shared'
+import { getRootNode, selectionState, useFormControl, useForwardExpose, useForwardScopeId } from '@/shared'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
 import { handleSelect } from './utils'
 
@@ -88,7 +88,7 @@ function handleClick(event: MouseEvent) {
     :aria-label="ariaLabel"
     :as-child="asChild"
     :disabled="disabled ? '' : undefined"
-    :data-state="checked ? 'checked' : 'unchecked'"
+    :data-state="selectionState(checked)"
     :data-disabled="disabled ? '' : undefined"
     :value="value"
     :required="required"

--- a/packages/core/src/RadioGroup/RadioGroupIndicator.vue
+++ b/packages/core/src/RadioGroup/RadioGroupIndicator.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { selectionState, useForwardExpose } from '@/shared'
 
 export interface RadioGroupIndicatorProps extends PrimitiveProps {
   /**
@@ -30,7 +30,7 @@ const itemContext = injectRadioGroupItemContext()
   >
     <Primitive
       :ref="forwardRef"
-      :data-state="itemContext.checked.value ? 'checked' : 'unchecked'"
+      :data-state="selectionState(itemContext.checked.value)"
       :data-disabled="itemContext.disabled.value ? '' : undefined"
       :as-child="asChild"
       :as="as"

--- a/packages/core/src/Rating/Rating.test.ts
+++ b/packages/core/src/Rating/Rating.test.ts
@@ -22,9 +22,9 @@ describe('given a default Rating', () => {
   })
 
   it('should have default selected', () => {
-    expect(radios[0].attributes('data-state')).toBe('active')
-    expect(radios[1].attributes('data-state')).toBeUndefined()
-    expect(radios[2].attributes('data-state')).toBeUndefined()
+    expect(radios[0].attributes('data-state')).toBe('checked')
+    expect(radios[1].attributes('data-state')).toBe('unchecked')
+    expect(radios[2].attributes('data-state')).toBe('unchecked')
   })
 
   describe('on keyboard navigation', () => {
@@ -40,8 +40,8 @@ describe('given a default Rating', () => {
     })
 
     it('should select next item on keydown', async () => {
-      expect(radios[0].attributes('data-state')).toBe('active')
-      expect(radios[1].attributes('data-state')).toBe('active')
+      expect(radios[0].attributes('data-state')).toBe('checked')
+      expect(radios[1].attributes('data-state')).toBe('checked')
       expect(radios[1].element).toBe(document.activeElement)
     })
 
@@ -49,8 +49,8 @@ describe('given a default Rating', () => {
       it('should select the first item again', async () => {
         await fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' })
         await sleep(0)
-        expect(radios[0].attributes('data-state')).toBe('active')
-        expect(radios[2].attributes('data-state')).toBeUndefined()
+        expect(radios[0].attributes('data-state')).toBe('checked')
+        expect(radios[2].attributes('data-state')).toBe('unchecked')
       })
     })
   })
@@ -71,10 +71,10 @@ describe('given disabled Rating', () => {
   })
 
   it('should have default selected', () => {
-    expect(radios[0].attributes('data-state')).toBe('active')
+    expect(radios[0].attributes('data-state')).toBe('checked')
   })
 
-  it.each([[0, 'active'], [1, undefined], [2, undefined]])('should not select any item', async (input, output) => {
+  it.each([[0, 'checked'], [1, 'unchecked'], [2, 'unchecked']])('should not select any item', async (input, output) => {
     await radios[input].trigger('click')
     expect(radios[input].attributes('data-state')).toBe(output)
   })

--- a/packages/core/src/Rating/RatingItemIndicator.vue
+++ b/packages/core/src/Rating/RatingItemIndicator.vue
@@ -3,7 +3,7 @@ import type { PrimitiveProps } from '@/Primitive'
 import { useActiveElement } from '@vueuse/core'
 import { computed } from 'vue'
 import { RadioGroupIndicator, RadioGroupItem } from '@/RadioGroup'
-import { useForwardExpose } from '@/shared'
+import { selectionState, useForwardExpose } from '@/shared'
 import { injectRatingItemContext } from './RatingItem.vue'
 import { injectRatingRootContext } from './RatingRoot.vue'
 
@@ -46,7 +46,7 @@ function handleMouseEnter() {
 
     }"
     :value="step"
-    :data-state="isActive ? 'active' : undefined"
+    :data-state="selectionState(isActive)"
     :disabled="rootContext.disabled.value"
     @select="rootContext.changeModelValue(step)"
     @mouseenter="handleMouseEnter"

--- a/packages/core/src/Rating/story/RatingDefault.story.vue
+++ b/packages/core/src/Rating/story/RatingDefault.story.vue
@@ -34,7 +34,7 @@ const value = ref(3)
               v-for="step in steps"
               :key="step"
               :step="step"
-              class="data-[state=active]:text-yellow-500 text-gray-400 absolute overflow-hidden w-[var(--reka-rating-item-step-width)] opacity-[var(--reka-rating-item-step-opacity)] z-[var(--reka-rating-item-step-z-index)]"
+              class="data-[state=checked]:text-yellow-500 text-gray-400 absolute overflow-hidden w-[var(--reka-rating-item-step-width)] opacity-[var(--reka-rating-item-step-opacity)] z-[var(--reka-rating-item-step-z-index)]"
             >
               <Icon
                 icon="radix-icons:star"

--- a/packages/core/src/Rating/story/_Rating.vue
+++ b/packages/core/src/Rating/story/_Rating.vue
@@ -23,7 +23,7 @@ const props = defineProps<RatingRootProps>()
         v-for="step in steps"
         :key="step"
         :step="step"
-        class="data-[state=active]:text-yellow-500 text-gray-400 absolute overflow-hidden w-[var(--reka-rating-item-step-width)] opacity-[var(--reka-rating-item-step-opacity)] z-[var(--reka-rating-item-step-z-index)]"
+        class="data-[state=checked]:text-yellow-500 text-gray-400 absolute overflow-hidden w-[var(--reka-rating-item-step-width)] opacity-[var(--reka-rating-item-step-opacity)] z-[var(--reka-rating-item-step-z-index)]"
         :aria-label="`Rating ${step} of ${items.length}`"
       >
         <Icon

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbar.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbar.vue
@@ -115,7 +115,7 @@ provideScrollAreaScrollbarContext({
     v-else-if="rootContext.type.value === 'always'"
     v-bind="$attrs"
     :ref="forwardRef"
-    data-state="visible"
+    data-state="open"
   >
     <slot />
   </ScrollAreaScrollbarVisible>

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbarAuto.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbarAuto.vue
@@ -8,7 +8,7 @@ export interface ScrollAreaScrollbarAutoProps {
 import { useDebounceFn, useResizeObserver } from '@vueuse/core'
 import { onMounted, ref } from 'vue'
 import { Presence } from '@/Presence'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import { injectScrollAreaScrollbarContext } from './ScrollAreaScrollbar.vue'
 import ScrollAreaScrollbarVisible from './ScrollAreaScrollbarVisible.vue'
@@ -48,7 +48,7 @@ useResizeObserver(rootContext.content, handleResize)
     <ScrollAreaScrollbarVisible
       v-bind="$attrs"
       :ref="forwardRef"
-      :data-state="visible ? 'visible' : 'hidden'"
+      :data-state="disclosureState(visible)"
     >
       <slot />
     </ScrollAreaScrollbarVisible>

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbarGlimpse.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbarGlimpse.vue
@@ -8,7 +8,7 @@ export interface ScrollAreaScrollbarGlimpseProps extends ScrollAreaScrollbarAuto
 import { useDebounceFn } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, watchEffect } from 'vue'
 import { Presence } from '@/Presence'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { useStateMachine } from '../shared/useStateMachine'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import { injectScrollAreaScrollbarContext } from './ScrollAreaScrollbar.vue'
@@ -131,7 +131,7 @@ onUnmounted(() => {
     <ScrollAreaScrollbarAuto
       v-bind="$attrs"
       :ref="forwardRef"
-      :data-state="visible ? 'visible' : 'hidden'"
+      :data-state="disclosureState(visible)"
     >
       <slot />
     </ScrollAreaScrollbarAuto>

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbarHover.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbarHover.vue
@@ -7,7 +7,7 @@ export interface ScrollAreaScrollbarHoverProps extends ScrollAreaScrollbarAutoPr
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue'
 import { Presence } from '@/Presence'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import ScrollAreaScrollbarAuto from './ScrollAreaScrollbarAuto.vue'
 
@@ -58,7 +58,7 @@ onUnmounted(() => {
     <ScrollAreaScrollbarAuto
       v-bind="$attrs"
       :ref="forwardRef"
-      :data-state="visible ? 'visible' : 'hidden'"
+      :data-state="disclosureState(visible)"
     >
       <slot />
     </ScrollAreaScrollbarAuto>

--- a/packages/core/src/ScrollArea/ScrollAreaScrollbarScroll.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaScrollbarScroll.vue
@@ -8,7 +8,7 @@ export interface ScrollAreaScrollbarScrollProps {
 import { useDebounceFn } from '@vueuse/core'
 import { computed, watchEffect } from 'vue'
 import { Presence } from '@/Presence'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 import { useStateMachine } from '../shared/useStateMachine'
 import { injectScrollAreaRootContext } from './ScrollAreaRoot.vue'
 import { injectScrollAreaScrollbarContext } from './ScrollAreaScrollbar.vue'
@@ -85,7 +85,7 @@ watchEffect((onCleanup) => {
     <ScrollAreaScrollbarVisible
       v-bind="$attrs"
       :ref="forwardRef"
-      :data-state="visible ? 'visible' : 'hidden'"
+      :data-state="disclosureState(visible)"
     >
       <slot />
     </ScrollAreaScrollbarVisible>

--- a/packages/core/src/ScrollArea/ScrollAreaThumb.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaThumb.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { useForwardExpose } from '@/shared'
+import { disclosureState, useForwardExpose } from '@/shared'
 
 export interface ScrollAreaThumbProps extends PrimitiveProps {}
 </script>
@@ -71,7 +71,7 @@ onUnmounted(() => {
 <template>
   <Primitive
     :ref="forwardRef"
-    :data-state="scrollbarContextVisible.hasThumb ? 'visible' : 'hidden'"
+    :data-state="disclosureState(scrollbarContextVisible.hasThumb)"
     :style="{
       width: 'var(--reka-scroll-area-thumb-width)',
       height: 'var(--reka-scroll-area-thumb-height)',

--- a/packages/core/src/ScrollArea/ScrollAreaThumb.vue
+++ b/packages/core/src/ScrollArea/ScrollAreaThumb.vue
@@ -71,7 +71,7 @@ onUnmounted(() => {
 <template>
   <Primitive
     :ref="forwardRef"
-    :data-state="disclosureState(scrollbarContextVisible.hasThumb)"
+    :data-state="disclosureState(scrollbarContextVisible.hasThumb.value)"
     :style="{
       width: 'var(--reka-scroll-area-thumb-width)',
       height: 'var(--reka-scroll-area-thumb-height)',

--- a/packages/core/src/ScrollArea/__snapshots__/ScrollArea.test.ts.snap
+++ b/packages/core/src/ScrollArea/__snapshots__/ScrollArea.test.ts.snap
@@ -20,8 +20,8 @@ exports[`given default ScrollArea > on hover > should render scrollbar 1`] = `
       display: none;
     }
   </style>
-  <div style="position: absolute; top: 0px; right: 0px; bottom: var(--reka-scroll-area-corner-height); --reka-scroll-area-thumb-height: 18px;" data-scrollbarimpl="" data-orientation="vertical" data-state="visible">
-    <div data-state="visible" style="width: var(--reka-scroll-area-thumb-width); height: var(--reka-scroll-area-thumb-height);"></div>
+  <div style="position: absolute; top: 0px; right: 0px; bottom: var(--reka-scroll-area-corner-height); --reka-scroll-area-thumb-height: 18px;" data-scrollbarimpl="" data-orientation="vertical" data-state="open">
+    <div data-state="closed" style="width: var(--reka-scroll-area-thumb-width); height: var(--reka-scroll-area-thumb-height);"></div>
   </div>
   <!--v-if-->
 </div>"
@@ -72,8 +72,8 @@ exports[`given prop:type="always" ScrollArea > should render content and scrollb
       display: none;
     }
   </style>
-  <div style="position: absolute; top: 0px; right: 0px; bottom: var(--reka-scroll-area-corner-height); --reka-scroll-area-thumb-height: 18px;" data-scrollbarimpl="" data-orientation="vertical" data-state="visible">
-    <div data-state="visible" style="width: var(--reka-scroll-area-thumb-width); height: var(--reka-scroll-area-thumb-height);"></div>
+  <div style="position: absolute; top: 0px; right: 0px; bottom: var(--reka-scroll-area-corner-height); --reka-scroll-area-thumb-height: 18px;" data-scrollbarimpl="" data-orientation="vertical" data-state="open">
+    <div data-state="closed" style="width: var(--reka-scroll-area-thumb-width); height: var(--reka-scroll-area-thumb-height);"></div>
   </div>
   <!--v-if-->
 </div>"
@@ -99,8 +99,8 @@ exports[`given prop:type="scroll" ScrollArea > on scroll > should render scrollb
       display: none;
     }
   </style>
-  <div style="position: absolute; top: 0px; right: 0px; bottom: var(--reka-scroll-area-corner-height); --reka-scroll-area-thumb-height: 18px;" data-scrollbarimpl="" data-orientation="vertical" data-state="visible">
-    <div data-state="visible" style="width: var(--reka-scroll-area-thumb-width); height: var(--reka-scroll-area-thumb-height);"></div>
+  <div style="position: absolute; top: 0px; right: 0px; bottom: var(--reka-scroll-area-corner-height); --reka-scroll-area-thumb-height: 18px;" data-scrollbarimpl="" data-orientation="vertical" data-state="open">
+    <div data-state="closed" style="width: var(--reka-scroll-area-thumb-width); height: var(--reka-scroll-area-thumb-height);"></div>
   </div>
   <!--v-if-->
 </div>"

--- a/packages/core/src/Select/SelectContentImpl.vue
+++ b/packages/core/src/Select/SelectContentImpl.vue
@@ -9,6 +9,7 @@ import type { AcceptableValue } from '@/shared/types'
 import { useCollection } from '@/Collection'
 import {
   createContext,
+  disclosureState,
   getEventTarget,
   useFocusGuards,
   useForwardProps,
@@ -317,7 +318,7 @@ provideSelectContentContext({
             }
           "
           role="listbox"
-          :data-state="rootContext.open.value ? 'open' : 'closed'"
+          :data-state="disclosureState(rootContext.open.value)"
           :dir="rootContext.dir.value"
           :style="{
             // flex layout so we can place the scroll buttons properly

--- a/packages/core/src/Select/SelectItem.vue
+++ b/packages/core/src/Select/SelectItem.vue
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import type { PrimitiveProps } from '@/Primitive'
 import type { AcceptableValue } from '@/shared/types'
 import { useCollection } from '@/Collection'
-import { createContext, getActiveElement, handleAndDispatchCustomEvent, useForwardExpose, useId } from '@/shared'
+import { createContext, getActiveElement, handleAndDispatchCustomEvent, selectionState, useForwardExpose, useId } from '@/shared'
 
 interface SelectItemContext<T = AcceptableValue> {
   value: T
@@ -160,7 +160,7 @@ provideSelectItemContext({
       :aria-labelledby="textId"
       :data-highlighted="isFocused ? '' : undefined"
       :aria-selected="isSelected"
-      :data-state="isSelected ? 'checked' : 'unchecked'"
+      :data-state="selectionState(isSelected)"
       :aria-disabled="disabled || undefined"
       :data-disabled="disabled ? '' : undefined"
       :tabindex="disabled ? undefined : -1"

--- a/packages/core/src/Select/SelectTrigger.vue
+++ b/packages/core/src/Select/SelectTrigger.vue
@@ -11,7 +11,7 @@ import type { PopperAnchorProps } from '@/Popper'
 import { computed, onMounted } from 'vue'
 import { PopperAnchor } from '@/Popper'
 import { Primitive } from '@/Primitive'
-import { useForwardExpose, useId, useTypeahead } from '@/shared'
+import { disclosureState, useForwardExpose, useId, useTypeahead } from '@/shared'
 import {
   injectSelectRootContext,
 } from './SelectRoot.vue'
@@ -110,7 +110,7 @@ function onTriggerClick(event: MouseEvent) {
       aria-autocomplete="none"
       :disabled="isDisabled"
       :dir="rootContext?.dir.value"
-      :data-state="rootContext?.open.value ? 'open' : 'closed'"
+      :data-state="disclosureState(rootContext.open.value)"
       :data-disabled="isDisabled ? '' : undefined"
       :data-placeholder="shouldShowPlaceholder(rootContext.modelValue?.value) ? '' : undefined"
       :as-child="asChild"

--- a/packages/core/src/Splitter/Splitter.test.ts
+++ b/packages/core/src/Splitter/Splitter.test.ts
@@ -165,13 +165,13 @@ describe('nested px SplitterGroup layout re-initialization (issue #2509)', () =>
     await nextTick() // panelDataArrayChanged → layout init
 
     const sidebar = wrapper.find('#sidebar')
-    expect(sidebar.attributes('data-state')).toBe('expanded')
+    expect(sidebar.attributes('data-state')).toBe('open')
 
     // Collapse via the public API; the panel reaches collapsedSize through
     // adjustLayoutByDelta, leaving panelSize a float-epsilon off collapsedSize.
     ;(wrapper.vm.$refs.sidebar as { collapse: () => void }).collapse()
     await nextTick()
 
-    expect(sidebar.attributes('data-state')).toBe('collapsed')
+    expect(sidebar.attributes('data-state')).toBe('closed')
   })
 })

--- a/packages/core/src/Splitter/SplitterPanel.vue
+++ b/packages/core/src/Splitter/SplitterPanel.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { useId } from '@/shared'
+import { disclosureState, useId } from '@/shared'
 import { PRECISION } from './utils/constants'
 
 export interface SplitterPanelProps extends PrimitiveProps {
@@ -186,7 +186,7 @@ defineExpose({
     :data-panel-group-id="groupId"
     :data-panel-id="panelId"
     :data-panel-size=" Number.parseFloat(`${style.flexGrow}`).toFixed(1)"
-    :data-state="collapsible ? isCollapsed ? 'collapsed' : 'expanded' : undefined"
+    :data-state="disclosureState(!isCollapsed)"
   >
     <slot
       :is-collapsed="isCollapsed"

--- a/packages/core/src/Splitter/story/SplitterPixelSizing.story.vue
+++ b/packages/core/src/Splitter/story/SplitterPixelSizing.story.vue
@@ -148,7 +148,6 @@ function toggleCollapsible() {
               :min-size="140"
               :max-size="260"
               class="flex items-center justify-center bg-blackA8 rounded-lg"
-              :data-state="collapsibleOpen ? 'expanded' : 'collapsed'"
               @collapse="handleCollapsed"
               @expand="handleExpanded"
             >

--- a/packages/core/src/Tabs/Tabs.test.ts
+++ b/packages/core/src/Tabs/Tabs.test.ts
@@ -173,13 +173,13 @@ describe('tabs characterization (pre-refactor contract)', () => {
     wrapper.unmount()
   })
 
-  it('marks the selected trigger active and others inactive (data-state + aria-selected)', async () => {
+  it('marks the selected trigger checked and others unchecked (data-state + aria-selected)', async () => {
     const wrapper = mount(twoTabFixture, { attachTo: document.body })
     await flushPromises()
     const [t1, t2] = wrapper.findAll('[role="tab"]')
-    expect(t1.attributes('data-state')).toBe('active')
+    expect(t1.attributes('data-state')).toBe('checked')
     expect(t1.attributes('aria-selected')).toBe('true')
-    expect(t2.attributes('data-state')).toBe('inactive')
+    expect(t2.attributes('data-state')).toBe('unchecked')
     expect(t2.attributes('aria-selected')).toBe('false')
     wrapper.unmount()
   })
@@ -191,7 +191,7 @@ describe('tabs characterization (pre-refactor contract)', () => {
     const idBefore = t2.attributes('id')
     await t2.trigger('mousedown')
     await flushPromises()
-    expect(t2.attributes('data-state')).toBe('active')
+    expect(t2.attributes('data-state')).toBe('checked')
     expect(t2.attributes('id')).toBe(idBefore)
     wrapper.unmount()
   })
@@ -202,7 +202,7 @@ describe('tabs characterization (pre-refactor contract)', () => {
     const t2 = wrapper.findAll('[role="tab"]')[1]
     await t2.trigger('focus')
     await flushPromises()
-    expect(t2.attributes('data-state')).toBe('active')
+    expect(t2.attributes('data-state')).toBe('checked')
     wrapper.unmount()
   })
 
@@ -212,11 +212,11 @@ describe('tabs characterization (pre-refactor contract)', () => {
     const [t1, t2] = wrapper.findAll('[role="tab"]')
     await t2.trigger('focus')
     await flushPromises()
-    expect(t1.attributes('data-state')).toBe('active')
-    expect(t2.attributes('data-state')).toBe('inactive')
+    expect(t1.attributes('data-state')).toBe('checked')
+    expect(t2.attributes('data-state')).toBe('unchecked')
     await t2.trigger('keydown', { key: 'Enter' })
     await flushPromises()
-    expect(t2.attributes('data-state')).toBe('active')
+    expect(t2.attributes('data-state')).toBe('checked')
     wrapper.unmount()
   })
 
@@ -257,7 +257,7 @@ describe('tabs characterization (pre-refactor contract)', () => {
     await t2.trigger('mousedown')
     await flushPromises()
     expect(spy).toHaveBeenCalledTimes(1)
-    expect(t2.attributes('data-state')).toBe('active')
+    expect(t2.attributes('data-state')).toBe('checked')
     wrapper.unmount()
   })
 
@@ -308,11 +308,11 @@ describe('v-model (foundation contract)', () => {
     expect(updated?.[0]?.[1]).toMatchObject({ reason: 'trigger-press', isCanceled: false })
     expect((updated?.[0]?.[1] as { event?: Event }).event).toBeInstanceOf(MouseEvent)
     // Controlled: nothing changes until the parent writes the new value back.
-    expect(t1.attributes('data-state')).toBe('active')
-    expect(t2.attributes('data-state')).toBe('inactive')
+    expect(t1.attributes('data-state')).toBe('checked')
+    expect(t2.attributes('data-state')).toBe('unchecked')
 
     await wrapper.setProps({ modelValue: 'tab2' })
-    expect(t2.attributes('data-state')).toBe('active')
+    expect(t2.attributes('data-state')).toBe('checked')
     wrapper.unmount()
   })
 
@@ -342,8 +342,8 @@ describe('v-model (foundation contract)', () => {
     // No second (`trigger-focus`) attempt, and nothing was applied.
     expect(wrapper.emitted('beforeUpdate:modelValue')).toHaveLength(1)
     expect(wrapper.emitted('update:modelValue')).toBeUndefined()
-    expect(t1.attributes('data-state')).toBe('active')
-    expect(t2.attributes('data-state')).toBe('inactive')
+    expect(t1.attributes('data-state')).toBe('checked')
+    expect(t2.attributes('data-state')).toBe('unchecked')
     wrapper.unmount()
   })
 
@@ -375,14 +375,14 @@ describe('v-model (foundation contract)', () => {
     await t2.trigger('mousedown')
     await flushPromises()
     expect(value.value).toBe('tab1')
-    expect(t1.attributes('data-state')).toBe('active')
-    expect(t2.attributes('data-state')).toBe('inactive')
+    expect(t1.attributes('data-state')).toBe('checked')
+    expect(t2.attributes('data-state')).toBe('unchecked')
 
     cancelNext.value = false
     await t2.trigger('mousedown')
     await flushPromises()
     expect(value.value).toBe('tab2')
-    expect(t2.attributes('data-state')).toBe('active')
+    expect(t2.attributes('data-state')).toBe('checked')
     wrapper.unmount()
   })
 })

--- a/packages/core/src/Tabs/TabsContent.vue
+++ b/packages/core/src/Tabs/TabsContent.vue
@@ -32,7 +32,7 @@ const rootContext = injectTabsRootContext()
 // mount-animation `style` stay in the SFC.
 const surface = getTabsContentSurface(rootContext, () => props.value)
 
-const isMountAnimationPreventedRef = ref(surface.state.value.state === 'active')
+const isMountAnimationPreventedRef = ref(surface.state.value.state === 'checked')
 
 onMounted(() => {
   rootContext.registerContent(props.value)
@@ -49,7 +49,7 @@ onBeforeUnmount(() => {
 <template>
   <Presence
     v-slot="{ present }"
-    :present="forceMount || surface.state.value.state === 'active'"
+    :present="forceMount || surface.state.value.state === 'checked'"
     force-mount
   >
     <Primitive

--- a/packages/core/src/Tabs/TabsIndicator.vue
+++ b/packages/core/src/Tabs/TabsIndicator.vue
@@ -43,7 +43,7 @@ watchPostEffect(() => {
 useResizeObserver(computed(() => [context.tabsList.value, ...tabs.value]), updateIndicatorStyle)
 
 function updateIndicatorStyle() {
-  const activeTab = context.tabsList.value?.querySelector<HTMLButtonElement>('[role="tab"][data-state="active"]')
+  const activeTab = context.tabsList.value?.querySelector<HTMLButtonElement>('[role="tab"][data-state="checked"]')
 
   if (!activeTab)
     return

--- a/packages/core/src/Tabs/TabsTrigger.vue
+++ b/packages/core/src/Tabs/TabsTrigger.vue
@@ -35,7 +35,7 @@ const surface = getTabsTriggerSurface(rootContext, () => props.value, () => prop
   <RovingFocusItem
     as-child
     :focusable="!disabled"
-    :active="surface.state.value.state === 'active'"
+    :active="surface.state.value.state === 'checked'"
   >
     <Primitive
       :ref="forwardRef"

--- a/packages/core/src/Tabs/story/Tabs.story.vue
+++ b/packages/core/src/Tabs/story/Tabs.story.vue
@@ -18,13 +18,13 @@ import { TabsContent, TabsIndicator, TabsList, TabsRoot, TabsTrigger } from '..'
         >
           <TabsIndicator class="absolute bg-violet11 left-0 h-[2px] bottom-0 w-[--reka-tabs-indicator-size] translate-x-[--reka-tabs-indicator-position] rounded-full  transition-[width,transform] duration-300" />
           <TabsTrigger
-            class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none rounded-tl-md   hover:text-violet11 focus-visible:shadow-[0_0_0_2px] data-[state=active]:text-violet11 outline-none cursor-default"
+            class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none rounded-tl-md   hover:text-violet11 focus-visible:shadow-[0_0_0_2px] data-[state=checked]:text-violet11 outline-none cursor-default"
             value="tab1"
           >
             Account
           </TabsTrigger>
           <TabsTrigger
-            class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none rounded-tr-md hover:text-violet11 focus-visible:shadow-[0_0_0_2px] data-[state=active]:text-violet11 outline-none cursor-default"
+            class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none rounded-tr-md hover:text-violet11 focus-visible:shadow-[0_0_0_2px] data-[state=checked]:text-violet11 outline-none cursor-default"
             value="tab2"
           >
             Password

--- a/packages/core/src/Tabs/story/TabsVertical.story.vue
+++ b/packages/core/src/Tabs/story/TabsVertical.story.vue
@@ -20,14 +20,14 @@ import { TabsContent, TabsIndicator, TabsList, TabsRoot, TabsTrigger } from '..'
           <TabsIndicator class="absolute bg-violet11 right-0 w-[2px] top-0 h-[--reka-tabs-indicator-size] translate-y-[--reka-tabs-indicator-position] rounded-full  transition-[width,transform] duration-300" />
           <TabsTrigger
             style="writing-mode:vertical-rl;"
-            class="bg-white px-5 w-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none rounded-tl-md hover:text-violet11 focus-visible:shadow-[0_0_0_2px] data-[state=active]:text-violet11 outline-none cursor-default"
+            class="bg-white px-5 w-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none rounded-tl-md hover:text-violet11 focus-visible:shadow-[0_0_0_2px] data-[state=checked]:text-violet11 outline-none cursor-default"
             value="tab1"
           >
             Account
           </TabsTrigger>
           <TabsTrigger
             style="writing-mode:vertical-rl;"
-            class="bg-white px-5 w-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none rounded-bl-md hover:text-violet11 focus-visible:shadow-[0_0_0_2px] data-[state=active]:text-violet11 outline-none cursor-default"
+            class="bg-white px-5 w-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none rounded-bl-md hover:text-violet11 focus-visible:shadow-[0_0_0_2px] data-[state=checked]:text-violet11 outline-none cursor-default"
             value="tab2"
           >
             Password

--- a/packages/core/src/Tabs/story/_Tabs.vue
+++ b/packages/core/src/Tabs/story/_Tabs.vue
@@ -12,13 +12,13 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '..'
       aria-label="Manage your account"
     >
       <TabsTrigger
-        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none first:rounded-tl-md last:rounded-tr-md hover:text-violet11 data-[state=active]:text-violet11 data-[state=active]:shadow-[inset_0_-1px_0_0,0_1px_0_0] data-[state=active]:shadow-current data-[state=active]:focus:relative data-[state=active]:focus:shadow-[0_0_0_2px] data-[state=active]:focus:shadow-black outline-none cursor-default"
+        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none first:rounded-tl-md last:rounded-tr-md hover:text-violet11 data-[state=checked]:text-violet11 data-[state=checked]:shadow-[inset_0_-1px_0_0,0_1px_0_0] data-[state=checked]:shadow-current data-[state=checked]:focus:relative data-[state=checked]:focus:shadow-[0_0_0_2px] data-[state=checked]:focus:shadow-black outline-none cursor-default"
         :value="1"
       >
         Account
       </TabsTrigger>
       <TabsTrigger
-        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none first:rounded-tl-md last:rounded-tr-md hover:text-violet11 data-[state=active]:text-violet11 data-[state=active]:shadow-[inset_0_-1px_0_0,0_1px_0_0] data-[state=active]:shadow-current data-[state=active]:focus:relative data-[state=active]:focus:shadow-[0_0_0_2px] data-[state=active]:focus:shadow-black outline-none cursor-default"
+        class="bg-white px-5 h-[45px] flex-1 flex items-center justify-center text-[15px] leading-none text-mauve11 select-none first:rounded-tl-md last:rounded-tr-md hover:text-violet11 data-[state=checked]:text-violet11 data-[state=checked]:shadow-[inset_0_-1px_0_0,0_1px_0_0] data-[state=checked]:shadow-current data-[state=checked]:focus:relative data-[state=checked]:focus:shadow-[0_0_0_2px] data-[state=checked]:focus:shadow-black outline-none cursor-default"
         value="tab2"
       >
         Password

--- a/packages/core/src/Tabs/useTabs.test.ts
+++ b/packages/core/src/Tabs/useTabs.test.ts
@@ -85,7 +85,7 @@ describe('useTabs — trigger surface', () => {
       'id': makeTriggerId('x', 'a'),
       'role': 'tab',
       'aria-selected': 'true',
-      'data-state': 'active',
+      'data-state': 'checked',
       'data-disabled': '',
       'data-orientation': 'vertical',
     })
@@ -103,9 +103,9 @@ describe('useTabs — trigger surface', () => {
   it('carries semantic state (active/inactive, disabled, orientation)', () => {
     const t = useTabs({ defaultValue: 'a', baseId: 'x', orientation: 'vertical' })
     const trig = t.getTriggerSurface('b', () => true)
-    expect(trig.state.value).toEqual({ state: 'inactive', disabled: true, orientation: 'vertical' })
+    expect(trig.state.value).toEqual({ state: 'unchecked', disabled: true, orientation: 'vertical' })
     t.selectTab('b')
-    expect(trig.state.value.state).toBe('active')
+    expect(trig.state.value.state).toBe('checked')
   })
 
   it('a reactive value passed as a getter keeps id and state live', () => {
@@ -113,12 +113,12 @@ describe('useTabs — trigger surface', () => {
     const value = ref('a')
     const trig = t.getTriggerSurface(() => value.value)
     expect(trig.props.value.id).toBe(makeTriggerId('x', 'a'))
-    expect(trig.state.value.state).toBe('active')
+    expect(trig.state.value.state).toBe('checked')
     value.value = 'b'
     expect(trig.props.value.id).toBe(makeTriggerId('x', 'b'))
     expect(trig.props.value['aria-selected']).toBe('false')
-    expect(trig.state.value.state).toBe('inactive')
-    expect(trig.attrs.value['data-state']).toBe('inactive')
+    expect(trig.state.value.state).toBe('unchecked')
+    expect(trig.attrs.value['data-state']).toBe('unchecked')
   })
 
   it('onMousedown (left) selects the tab; right button and ctrl+click do not', () => {
@@ -211,8 +211,8 @@ describe('useTabs — content, root & list surfaces', () => {
       'tabindex': 0,
     })
     expect(noDataAttrs(content.props.value)).toBe(true)
-    expect(content.state.value.state).toBe('active')
-    expect(content.attrs.value['data-state']).toBe('active')
+    expect(content.state.value.state).toBe('checked')
+    expect(content.attrs.value['data-state']).toBe('checked')
     expect(content.attrs.value['data-orientation']).toBe('horizontal')
   })
 

--- a/packages/core/src/Tabs/useTabs.ts
+++ b/packages/core/src/Tabs/useTabs.ts
@@ -1,9 +1,9 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import type { TabsRootContext } from './TabsRoot.vue'
-import type { BaseChangeReason, ChangeEventDetails, PartSurface } from '@/shared'
+import type { BaseChangeReason, ChangeEventDetails, PartSurface, SelectionState } from '@/shared'
 import type { DataOrientation, Direction, StringOrNumber } from '@/shared/types'
 import { computed, ref, shallowRef, toValue } from 'vue'
-import { createPartSurface, useControllableState } from '@/shared'
+import { createPartSurface, selectionState, useControllableState } from '@/shared'
 import { makeContentId, makeTriggerId } from './utils'
 
 // `PartSurface` is the shared contract in `@/shared` and is already published via
@@ -13,11 +13,11 @@ import { makeContentId, makeTriggerId } from './utils'
 export type TabsChangeReason = 'trigger-press' | 'trigger-focus' | 'trigger-keydown'
 
 export type TabsTriggerState = {
-  state: 'active' | 'inactive'
+  state: SelectionState
   disabled: boolean
   orientation: DataOrientation
 }
-export type TabsContentState = { state: 'active' | 'inactive', orientation: DataOrientation }
+export type TabsContentState = { state: SelectionState, orientation: DataOrientation }
 
 /** Standalone `useTabs()` calls without a `baseId` draw `reka-tabs-<n>` from here. */
 let tabsCount = 0
@@ -75,7 +75,7 @@ export function getTabsTriggerSurface(
       },
     }),
     () => ({
-      state: isSelected.value ? 'active' : 'inactive',
+      state: selectionState(isSelected.value),
       disabled: isDisabled.value,
       orientation: context.orientation.value,
     }),
@@ -93,7 +93,7 @@ export function getTabsContentSurface(context: TabsRootContext, value: MaybeRefO
       'tabindex': 0,
     }),
     () => ({
-      state: isSelected.value ? 'active' : 'inactive',
+      state: selectionState(isSelected.value),
       orientation: context.orientation.value,
     }),
   )

--- a/packages/core/src/TagsInput/TagsInput.test.ts
+++ b/packages/core/src/TagsInput/TagsInput.test.ts
@@ -68,23 +68,23 @@ describe('given default TagsInput', () => {
       })
 
       it('should select the last tags', () => {
-        expect(tags.at(-1).attributes('data-state')).toBe('active')
+        expect(tags.at(-1).attributes('data-state')).toBe('checked')
       })
 
       it('should select the previous tag when press ArrowLeft', async () => {
         await input.trigger('keydown', {
           key: 'ArrowLeft',
         })
-        expect(tags.at(-1).attributes('data-state')).toBe('inactive')
-        expect(tags[tags.length - 2].attributes('data-state')).toBe('active')
+        expect(tags.at(-1).attributes('data-state')).toBe('unchecked')
+        expect(tags[tags.length - 2].attributes('data-state')).toBe('checked')
       })
 
       it('should select the first item when press Home', async () => {
         await input.trigger('keydown', {
           key: 'Home',
         })
-        expect(tags[0].attributes('data-state')).toBe('active')
-        expect(tags.at(-1).attributes('data-state')).toBe('inactive')
+        expect(tags[0].attributes('data-state')).toBe('checked')
+        expect(tags.at(-1).attributes('data-state')).toBe('unchecked')
       })
 
       it('should select the last item when press End', async () => {
@@ -94,21 +94,21 @@ describe('given default TagsInput', () => {
         await input.trigger('keydown', {
           key: 'End',
         })
-        expect(tags[0].attributes('data-state')).toBe('inactive')
-        expect(tags.at(-1).attributes('data-state')).toBe('active')
+        expect(tags[0].attributes('data-state')).toBe('unchecked')
+        expect(tags.at(-1).attributes('data-state')).toBe('checked')
       })
 
       it('should remove active state when press ArrowRight', async () => {
         await input.trigger('keydown', {
           key: 'ArrowRight',
         })
-        expect(tags.at(-1).attributes('data-state')).toBe('inactive')
+        expect(tags.at(-1).attributes('data-state')).toBe('unchecked')
       })
 
       describe('after pressing on Backspace', () => {
         let prevTag: DOMWrapper<HTMLElement>
         beforeEach(async () => {
-          prevTag = wrapper.find('[data-state="active"]')
+          prevTag = wrapper.find('[data-state="checked"]')
           await input.trigger('keydown', {
             key: 'Backspace',
           })
@@ -125,7 +125,7 @@ describe('given default TagsInput', () => {
         })
 
         it('should select the new last tag', () => {
-          expect(tags.at(-1).attributes('data-state')).toBe('active')
+          expect(tags.at(-1).attributes('data-state')).toBe('checked')
         })
       })
     })

--- a/packages/core/src/TagsInput/TagsInputItem.vue
+++ b/packages/core/src/TagsInput/TagsInputItem.vue
@@ -3,7 +3,7 @@ import type { ComputedRef, Ref } from 'vue'
 import type { AcceptableInputValue } from './TagsInputRoot.vue'
 import type { PrimitiveProps } from '@/Primitive'
 import { computed, toRefs } from 'vue'
-import { createContext, useForwardExpose } from '@/shared'
+import { createContext, selectionState, useForwardExpose } from '@/shared'
 import { injectTagsInputRootContext } from './TagsInputRoot.vue'
 
 export interface TagsInputItemProps extends PrimitiveProps {
@@ -58,7 +58,7 @@ const itemContext = provideTagsInputItemContext({
       :aria-labelledby="itemContext.textId"
       :aria-current="isSelected"
       :data-disabled="disabled ? '' : undefined"
-      :data-state="isSelected ? 'active' : 'inactive'"
+      :data-state="selectionState(isSelected)"
     >
       <slot />
     </Primitive>

--- a/packages/core/src/TagsInput/TagsInputItemDelete.vue
+++ b/packages/core/src/TagsInput/TagsInputItemDelete.vue
@@ -2,7 +2,7 @@
 import type { PrimitiveProps } from '@/Primitive'
 import { isEqual } from 'ohash'
 import { computed } from 'vue'
-import { useForwardExpose } from '@/shared'
+import { selectionState, useForwardExpose } from '@/shared'
 import { injectTagsInputItemContext } from './TagsInputItem.vue'
 import { injectTagsInputRootContext } from './TagsInputRoot.vue'
 
@@ -36,7 +36,7 @@ function handleDelete() {
     v-bind="props"
     :aria-labelledby="itemContext.textId"
     :aria-current="itemContext.isSelected.value"
-    :data-state="itemContext.isSelected.value ? 'active' : 'inactive'"
+    :data-state="selectionState(itemContext.isSelected.value)"
     :data-disabled="disabled ? '' : undefined"
     :type="as === 'button' ? 'button' : undefined"
     @click="handleDelete"

--- a/packages/core/src/Toast/ToastRootImpl.vue
+++ b/packages/core/src/Toast/ToastRootImpl.vue
@@ -3,7 +3,7 @@ import type { SwipeEvent } from './utils'
 import type { PrimitiveProps } from '@/Primitive'
 import { isClient } from '@vueuse/shared'
 import { useCollection } from '@/Collection'
-import { createContext, getActiveElement, useForwardExpose } from '@/shared'
+import { createContext, disclosureState, getActiveElement, useForwardExpose } from '@/shared'
 
 export type ToastRootImplEmits = {
   close: []
@@ -210,7 +210,7 @@ provideToastRootContext({ onClose: handleClose })
         v-bind="$attrs"
         :as="as"
         :as-child="asChild"
-        :data-state="open ? 'open' : 'closed'"
+        :data-state="disclosureState(open)"
         :data-swipe-direction="providerContext.swipeDirection.value"
         :style="providerContext.disableSwipe.value
           ? undefined

--- a/packages/core/src/Toggle/Toggle.story.vue
+++ b/packages/core/src/Toggle/Toggle.story.vue
@@ -28,7 +28,7 @@ function onChange() {
         <Toggle
           v-model="toggleState"
           aria-label="Toggle bold"
-          class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
+          class="hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
         >
           <Icon
             icon="radix-icons:font-bold"
@@ -40,7 +40,7 @@ function onChange() {
           v-model="toggleStateOn"
           :default-value="true"
           aria-label="Toggle bold"
-          class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
+          class="hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
         >
           <Icon
             icon="radix-icons:font-bold"
@@ -56,7 +56,7 @@ function onChange() {
           v-model="toggleStateDefaultOff"
           aria-label="Toggle bold"
           :default-value="false"
-          class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
+          class="hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
         >
           <Icon
             icon="radix-icons:font-bold"
@@ -69,7 +69,7 @@ function onChange() {
           v-model="toggleStateDefaultOn"
           aria-label="Toggle bold"
           :default-value="true"
-          class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
+          class="hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
         >
           <Icon
             icon="radix-icons:font-bold"
@@ -84,7 +84,7 @@ function onChange() {
         <Toggle
           v-model="toggleState"
           aria-label="Toggle bold"
-          class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
+          class="hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
           @update:model-value="onChange"
         >
           <Icon
@@ -98,7 +98,7 @@ function onChange() {
       <Toggle
         v-model="toggleState"
         aria-label="Toggle bold"
-        class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
+        class="hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
       >
         <Icon
           icon="radix-icons:font-bold"
@@ -111,7 +111,7 @@ function onChange() {
         v-model="toggleStateDefaultOn"
         aria-label="Toggle bold"
         :default-value="true"
-        class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
+        class="hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
       >
         <Icon
           icon="radix-icons:font-bold"
@@ -123,7 +123,7 @@ function onChange() {
       <Toggle
         v-model="toggleState"
         aria-label="Toggle bold"
-        class="hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
+        class="hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 shadow-blackA7 flex h-[35px] w-[35px] items-center justify-center rounded bg-white text-base leading-4 shadow-[0_2px_10px] focus-within:shadow-[0_0_0_2px] focus-within:shadow-black"
         @update:model-value="onChange"
       >
         <Icon

--- a/packages/core/src/Toggle/Toggle.test.ts
+++ b/packages/core/src/Toggle/Toggle.test.ts
@@ -18,7 +18,7 @@ describe('given default Toggle', () => {
   })
 
   it('should not be toggled yet', () => {
-    expect(wrapper.get('button').attributes('data-state')).toBe('off')
+    expect(wrapper.get('button').attributes('data-state')).toBe('unchecked')
   })
 
   describe('after toggling', () => {
@@ -27,7 +27,7 @@ describe('given default Toggle', () => {
     })
 
     it('should be toggled on', () => {
-      expect(wrapper.get('button').attributes('data-state')).toBe('on')
+      expect(wrapper.get('button').attributes('data-state')).toBe('checked')
     })
 
     describe('after toggling again', () => {
@@ -36,7 +36,7 @@ describe('given default Toggle', () => {
       })
 
       it('should be toggled off', () => {
-        expect(wrapper.get('button').attributes('data-state')).toBe('off')
+        expect(wrapper.get('button').attributes('data-state')).toBe('unchecked')
       })
     })
   })
@@ -57,7 +57,7 @@ describe('given disabled Toggle', () => {
   })
 
   it('should not be toggled yet', () => {
-    expect(wrapper.get('button').attributes('data-state')).toBe('off')
+    expect(wrapper.get('button').attributes('data-state')).toBe('unchecked')
   })
 
   describe('try toggling', () => {
@@ -66,7 +66,7 @@ describe('given disabled Toggle', () => {
     })
 
     it('should be toggled off', () => {
-      expect(wrapper.get('button').attributes('data-state')).toBe('off')
+      expect(wrapper.get('button').attributes('data-state')).toBe('unchecked')
     })
 
     it('should render disable attributes', () => {

--- a/packages/core/src/Toggle/Toggle.vue
+++ b/packages/core/src/Toggle/Toggle.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
+import type { SelectionState } from '@/shared'
 import type { FormFieldProps } from '@/shared/types'
-import { useFormControl, useForwardExpose, useForwardScopeId } from '@/shared'
+import { selectionState, useFormControl, useForwardExpose, useForwardScopeId } from '@/shared'
 import { injectToggleGroupRootContext } from '@/ToggleGroup/ToggleGroupRoot.vue'
 import VisuallyHiddenInput from '@/VisuallyHidden/VisuallyHiddenInput.vue'
 
@@ -9,8 +10,6 @@ export type ToggleEmits = {
   /** Event handler called when the value of the toggle changes. */
   'update:modelValue': [value: boolean]
 }
-
-export type DataState = 'on' | 'off'
 
 export interface ToggleProps extends PrimitiveProps, FormFieldProps {
   /**
@@ -74,9 +73,7 @@ function togglePressed() {
   modelValue.value = !modelValue.value
 }
 
-const dataState = computed<DataState>(() => {
-  return modelValue.value ? 'on' : 'off'
-})
+const dataState = computed<SelectionState>(() => selectionState(modelValue.value))
 
 const isFormControl = useFormControl(currentElement)
 </script>

--- a/packages/core/src/ToggleGroup/ToggleGroup.test.ts
+++ b/packages/core/src/ToggleGroup/ToggleGroup.test.ts
@@ -24,9 +24,9 @@ describe('given default Toggle Group', () => {
   })
 
   it('should have active toggle=center', () => {
-    expect(triggers[0].attributes('data-state')).toBe('off')
-    expect(triggers[1].attributes('data-state')).toBe('on')
-    expect(triggers[2].attributes('data-state')).toBe('off')
+    expect(triggers[0].attributes('data-state')).toBe('unchecked')
+    expect(triggers[1].attributes('data-state')).toBe('checked')
+    expect(triggers[2].attributes('data-state')).toBe('unchecked')
   })
 
   describe('after toggling current active', () => {
@@ -37,9 +37,9 @@ describe('given default Toggle Group', () => {
     })
 
     it('should deselect pre-existing value', () => {
-      expect(triggers[0].attributes('data-state')).toBe('off')
-      expect(triggers[1].attributes('data-state')).toBe('off')
-      expect(triggers[2].attributes('data-state')).toBe('off')
+      expect(triggers[0].attributes('data-state')).toBe('unchecked')
+      expect(triggers[1].attributes('data-state')).toBe('unchecked')
+      expect(triggers[2].attributes('data-state')).toBe('unchecked')
     })
   })
 
@@ -59,9 +59,9 @@ describe('given default Toggle Group', () => {
       })
 
       it('should have next active value', () => {
-        expect(triggers[0].attributes('data-state')).toBe('off')
-        expect(triggers[1].attributes('data-state')).toBe('off')
-        expect(triggers[2].attributes('data-state')).toBe('on')
+        expect(triggers[0].attributes('data-state')).toBe('unchecked')
+        expect(triggers[1].attributes('data-state')).toBe('unchecked')
+        expect(triggers[2].attributes('data-state')).toBe('checked')
       })
 
       describe('after triggering ArrowRight again', () => {
@@ -92,9 +92,9 @@ describe('given default Toggle Group', () => {
       })
 
       it('should have next active value', () => {
-        expect(triggers[0].attributes('data-state')).toBe('on')
-        expect(triggers[1].attributes('data-state')).toBe('off')
-        expect(triggers[2].attributes('data-state')).toBe('off')
+        expect(triggers[0].attributes('data-state')).toBe('checked')
+        expect(triggers[1].attributes('data-state')).toBe('unchecked')
+        expect(triggers[2].attributes('data-state')).toBe('unchecked')
       })
     })
   })
@@ -123,9 +123,9 @@ describe('given multiple value Toggle Group', () => {
   })
 
   it('should have active toggle=center', () => {
-    expect(triggers[0].attributes('data-state')).toBe('off')
-    expect(triggers[1].attributes('data-state')).toBe('on')
-    expect(triggers[2].attributes('data-state')).toBe('on')
+    expect(triggers[0].attributes('data-state')).toBe('unchecked')
+    expect(triggers[1].attributes('data-state')).toBe('checked')
+    expect(triggers[2].attributes('data-state')).toBe('checked')
   })
 
   describe('after triggering ArrowRight', () => {
@@ -144,9 +144,9 @@ describe('given multiple value Toggle Group', () => {
       })
 
       it('should have next active value', () => {
-        expect(triggers[0].attributes('data-state')).toBe('off')
-        expect(triggers[1].attributes('data-state')).toBe('on')
-        expect(triggers[2].attributes('data-state')).toBe('off')
+        expect(triggers[0].attributes('data-state')).toBe('unchecked')
+        expect(triggers[1].attributes('data-state')).toBe('checked')
+        expect(triggers[2].attributes('data-state')).toBe('unchecked')
       })
 
       describe('after triggering ArrowRight again', () => {
@@ -177,9 +177,9 @@ describe('given multiple value Toggle Group', () => {
       })
 
       it('should have next active value', () => {
-        expect(triggers[0].attributes('data-state')).toBe('on')
-        expect(triggers[1].attributes('data-state')).toBe('on')
-        expect(triggers[2].attributes('data-state')).toBe('on')
+        expect(triggers[0].attributes('data-state')).toBe('checked')
+        expect(triggers[1].attributes('data-state')).toBe('checked')
+        expect(triggers[2].attributes('data-state')).toBe('checked')
       })
     })
   })

--- a/packages/core/src/ToggleGroup/story/ToggleGroup.story.vue
+++ b/packages/core/src/ToggleGroup/story/ToggleGroup.story.vue
@@ -7,7 +7,7 @@ const toggleStateSingle = ref<string | null>(null)
 const toggleStateMultiple = ref<string[] | string | null>('123')
 
 const toggleGroupItemClasses
-  = 'hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 flex h-[35px] w-[35px] items-center justify-center bg-white text-base leading-4 first:rounded-l last:rounded-r focus:z-10 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none'
+  = 'hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 flex h-[35px] w-[35px] items-center justify-center bg-white text-base leading-4 first:rounded-l last:rounded-r focus:z-10 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none'
 </script>
 
 <template>

--- a/packages/core/src/ToggleGroup/story/_ToggleGroup.vue
+++ b/packages/core/src/ToggleGroup/story/_ToggleGroup.vue
@@ -10,7 +10,7 @@ const emits = defineEmits<ToggleGroupRootEmits>()
 const forwarded = useForwardPropsEmits(props, emits)
 
 const toggleGroupItemClasses
-  = 'hover:bg-violet3 color-mauve11 data-[state=on]:bg-violet6 data-[state=on]:text-violet12 flex h-[35px] w-[35px] items-center justify-center bg-white text-base leading-4 first:rounded-l last:rounded-r focus:z-10 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none'
+  = 'hover:bg-violet3 color-mauve11 data-[state=checked]:bg-violet6 data-[state=checked]:text-violet12 flex h-[35px] w-[35px] items-center justify-center bg-white text-base leading-4 first:rounded-l last:rounded-r focus:z-10 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none'
 </script>
 
 <template>

--- a/packages/core/src/Toolbar/Toolbar.test.ts
+++ b/packages/core/src/Toolbar/Toolbar.test.ts
@@ -22,7 +22,7 @@ describe('given default Toolbar', () => {
   })
 
   it('should have default selected value', () => {
-    const selected = triggers.filter(i => i.attributes('data-state') === 'on').map(i => i.element)
+    const selected = triggers.filter(i => i.attributes('data-state') === 'checked').map(i => i.element)
     expect(selected.includes(triggers[4].element)).toBeTruthy()
   })
 

--- a/packages/core/src/Toolbar/story/Toolbar.story.vue
+++ b/packages/core/src/Toolbar/story/Toolbar.story.vue
@@ -30,21 +30,21 @@ const toggleStateMultiple = ref([])
           aria-label="Text formatting"
         >
           <ToolbarToggleItem
-            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
             value="bold"
             aria-label="Bold"
           >
             <Icon icon="radix-icons:font-bold" />
           </ToolbarToggleItem>
           <ToolbarToggleItem
-            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
             value="italic"
             aria-label="Italic"
           >
             <Icon icon="radix-icons:font-italic" />
           </ToolbarToggleItem>
           <ToolbarToggleItem
-            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
             value="strikethrough"
             aria-label="Strike through"
           >
@@ -58,21 +58,21 @@ const toggleStateMultiple = ref([])
           aria-label="Text Alignment"
         >
           <ToolbarToggleItem
-            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
             value="left"
             aria-label="Left Aligned"
           >
             <Icon icon="radix-icons:text-align-left" />
           </ToolbarToggleItem>
           <ToolbarToggleItem
-            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
             value="center"
             aria-label="Center Aligned"
           >
             <Icon icon="radix-icons:text-align-center" />
           </ToolbarToggleItem>
           <ToolbarToggleItem
-            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+            class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
             value="right"
             aria-label="Right Aligned"
           >
@@ -81,7 +81,7 @@ const toggleStateMultiple = ref([])
         </ToolbarToggleGroup>
         <ToolbarSeparator class="w-[1px] bg-mauve6 mx-[10px]" />
         <ToolbarLink
-          class="bg-transparent text-mauve11 inline-flex justify-center items-center hover:bg-transparent hover:cursor-pointer flex-shrink-0 flex-grow-0 basis-auto h-[25px] px-[5px] rounded text-[13px] leading-none bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+          class="bg-transparent text-mauve11 inline-flex justify-center items-center hover:bg-transparent hover:cursor-pointer flex-shrink-0 flex-grow-0 basis-auto h-[25px] px-[5px] rounded text-[13px] leading-none bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
           href="#"
           target="_blank"
           style="margin-right: 10"

--- a/packages/core/src/Toolbar/story/_Toolbar.vue
+++ b/packages/core/src/Toolbar/story/_Toolbar.vue
@@ -25,21 +25,21 @@ const toggleStateMultiple = ref([])
       aria-label="Text formatting"
     >
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
         value="bold"
         aria-label="Bold"
       >
         <Icon icon="radix-icons:font-bold" />
       </ToolbarToggleItem>
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
         value="italic"
         aria-label="Italic"
       >
         <Icon icon="radix-icons:font-italic" />
       </ToolbarToggleItem>
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
         value="strikethrough"
         aria-label="Strike through"
       >
@@ -53,21 +53,21 @@ const toggleStateMultiple = ref([])
       aria-label="Text Alignment"
     >
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
         value="left"
         aria-label="Left Aligned"
       >
         <Icon icon="radix-icons:text-align-left" />
       </ToolbarToggleItem>
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
         value="center"
         aria-label="Center Aligned"
       >
         <Icon icon="radix-icons:text-align-center" />
       </ToolbarToggleItem>
       <ToolbarToggleItem
-        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        class="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
         value="right"
         aria-label="Right Aligned"
       >
@@ -76,7 +76,7 @@ const toggleStateMultiple = ref([])
     </ToolbarToggleGroup>
     <ToolbarSeparator class="w-[1px] bg-mauve6 mx-[10px]" />
     <ToolbarLink
-      class="bg-transparent text-mauve11 inline-flex justify-center items-center hover:bg-transparent hover:cursor-pointer flex-shrink-0 flex-grow-0 basis-auto h-[25px] px-[5px] rounded text-[13px] leading-none bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+      class="bg-transparent text-mauve11 inline-flex justify-center items-center hover:bg-transparent hover:cursor-pointer flex-shrink-0 flex-grow-0 basis-auto h-[25px] px-[5px] rounded text-[13px] leading-none bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=checked]:bg-violet5 data-[state=checked]:text-violet11"
       href="#"
       target="_blank"
       style="margin-right: 10"

--- a/packages/core/src/Tooltip/Tooltip.test.ts
+++ b/packages/core/src/Tooltip/Tooltip.test.ts
@@ -1,7 +1,8 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
+import { nextTick } from 'vue'
 import Tooltip from './stories/_Tooltip.vue'
 import TooltipProvider from './TooltipProvider.vue'
 
@@ -94,5 +95,75 @@ describe('given tooltip within TooltipProvider', () => {
     })
 
     expect(tooltipContentImpl.html()).toContain('data-side="left"')
+  })
+})
+
+// `data-state` is the disclosure axis only (`open` | `closed`, #2823); whether the
+// open was delayed is a separate boolean qualifier, `data-delayed`.
+describe('given tooltip data-state / data-delayed contract', () => {
+  let wrapper: VueWrapper<InstanceType<typeof Tooltip>>
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    document.body.innerHTML = ''
+    wrapper = mount(Tooltip, {
+      global: { stubs: { teleport: { template: '<div><slot /></div>' } } },
+      attachTo: document.body,
+      props: { tooltipProvider: { delayDuration: 700 } },
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('is `closed` without `data-delayed` initially', () => {
+    const trigger = wrapper.find('button')
+    expect(trigger.attributes('data-state')).toBe('closed')
+    expect(trigger.attributes('data-delayed')).toBeUndefined()
+  })
+
+  it('is `open` without `data-delayed` after an instant open (focus)', async () => {
+    const trigger = wrapper.find('button')
+    await trigger.trigger('focus')
+    await nextTick()
+
+    expect(trigger.attributes('data-state')).toBe('open')
+    expect(trigger.attributes('data-delayed')).toBeUndefined()
+    const content = wrapper.find('[data-state="open"]:not(button)')
+    expect(content.exists()).toBe(true)
+    expect(content.attributes('data-delayed')).toBeUndefined()
+  })
+
+  it('is `open` with `data-delayed=""` after a delayed open (pointer + timer)', async () => {
+    const trigger = wrapper.find('button')
+    await trigger.trigger('pointermove', { pointerType: 'mouse' })
+    await nextTick()
+    // Timer has not fired yet: still closed, no qualifier.
+    expect(trigger.attributes('data-state')).toBe('closed')
+    expect(trigger.attributes('data-delayed')).toBeUndefined()
+
+    vi.advanceTimersByTime(700)
+    await nextTick()
+    await nextTick()
+
+    expect(trigger.attributes('data-state')).toBe('open')
+    expect(trigger.attributes('data-delayed')).toBe('')
+    const content = wrapper.find('[data-state="open"]:not(button)')
+    expect(content.exists()).toBe(true)
+    expect(content.attributes('data-delayed')).toBe('')
+  })
+
+  it('drops `data-delayed` again once closed', async () => {
+    const trigger = wrapper.find('button')
+    await trigger.trigger('pointermove', { pointerType: 'mouse' })
+    vi.advanceTimersByTime(700)
+    await nextTick()
+    expect(trigger.attributes('data-delayed')).toBe('')
+
+    await trigger.trigger('blur')
+    await nextTick()
+    expect(trigger.attributes('data-state')).toBe('closed')
+    expect(trigger.attributes('data-delayed')).toBeUndefined()
   })
 })

--- a/packages/core/src/Tooltip/TooltipContentImpl.vue
+++ b/packages/core/src/Tooltip/TooltipContentImpl.vue
@@ -108,6 +108,7 @@ onMounted(() => {
     <PopperContent
       :ref="forwardRef"
       :data-state="rootContext.stateAttribute.value"
+      :data-delayed="rootContext.isDelayed.value ? '' : undefined"
       v-bind="{ ...$attrs, ...popperContentProps }"
       :style="{
         '--reka-tooltip-content-transform-origin': 'var(--reka-popper-transform-origin)',

--- a/packages/core/src/Tooltip/TooltipRoot.vue
+++ b/packages/core/src/Tooltip/TooltipRoot.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Ref } from 'vue'
-import { createContext, useForwardExpose } from '@/shared'
+import type { DisclosureState } from '@/shared'
+import { createContext, disclosureState, useForwardExpose } from '@/shared'
 
 export interface TooltipRootProps {
   /**
@@ -53,7 +54,10 @@ export type TooltipRootEmits = {
 export interface TooltipContext {
   contentId: string
   open: Ref<boolean>
-  stateAttribute: Ref<'closed' | 'delayed-open' | 'instant-open'>
+  /** `'open' | 'closed'` — the disclosure axis of `data-state` (#2823). */
+  stateAttribute: Ref<DisclosureState>
+  /** `true` only while open AND that open came from the delay timer; bound as `data-delayed`. */
+  isDelayed: Ref<boolean>
   trigger: Ref<HTMLElement | undefined>
   onTriggerChange: (trigger: HTMLElement | undefined) => void
   onTriggerEnter: () => void
@@ -128,11 +132,8 @@ watch(open, (isOpen) => {
 const wasOpenDelayedRef = ref(false)
 const trigger = ref<HTMLElement>()
 
-const stateAttribute = computed(() => {
-  if (!open.value)
-    return 'closed'
-  return wasOpenDelayedRef.value ? 'delayed-open' : 'instant-open'
-})
+const stateAttribute = computed<DisclosureState>(() => disclosureState(open.value))
+const isDelayed = computed(() => open.value && wasOpenDelayedRef.value)
 
 const { start: startTimer, stop: clearTimer } = useTimeoutFn(() => {
   wasOpenDelayedRef.value = true
@@ -156,6 +157,7 @@ provideTooltipRootContext({
   contentId: '',
   open,
   stateAttribute,
+  isDelayed,
   trigger,
   onTriggerChange(el) {
     trigger.value = el

--- a/packages/core/src/Tooltip/TooltipTrigger.vue
+++ b/packages/core/src/Tooltip/TooltipTrigger.vue
@@ -1,10 +1,8 @@
 <script lang="ts">
+import type { DisclosureState } from '@/shared'
 import { useForwardExpose, useId } from '@/shared'
 
-export type TooltipTriggerDataState
-  = | 'closed'
-    | 'delayed-open'
-    | 'instant-open'
+export type TooltipTriggerDataState = DisclosureState
 
 export interface TooltipTriggerProps extends PopperAnchorProps {}
 </script>
@@ -111,6 +109,7 @@ function handleClick() {
         rootContext.open.value ? rootContext.contentId : undefined
       "
       :data-state="rootContext.stateAttribute.value"
+      :data-delayed="rootContext.isDelayed.value ? '' : undefined"
       :as="as"
       :as-child="props.asChild"
       data-grace-area-trigger

--- a/packages/core/src/Tooltip/stories/Tooltip.content.story.vue
+++ b/packages/core/src/Tooltip/stories/Tooltip.content.story.vue
@@ -31,7 +31,7 @@ const lastEvent = ref('')
                 :align-offset="20"
                 aria-label="label tooltip content"
                 :side-offset="5"
-                class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
+                class="data-[state=open]:data-[delayed]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[delayed]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[delayed]:data-[side=left]:animate-slideRightAndFade data-[state=open]:data-[delayed]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
               >
                 <ul>
                   <h4>Add to library</h4>
@@ -69,7 +69,7 @@ const lastEvent = ref('')
             <Teleport to="body">
               <TooltipContent
                 :side-offset="5"
-                class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
+                class="data-[state=open]:data-[delayed]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[delayed]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[delayed]:data-[side=left]:animate-slideRightAndFade data-[state=open]:data-[delayed]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
                 @escape-key-down="lastEvent = '@on-escape-key-down'"
                 @pointer-down-outside="lastEvent = '@pointer-down-outside'"
               >

--- a/packages/core/src/Tooltip/stories/Tooltip.story.vue
+++ b/packages/core/src/Tooltip/stories/Tooltip.story.vue
@@ -24,7 +24,7 @@ const disableTooltip = ref(false)
             <TooltipPortal>
               <TooltipContent
                 :side-offset="5"
-                class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
+                class="data-[state=open]:data-[delayed]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[delayed]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[delayed]:data-[side=left]:animate-slideRightAndFade data-[state=open]:data-[delayed]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
               >
                 Add to library
                 <TooltipArrow class="fill-white" />
@@ -46,7 +46,7 @@ const disableTooltip = ref(false)
             <TooltipPortal>
               <TooltipContent
                 :side-offset="5"
-                class="data-[state=closed]:animate-fadeOut data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
+                class="data-[state=closed]:animate-fadeOut data-[state=open]:data-[delayed]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[delayed]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[delayed]:data-[side=left]:animate-slideRightAndFade data-[state=open]:data-[delayed]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
               >
                 Add to library
                 <TooltipArrow class="fill-white" />

--- a/packages/core/src/Tooltip/stories/_Tooltip.vue
+++ b/packages/core/src/Tooltip/stories/_Tooltip.vue
@@ -23,7 +23,7 @@ const toggleState = ref(false)
       <TooltipPortal>
         <TooltipContent
           :side-offset="5"
-          class="data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
+          class="data-[state=open]:data-[delayed]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[delayed]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[delayed]:data-[side=left]:animate-slideRightAndFade data-[state=open]:data-[delayed]:data-[side=bottom]:animate-slideUpAndFade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
         >
           Add to library
           <TooltipArrow class="fill-white" />


### PR DESCRIPTION
### 🔗 Linked issue

Implements the decision recorded on #2823. Part of the v3 roadmap #2721.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`data-state` now answers exactly one of two questions. Disclosure ("is this surface revealed?") → `open` | `closed`. Selection ("is this control in its affirmative state?") → `checked` | `unchecked`, plus `indeterminate` for tri-state controls. Both values are always emitted, and qualifiers live in their own attribute.

**Renames**

| Part(s) | v2 | v3 |
|---|---|---|
| Toggle, ToggleGroupItem, ToolbarToggleItem | `on` / `off` | `checked` / `unchecked` |
| TabsTrigger, TabsContent, TagsInputItem, TagsInputItemDelete | `active` / `inactive` | `checked` / `unchecked` |
| RatingItemIndicator | `active` / absent | `checked` / `unchecked` |
| ScrollArea scrollbars and thumb, NavigationMenuIndicator | `visible` / `hidden` | `open` / `closed` |
| SplitterPanel | `expanded` / `collapsed` / absent | `open` / `closed` |
| CollapsibleContent | `open` / `closed` / absent on the animated mount | `open` / `closed` |
| TooltipTrigger, TooltipContent | `closed` / `delayed-open` / `instant-open` | `open` / `closed` + boolean `data-delayed` while a delayed open is showing |

Progress, Stepper and SplitterResizeHandle are grandfathered unchanged, per the decision.

**One home for the vocabulary.** `shared/dataState.ts` (landed in #2910) is now the only place the literals exist. The duplicate `getOpenState` / `getCheckedState` (Menu, NavigationMenu), Checkbox's `getState`, Toggle's `DataState` and the `AccordionItemState` enum are deleted; every binding site calls `disclosureState()` / `selectionState()`. `TabsTriggerState`, `TabsContentState` and `TooltipTriggerDataState` are retyped to the shared unions. Dialog no longer imports a helper from `@/Menu/utils`.

**Tooltip contract.** `TooltipContext.stateAttribute` is `DisclosureState`; a new `isDelayed` ref is bound as `data-delayed=""` on the trigger and content only while open via the delay timer. Tailwind: `data-[state=open]:data-[delayed]:` (the arbitrary form, since the docs run Tailwind 3.4 where a bare `data-delayed:` variant is silently ignored). New tests cover the four states.

**CollapsibleContent.** The `undefined` gap on the initial animated mount is dropped; the inline `transition-duration: 0s` / `animation-name: none` styles already suppress the mount animation, so the attribute gap was redundant.

**Docs.** Every hand-written `DataAttributesTable` row is updated, the demos and site components use the new selectors, the styling guide states the two-axis rule, and a new **Migration to v3** guide carries the mapping table and the search-and-replace list (linked from the sidebar).

**Left for follow-ups**: the best-effort codemod (separate PR, as agreed), renaming Stepper's `active/inactive` for rule purity, and `docs:gen` for touched families.

**Validation note:** the authoring environment blocks the npm registry, so tests, type-check and lint could not run locally. CI is the first execution.

### 📸 Screenshots (if appropriate)

n/a

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a v2-to-v3 migration guide covering updated state attributes and migration steps.
  * Added clearer tooltip state reporting with `open`/`closed` states and a separate delayed indicator.

* **Improvements**
  * Standardized component state attributes around `open`/`closed` and `checked`/`unchecked`.
  * Updated tabs, toggles, ratings, navigation, scroll areas, splitters, and related styling to reflect the new state names.

* **Documentation**
  * Updated component references and styling guidance with the revised state vocabulary and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->