### PR TITLE
feat(v3)!: data-state codemod, and change details on Dialog and Popover open

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,6 +49,9 @@ jobs:
       - name: Test (with coverage)
         run: pnpm --filter reka-ui test:coverage
 
+      - name: Test codemod
+        run: pnpm --filter @reka-ui/codemod test
+
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7

--- a/docs/content/docs/guides/migration-v3.md
+++ b/docs/content/docs/guides/migration-v3.md
@@ -67,3 +67,39 @@ Because both values are now always emitted, any styles that relied on the attrib
   animation-name: slideDownAndFade;
 }
 ```
+
+### Codemod
+
+The `@reka-ui/codemod` package automates the mechanical part: `npx @reka-ui/codemod data-state ./src` applies the mapping above to Tailwind variants and CSS attribute selectors in every `.vue`, `.css`, `.scss`, `.ts`, `.tsx`, `.js`, `.jsx`, `.html` and `.md` file under the given paths. It is deliberately conservative—`active` / `inactive` selectors are only rewritten in files that clearly belong to Tabs, TagsInput or Rating rather than Stepper or Splitter, and presence-only selectors such as `:not([data-state])` are never touched; both cases are left as they are and reported as a `file:line` warning for you to resolve by hand. Run it with `--dry-run` first to review the changes it would make before letting it write to disk.
+
+## Change events carry details
+
+`update:*` events on stateful roots now receive a second argument, a `ChangeEventDetails` object, and a cancellable `beforeUpdate:*` event fires before every change. `v-model` keeps working unchanged. The details tell you *why* the state changed (`details.reason`) and which native event caused it (`details.event`), and `details.cancel()` inside `beforeUpdate:*` keeps the current state.
+
+Converted so far: `SwitchRoot`, `TabsRoot` (`modelValue`), `MenuRoot`, `ContextMenuRoot`, `DialogRoot`, `AlertDialogRoot`, `PopoverRoot`, `DatePickerRoot` and `DateRangePickerRoot` (`open`). The remaining families follow as they move to their headless composables.
+
+Each family exports its reason union, for example `DialogOpenChangeReason` (`'trigger-press' | 'close-press' | 'escape-key' | 'outside-press' | 'focus-outside'`); every family also reports `'imperative-action'` for programmatic changes such as the slot's `close()`.
+
+What to check in your code:
+
+- Explicit `@update:open` / `@update:model-value` listeners receive an extra argument. Handlers that only read the first argument keep working; handlers typed with a single-parameter signature still type-check.
+- Wrappers that re-declare the emit types need the new tuple shape:
+
+  ```ts
+  'update:open': [value: boolean] // [!code --]
+  'update:open': [value: boolean, details: ChangeEventDetails<DialogOpenChangeReason>] // [!code ++]
+  ```
+
+- Uncontrolled components emit synchronously from the interaction instead of from a watcher on the next tick. Code that relied on the old timing may observe the difference.
+- A component that mounts uncontrolled and later receives a defined model value becomes controlled at that point and stays controlled, even if the model is later cleared to `undefined`.
+
+```vue
+<DialogRoot
+  v-model:open="open"
+  @before-update:open="(value, details) => {
+    // keep the dialog open while the form is dirty, but let the close button through
+    if (!value && isDirty && details.reason !== 'close-press')
+      details.cancel()
+  }"
+/>
+```

--- a/docs/content/docs/guides/migration-v3.md
+++ b/docs/content/docs/guides/migration-v3.md
@@ -34,7 +34,7 @@ Parts that were already on `open` / `closed` or `checked` / `unchecked` / `indet
 The rewrites are mechanical. In Tailwind variants:
 
 - `data-[state=on]:` → `data-[state=checked]:`, `data-[state=off]:` → `data-[state=unchecked]:`
-- `data-[state=active]:` → `data-[state=checked]:`, `data-[state=inactive]:` → `data-[state=unchecked]:` — for **Tabs and TagsInput only**. Stepper keeps `active` / `inactive` / `completed`, so leave selectors on `StepperItem` alone.
+- `data-[state=active]:` → `data-[state=checked]:`, `data-[state=inactive]:` → `data-[state=unchecked]:` — for **Tabs, TagsInput and Rating only**. Stepper keeps `active` / `inactive` / `completed`, so leave selectors on `StepperItem` alone.
 - `data-[state=visible]:` → `data-[state=open]:`, `data-[state=hidden]:` → `data-[state=closed]:`
 - `data-[state=expanded]:` → `data-[state=open]:`, `data-[state=collapsed]:` → `data-[state=closed]:`
 - `data-[state=delayed-open]:` → `data-[state=open]:data-[delayed]:`
@@ -43,7 +43,7 @@ The rewrites are mechanical. In Tailwind variants:
 In plain CSS the same rewrites apply to attribute selectors:
 
 - `[data-state='on']` → `[data-state='checked']`, `[data-state='off']` → `[data-state='unchecked']`
-- `[data-state='active']` → `[data-state='checked']`, `[data-state='inactive']` → `[data-state='unchecked']` — Tabs and TagsInput only, not Stepper.
+- `[data-state='active']` → `[data-state='checked']`, `[data-state='inactive']` → `[data-state='unchecked']` — Tabs, TagsInput and Rating only, not Stepper.
 - `[data-state='visible']` → `[data-state='open']`, `[data-state='hidden']` → `[data-state='closed']`
 - `[data-state='expanded']` → `[data-state='open']`, `[data-state='collapsed']` → `[data-state='closed']`
 - `[data-state='delayed-open']` → `[data-state='open'][data-delayed]`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,13 @@ export default antfu(
     },
   },
   {
+    // The codemod package is dependency-free and runs its tests with `node --test`.
+    files: ['packages/codemod/test/**/*.mjs'],
+    rules: {
+      'test/no-import-node-test': 'off',
+    },
+  },
+  {
     files: ['**/package.json'],
     rules: {
       // Wrecks the order of `files` otherwise, and breaks the exclusion patterns

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -1,0 +1,36 @@
+# @reka-ui/codemod
+
+Best-effort codemods for migrating a codebase between Reka UI major versions.
+
+```sh
+npx @reka-ui/codemod data-state ./src
+```
+
+Run with `--dry-run` first to see what would change without writing anything, and use `--ext` to change the file extensions that are processed (default: `vue,css,scss,ts,tsx,js,jsx,html,md`). `node_modules`, `dist`, `.git`, `.nuxt`, `.output` and `coverage` are always skipped.
+
+```sh
+npx @reka-ui/codemod data-state ./src --dry-run
+npx @reka-ui/codemod data-state ./src ./docs --ext vue,css
+```
+
+## `data-state`
+
+Rewrites the v2 `data-state` values to the [v3 vocabulary](https://reka-ui.com/docs/guides/migration-v3) in Tailwind variants (`data-[state=…]:`, `group-data-[state=…]:`, `peer-data-[state=…]:`) and CSS attribute selectors (`[data-state=…]`, `[data-state='…']`, `[data-state="…"]`):
+
+| v2 | v3 |
+| --- | --- |
+| `on` / `off` | `checked` / `unchecked` |
+| `visible` / `hidden` | `open` / `closed` |
+| `expanded` / `collapsed` | `open` / `closed` |
+| `instant-open` | `open` |
+| `delayed-open` | `open` + `data-delayed` (`data-[state=open]:data-[delayed]:` / `[data-state=open][data-delayed]`) |
+| `active` / `inactive` | `checked` / `unchecked` — only when the file is clearly about Tabs, TagsInput or Rating |
+
+Everything else — `data-[side=…]`, `data-orientation`, values already on `open` / `closed` / `checked` / `unchecked` — is left as is, and running the codemod twice makes no further changes.
+
+### Warnings
+
+Two situations cannot be decided mechanically. The codemod leaves the source untouched and prints a `file:line: message` warning for each so you can finish the migration by hand:
+
+- `ambiguous data-state "active": rewrite to "checked" for Tabs/TagsInput/Rating, keep for Stepper/Splitter` — Tabs, TagsInput and Rating moved from `active` / `inactive` to `checked` / `unchecked`, but Stepper still emits `active` / `inactive` / `completed` and the Splitter resize handle still emits `inactive`. The decision is made per file from the component names it mentions: a file that mentions `Tabs`, `TagsInput` or `Rating` (and not `Stepper` or `SplitterResizeHandle`) is rewritten, a file that only mentions `Stepper` or `SplitterResizeHandle` is kept, and a file that mentions both or neither gets this warning.
+- `"[data-state]" is now always present; target the explicit value instead` — a `:not([data-state])` selector relied on the attribute being absent (for example a `RatingItemIndicator` that was not active, or a non-collapsible `SplitterPanel`). In v3 both values are always emitted, so the selector matches nothing; target `unchecked` / `open` instead.

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -6,7 +6,7 @@ Best-effort codemods for migrating a codebase between Reka UI major versions.
 npx @reka-ui/codemod data-state ./src
 ```
 
-Run with `--dry-run` first to see what would change without writing anything, and use `--ext` to change the file extensions that are processed (default: `vue,css,scss,ts,tsx,js,jsx,html,md`). `node_modules`, `dist`, `.git`, `.nuxt`, `.output` and `coverage` are always skipped.
+Run with `--dry-run` first to see what would change without writing anything, and use `--ext` to change the file extensions that are processed (default: `vue,css,scss,ts,tsx,js,jsx,html,md`). `node_modules`, `dist`, `.git`, `.nuxt`, `.output` and `coverage` are always skipped, including when a supplied path is or sits inside one of them.
 
 ```sh
 npx @reka-ui/codemod data-state ./src --dry-run
@@ -33,4 +33,4 @@ Everything else — `data-[side=…]`, `data-orientation`, values already on `op
 Two situations cannot be decided mechanically. The codemod leaves the source untouched and prints a `file:line: message` warning for each so you can finish the migration by hand:
 
 - `ambiguous data-state "active": rewrite to "checked" for Tabs/TagsInput/Rating, keep for Stepper/Splitter` — Tabs, TagsInput and Rating moved from `active` / `inactive` to `checked` / `unchecked`, but Stepper still emits `active` / `inactive` / `completed` and the Splitter resize handle still emits `inactive`. The decision is made per file from the component names it mentions: a file that mentions `Tabs`, `TagsInput` or `Rating` (and not `Stepper` or `SplitterResizeHandle`) is rewritten, a file that only mentions `Stepper` or `SplitterResizeHandle` is kept, and a file that mentions both or neither gets this warning.
-- `"[data-state]" is now always present; target the explicit value instead` — a `:not([data-state])` selector relied on the attribute being absent (for example a `RatingItemIndicator` that was not active, or a non-collapsible `SplitterPanel`). In v3 both values are always emitted, so the selector matches nothing; target `unchecked` / `open` instead.
+- `"[data-state]" is now always present, so a presence-only selector matches every part; target the explicit value instead` — a bare `[data-state]` or `:not([data-state])` selector relied on the attribute being present or absent (for example a `RatingItemIndicator` that was active, or a non-collapsible `SplitterPanel`). In v3 both values are always emitted, so `[data-state]` matches every part and `:not([data-state])` matches nothing; target `checked` / `unchecked` or `open` / `closed` instead.

--- a/packages/codemod/bin/reka-ui-codemod.mjs
+++ b/packages/codemod/bin/reka-ui-codemod.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { extname, join, relative } from 'node:path'
+import process from 'node:process'
+import { transformDataState } from '../src/data-state.mjs'
+
+const DEFAULT_EXTENSIONS = ['vue', 'css', 'scss', 'ts', 'tsx', 'js', 'jsx', 'html', 'md']
+const SKIPPED_DIRECTORIES = new Set(['node_modules', 'dist', '.git', '.nuxt', '.output', 'coverage'])
+
+const TRANSFORMS = {
+  'data-state': transformDataState,
+}
+
+const USAGE = `Usage: reka-ui-codemod <transform> [paths...] [--dry-run] [--ext vue,css,scss,ts,tsx,js,jsx,html,md]
+
+Transforms:
+  data-state   Rewrite v2 data-state values (on/off, active/inactive, visible/hidden,
+               expanded/collapsed, delayed-open/instant-open) to the v3 vocabulary
+               in Tailwind variants and CSS attribute selectors.
+
+Options:
+  --dry-run    Report what would change without writing any file.
+  --ext        Comma-separated list of file extensions to process.
+  -h, --help   Show this message.
+`
+
+function print(message) {
+  process.stdout.write(`${message}\n`)
+}
+
+function parseArgs(argv) {
+  const options = { transform: undefined, paths: [], dryRun: false, extensions: DEFAULT_EXTENSIONS, help: false }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--dry-run') {
+      options.dryRun = true
+    }
+    else if (arg === '-h' || arg === '--help') {
+      options.help = true
+    }
+    else if (arg === '--ext') {
+      options.extensions = parseExtensions(argv[++i])
+    }
+    else if (arg.startsWith('--ext=')) {
+      options.extensions = parseExtensions(arg.slice('--ext='.length))
+    }
+    else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+    else if (options.transform === undefined) {
+      options.transform = arg
+    }
+    else {
+      options.paths.push(arg)
+    }
+  }
+  if (options.paths.length === 0)
+    options.paths.push('.')
+  return options
+}
+
+function parseExtensions(value = '') {
+  const extensions = value
+    .split(',')
+    .map(ext => ext.trim().replace(/^\./, ''))
+    .filter(Boolean)
+  if (extensions.length === 0)
+    throw new Error('--ext expects a comma-separated list of extensions')
+  return extensions
+}
+
+function* walk(path, extensions) {
+  const stats = statSync(path)
+  if (stats.isFile()) {
+    if (extensions.has(extname(path).slice(1)))
+      yield path
+    return
+  }
+  if (!stats.isDirectory())
+    return
+  const entries = readdirSync(path, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRECTORIES.has(entry.name))
+        yield * walk(join(path, entry.name), extensions)
+    }
+    else if (entry.isFile() && extensions.has(extname(entry.name).slice(1))) {
+      yield join(path, entry.name)
+    }
+  }
+}
+
+function run(argv) {
+  const options = parseArgs(argv)
+  if (options.help || options.transform === undefined) {
+    print(USAGE)
+    return options.help ? 0 : 1
+  }
+
+  const transform = TRANSFORMS[options.transform]
+  if (!transform) {
+    print(`Unknown transform "${options.transform}".\n`)
+    print(USAGE)
+    return 1
+  }
+
+  const extensions = new Set(options.extensions)
+  let changedFiles = 0
+  let warningCount = 0
+
+  for (const root of options.paths) {
+    for (const file of walk(root, extensions)) {
+      const source = readFileSync(file, 'utf8')
+      const { code, changed, warnings } = transform(source, { filename: file })
+      const displayPath = relative(process.cwd(), file) || file
+
+      if (changed) {
+        changedFiles++
+        if (!options.dryRun)
+          writeFileSync(file, code)
+        print(`${options.dryRun ? 'would change' : 'changed'} ${displayPath}`)
+      }
+      for (const warning of warnings) {
+        warningCount++
+        print(`${displayPath}:${warning.line}: ${warning.message}`)
+      }
+    }
+  }
+
+  const suffix = options.dryRun ? ' (dry run, nothing written)' : ''
+  print(`${changedFiles} files changed, ${warningCount} warnings${suffix}`)
+  return 0
+}
+
+try {
+  process.exitCode = run(process.argv.slice(2))
+}
+catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+}

--- a/packages/codemod/bin/reka-ui-codemod.mjs
+++ b/packages/codemod/bin/reka-ui-codemod.mjs
@@ -70,6 +70,10 @@ function parseExtensions(value = '') {
 }
 
 function* walk(path, extensions) {
+  // A supplied root that is, or sits inside, an always-skipped directory is
+  // skipped too, so the documented contract holds for explicit paths as well.
+  if (path.split(/[\\/]/).some(segment => SKIPPED_DIRECTORIES.has(segment)))
+    return
   const stats = statSync(path)
   if (stats.isFile()) {
     if (extensions.has(extname(path).slice(1)))
@@ -82,7 +86,7 @@ function* walk(path, extensions) {
   for (const entry of entries) {
     if (entry.isDirectory()) {
       if (!SKIPPED_DIRECTORIES.has(entry.name))
-        yield * walk(join(path, entry.name), extensions)
+        yield* walk(join(path, entry.name), extensions)
     }
     else if (entry.isFile() && extensions.has(extname(entry.name).slice(1))) {
       yield join(path, entry.name)

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@reka-ui/codemod",
+  "type": "module",
+  "version": "3.0.0-alpha.0",
+  "description": "Codemods for migrating a codebase between Reka UI major versions.",
+  "author": "UnoVue Contributors (https://github.com/unovue)",
+  "license": "MIT",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/zernonia"
+  },
+  "homepage": "https://github.com/unovue/reka-ui",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unovue/reka-ui.git",
+    "directory": "packages/codemod"
+  },
+  "bugs": {
+    "url": "https://github.com/unovue/reka-ui/issues"
+  },
+  "keywords": [
+    "reka-ui",
+    "codemod",
+    "migration",
+    "vue"
+  ],
+  "bin": {
+    "reka-ui-codemod": "./bin/reka-ui-codemod.mjs"
+  },
+  "files": [
+    "bin",
+    "src"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/packages/codemod/src/data-state.mjs
+++ b/packages/codemod/src/data-state.mjs
@@ -60,9 +60,10 @@ const CSS_AMBIGUOUS = cssPattern(AMBIGUOUS_VALUES)
 const TAILWIND_DELAYED = /((?:group|peer)-)?data-\[state=(['"]?)delayed-open\2\](\/[\w-]+)?/g
 const CSS_DELAYED = /(\[data-state\s*=\s*)(['"]?)delayed-open\2\s*\]/g
 
-const PRESENCE_ONLY = /:not\(\s*\[data-state\]\s*\)/
+/** A bare `[data-state]` (with or without `:not(...)`): presence-only, so it now matches every part. */
+const PRESENCE_ONLY = /\[\s*data-state\s*\]/
 
-const PRESENCE_WARNING = '"[data-state]" is now always present; target the explicit value instead'
+const PRESENCE_WARNING = '"[data-state]" is now always present, so a presence-only selector matches every part; target the explicit value instead'
 
 function mentionsAny(source, names) {
   return names.some(name => source.includes(name))

--- a/packages/codemod/src/data-state.mjs
+++ b/packages/codemod/src/data-state.mjs
@@ -1,0 +1,144 @@
+/**
+ * Best-effort rewrite of v2 `data-state` values to the v3 vocabulary.
+ *
+ * Handles Tailwind variants (`data-[state=on]:`, `group-data-[state=on]:`,
+ * `peer-data-[state=on]:`, quoted or not) and CSS attribute selectors
+ * (`[data-state=on]`, `[data-state='on']`, `[data-state="on"]`).
+ *
+ * Anything that cannot be decided mechanically is left untouched and reported
+ * as a warning so a human can finish the job.
+ */
+
+/** Values that always map to the same v3 value, whatever the component. */
+const RENAMES = {
+  'on': 'checked',
+  'off': 'unchecked',
+  'visible': 'open',
+  'hidden': 'closed',
+  'expanded': 'open',
+  'collapsed': 'closed',
+  'instant-open': 'open',
+}
+
+/** Values whose meaning depends on the component the file is styling. */
+const AMBIGUOUS = {
+  active: 'checked',
+  inactive: 'unchecked',
+}
+
+/** Components that moved `active` / `inactive` to `checked` / `unchecked`. */
+const SELECTION_COMPONENTS = ['Tabs', 'TagsInput', 'Rating']
+
+/** Components that still emit `active` / `inactive`. */
+const MULTI_STATE_COMPONENTS = ['Stepper', 'SplitterResizeHandle']
+
+const ALWAYS_VALUES = Object.keys(RENAMES)
+const AMBIGUOUS_VALUES = Object.keys(AMBIGUOUS)
+
+/**
+ * `data-[state=X]` / `data-[state='X']` / `data-[state="X"]`, optionally
+ * preceded by `group-` / `peer-`. Groups: prefix, quote, value.
+ */
+function tailwindPattern(values) {
+  return new RegExp(`((?:group|peer)-)?data-\\[state=(['"]?)(${values.join('|')})\\2\\]`, 'g')
+}
+
+/**
+ * `[data-state=X]` / `[data-state='X']` / `[data-state="X"]`, with optional
+ * whitespace around `=`. Groups: opening, quote, value, closing.
+ */
+function cssPattern(values) {
+  return new RegExp(`(\\[data-state\\s*=\\s*)(['"]?)(${values.join('|')})\\2(\\s*\\])`, 'g')
+}
+
+const TAILWIND_RENAME = tailwindPattern(ALWAYS_VALUES)
+const CSS_RENAME = cssPattern(ALWAYS_VALUES)
+const TAILWIND_AMBIGUOUS = tailwindPattern(AMBIGUOUS_VALUES)
+const CSS_AMBIGUOUS = cssPattern(AMBIGUOUS_VALUES)
+
+/** `data-[state=delayed-open]`, with an optional named-group suffix (`/name`). */
+const TAILWIND_DELAYED = /((?:group|peer)-)?data-\[state=(['"]?)delayed-open\2\](\/[\w-]+)?/g
+const CSS_DELAYED = /(\[data-state\s*=\s*)(['"]?)delayed-open\2\s*\]/g
+
+const PRESENCE_ONLY = /:not\(\s*\[data-state\]\s*\)/
+
+const PRESENCE_WARNING = '"[data-state]" is now always present; target the explicit value instead'
+
+function mentionsAny(source, names) {
+  return names.some(name => source.includes(name))
+}
+
+/**
+ * Decide, once per file, what to do with `active` / `inactive`.
+ * @returns {'rewrite' | 'keep' | 'warn'}
+ */
+function decideAmbiguous(source) {
+  const selection = mentionsAny(source, SELECTION_COMPONENTS)
+  const multiState = mentionsAny(source, MULTI_STATE_COMPONENTS)
+  if (selection && !multiState)
+    return 'rewrite'
+  if (multiState && !selection)
+    return 'keep'
+  return 'warn'
+}
+
+function ambiguousWarning(value) {
+  return `ambiguous data-state "${value}": rewrite to "${AMBIGUOUS[value]}" for Tabs/TagsInput/Rating, keep for Stepper/Splitter`
+}
+
+function transformLine(line, mode) {
+  const warnings = []
+
+  let out = line
+    .replace(TAILWIND_DELAYED, (_, prefix = '', quote, name = '') =>
+      `${prefix}data-[state=${quote}open${quote}]${name}:${prefix}data-[delayed]${name}`)
+    .replace(CSS_DELAYED, (_, open, quote) => `${open}${quote}open${quote}][data-delayed]`)
+    .replace(TAILWIND_RENAME, (_, prefix = '', quote, value) => `${prefix}data-[state=${quote}${RENAMES[value]}${quote}]`)
+    .replace(CSS_RENAME, (_, open, quote, value, close) => `${open}${quote}${RENAMES[value]}${quote}${close}`)
+
+  if (mode === 'rewrite') {
+    out = out
+      .replace(TAILWIND_AMBIGUOUS, (_, prefix = '', quote, value) => `${prefix}data-[state=${quote}${AMBIGUOUS[value]}${quote}]`)
+      .replace(CSS_AMBIGUOUS, (_, open, quote, value, close) => `${open}${quote}${AMBIGUOUS[value]}${quote}${close}`)
+  }
+  else if (mode === 'warn') {
+    const found = new Set()
+    for (const pattern of [TAILWIND_AMBIGUOUS, CSS_AMBIGUOUS]) {
+      for (const match of out.matchAll(pattern))
+        found.add(match[3])
+    }
+    for (const value of AMBIGUOUS_VALUES) {
+      if (found.has(value))
+        warnings.push(ambiguousWarning(value))
+    }
+  }
+
+  if (PRESENCE_ONLY.test(out))
+    warnings.push(PRESENCE_WARNING)
+
+  return { line: out, warnings }
+}
+
+/**
+ * Rewrite v2 `data-state` values in `source` to their v3 equivalents.
+ *
+ * @param {string} source
+ * @param {{ filename?: string }} [_options] reserved for future use
+ * @returns {{ code: string, changed: boolean, warnings: Array<{ line: number, message: string }> }}
+ */
+export function transformDataState(source, _options = {}) {
+  const mode = decideAmbiguous(source)
+  const warnings = []
+  const lines = source.split('\n')
+
+  const code = lines
+    .map((line, index) => {
+      const result = transformLine(line, mode)
+      for (const message of result.warnings)
+        warnings.push({ line: index + 1, message })
+      return result.line
+    })
+    .join('\n')
+
+  return { code, changed: code !== source, warnings }
+}

--- a/packages/codemod/test/data-state.test.mjs
+++ b/packages/codemod/test/data-state.test.mjs
@@ -6,6 +6,8 @@ function code(source) {
   return transformDataState(source).code
 }
 
+const PRESENCE_MESSAGE = '"[data-state]" is now always present, so a presence-only selector matches every part; target the explicit value instead'
+
 describe('unconditional renames', () => {
   it('rewrites tailwind variants', () => {
     const source = '<Toggle class="data-[state=on]:bg-green-5 data-[state=off]:bg-gray-3" />'
@@ -167,6 +169,21 @@ describe('active / inactive', () => {
 })
 
 describe('presence-only selectors', () => {
+  it('leaves a bare [data-state] alone and warns', () => {
+    const source = [
+      '.RatingItemIndicator[data-state] { opacity: 1; }',
+      '.SplitterPanel[ data-state ] { flex: 1; }',
+      '.Toggle[data-state=checked] { color: red; }',
+    ].join('\n')
+    const result = transformDataState(source)
+    assert.equal(result.code, source)
+    assert.equal(result.changed, false)
+    assert.deepEqual(result.warnings, [
+      { line: 1, message: PRESENCE_MESSAGE },
+      { line: 2, message: PRESENCE_MESSAGE },
+    ])
+  })
+
   it('leaves :not([data-state]) alone and warns', () => {
     const source = [
       '.RatingItemIndicator:not([data-state]) { opacity: 0.3; }',
@@ -176,8 +193,8 @@ describe('presence-only selectors', () => {
     assert.equal(result.code, source)
     assert.equal(result.changed, false)
     assert.deepEqual(result.warnings, [
-      { line: 1, message: '"[data-state]" is now always present; target the explicit value instead' },
-      { line: 2, message: '"[data-state]" is now always present; target the explicit value instead' },
+      { line: 1, message: PRESENCE_MESSAGE },
+      { line: 2, message: PRESENCE_MESSAGE },
     ])
   })
 })

--- a/packages/codemod/test/data-state.test.mjs
+++ b/packages/codemod/test/data-state.test.mjs
@@ -1,0 +1,226 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { transformDataState } from '../src/data-state.mjs'
+
+function code(source) {
+  return transformDataState(source).code
+}
+
+describe('unconditional renames', () => {
+  it('rewrites tailwind variants', () => {
+    const source = '<Toggle class="data-[state=on]:bg-green-5 data-[state=off]:bg-gray-3" />'
+    const result = transformDataState(source)
+    assert.equal(result.code, '<Toggle class="data-[state=checked]:bg-green-5 data-[state=unchecked]:bg-gray-3" />')
+    assert.equal(result.changed, true)
+    assert.deepEqual(result.warnings, [])
+  })
+
+  it('rewrites every mapped value in tailwind variants', () => {
+    const source = [
+      'data-[state=visible]:opacity-100',
+      'data-[state=hidden]:opacity-0',
+      'data-[state=expanded]:w-64',
+      'data-[state=collapsed]:w-0',
+      'data-[state=instant-open]:animate-in',
+    ].join(' ')
+    assert.equal(code(source), [
+      'data-[state=open]:opacity-100',
+      'data-[state=closed]:opacity-0',
+      'data-[state=open]:w-64',
+      'data-[state=closed]:w-0',
+      'data-[state=open]:animate-in',
+    ].join(' '))
+  })
+
+  it('rewrites quoted tailwind variants', () => {
+    assert.equal(code(`data-[state='on']:bg-x data-[state="off"]:bg-y`), `data-[state='checked']:bg-x data-[state="unchecked"]:bg-y`)
+  })
+
+  it('rewrites group- and peer- prefixed tailwind variants', () => {
+    const source = 'group-data-[state=on]:text-white peer-data-[state=hidden]:hidden group-data-[state=expanded]/sidebar:block'
+    assert.equal(code(source), 'group-data-[state=checked]:text-white peer-data-[state=closed]:hidden group-data-[state=open]/sidebar:block')
+  })
+
+  it('rewrites unquoted css attribute selectors', () => {
+    assert.equal(code('.Toggle[data-state=on] { color: red; }'), '.Toggle[data-state=checked] { color: red; }')
+  })
+
+  it('rewrites single-quoted css attribute selectors', () => {
+    assert.equal(code(`.Toggle[data-state='on'] { color: red; }`), `.Toggle[data-state='checked'] { color: red; }`)
+  })
+
+  it('rewrites double-quoted css attribute selectors', () => {
+    assert.equal(code(`.Toggle[data-state="on"] { color: red; }`), `.Toggle[data-state="checked"] { color: red; }`)
+  })
+
+  it('rewrites every mapped value in css attribute selectors', () => {
+    const source = [
+      `.ScrollAreaScrollbar[data-state='visible'] {}`,
+      `.ScrollAreaScrollbar[data-state='hidden'] {}`,
+      `.SplitterPanel[data-state='expanded'] {}`,
+      `.SplitterPanel[data-state='collapsed'] {}`,
+      `.TooltipContent[data-state='instant-open'] {}`,
+    ].join('\n')
+    assert.equal(code(source), [
+      `.ScrollAreaScrollbar[data-state='open'] {}`,
+      `.ScrollAreaScrollbar[data-state='closed'] {}`,
+      `.SplitterPanel[data-state='open'] {}`,
+      `.SplitterPanel[data-state='closed'] {}`,
+      `.TooltipContent[data-state='open'] {}`,
+    ].join('\n'))
+  })
+
+  it('preserves whitespace around the css equals sign', () => {
+    assert.equal(code(`[data-state = "off" ]`), `[data-state = "unchecked" ]`)
+  })
+})
+
+describe('delayed-open', () => {
+  it('splits the tailwind variant into open and delayed', () => {
+    assert.equal(
+      code('data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in'),
+      'data-[state=open]:data-[delayed]:animate-in data-[state=open]:data-[delayed]:fade-in',
+    )
+  })
+
+  it('keeps the group- and peer- prefix on both variants', () => {
+    assert.equal(
+      code('group-data-[state=delayed-open]:visible peer-data-[state=delayed-open]:visible'),
+      'group-data-[state=open]:group-data-[delayed]:visible peer-data-[state=open]:peer-data-[delayed]:visible',
+    )
+  })
+
+  it('keeps a named group on both variants', () => {
+    assert.equal(code('group-data-[state=delayed-open]/tip:block'), 'group-data-[state=open]/tip:group-data-[delayed]/tip:block')
+  })
+
+  it('keeps quoting in the tailwind variant', () => {
+    assert.equal(code(`data-[state='delayed-open']:block`), `data-[state='open']:data-[delayed]:block`)
+  })
+
+  it('appends [data-delayed] to css selectors and keeps the quoting style', () => {
+    assert.equal(code(`.TooltipContent[data-state='delayed-open'][data-side='top'] {}`), `.TooltipContent[data-state='open'][data-delayed][data-side='top'] {}`)
+    assert.equal(code(`.TooltipContent[data-state="delayed-open"] {}`), `.TooltipContent[data-state="open"][data-delayed] {}`)
+    assert.equal(code('.TooltipContent[data-state=delayed-open] {}'), '.TooltipContent[data-state=open][data-delayed] {}')
+  })
+})
+
+describe('active / inactive', () => {
+  const activeWarning = 'ambiguous data-state "active": rewrite to "checked" for Tabs/TagsInput/Rating, keep for Stepper/Splitter'
+  const inactiveWarning = 'ambiguous data-state "inactive": rewrite to "unchecked" for Tabs/TagsInput/Rating, keep for Stepper/Splitter'
+
+  it('rewrites when the file only mentions Tabs, TagsInput or Rating', () => {
+    const source = [
+      '<TabsTrigger class="data-[state=active]:text-grass-11 data-[state=inactive]:text-gray-11" />',
+      `.TagsInputItem[data-state='active'] {}`,
+      `.RatingItemIndicator[data-state="inactive"] {}`,
+    ].join('\n')
+    const result = transformDataState(source)
+    assert.equal(result.code, [
+      '<TabsTrigger class="data-[state=checked]:text-grass-11 data-[state=unchecked]:text-gray-11" />',
+      `.TagsInputItem[data-state='checked'] {}`,
+      `.RatingItemIndicator[data-state="unchecked"] {}`,
+    ].join('\n'))
+    assert.deepEqual(result.warnings, [])
+  })
+
+  it('keeps active and inactive when the file only mentions Stepper or SplitterResizeHandle', () => {
+    const source = [
+      '<StepperItem class="data-[state=active]:font-bold data-[state=inactive]:opacity-50 data-[state=completed]:text-green" />',
+      `.SplitterResizeHandle[data-state='inactive'] {}`,
+    ].join('\n')
+    const result = transformDataState(source)
+    assert.equal(result.code, source)
+    assert.equal(result.changed, false)
+    assert.deepEqual(result.warnings, [])
+  })
+
+  it('warns per line when the file mentions both families', () => {
+    const source = [
+      '<TabsTrigger class="data-[state=active]:font-bold" />',
+      '<StepperItem class="data-[state=active]:font-bold" />',
+      `.Tabs [data-state='inactive'] {}`,
+    ].join('\n')
+    const result = transformDataState(source)
+    assert.equal(result.code, source)
+    assert.equal(result.changed, false)
+    assert.deepEqual(result.warnings, [
+      { line: 1, message: activeWarning },
+      { line: 2, message: activeWarning },
+      { line: 3, message: inactiveWarning },
+    ])
+  })
+
+  it('warns when the file mentions neither family', () => {
+    const source = `.trigger[data-state="active"] { color: red; }`
+    const result = transformDataState(source)
+    assert.equal(result.code, source)
+    assert.deepEqual(result.warnings, [{ line: 1, message: activeWarning }])
+  })
+
+  it('still applies the unconditional renames on ambiguous files', () => {
+    const source = '<StepperItem class="data-[state=active]:x" /><TabsTrigger class="data-[state=on]:y" />'
+    const result = transformDataState(source)
+    assert.equal(result.code, '<StepperItem class="data-[state=active]:x" /><TabsTrigger class="data-[state=checked]:y" />')
+    assert.equal(result.warnings.length, 1)
+  })
+})
+
+describe('presence-only selectors', () => {
+  it('leaves :not([data-state]) alone and warns', () => {
+    const source = [
+      '.RatingItemIndicator:not([data-state]) { opacity: 0.3; }',
+      '.SplitterPanel:not( [data-state] ) { flex: 1; }',
+    ].join('\n')
+    const result = transformDataState(source)
+    assert.equal(result.code, source)
+    assert.equal(result.changed, false)
+    assert.deepEqual(result.warnings, [
+      { line: 1, message: '"[data-state]" is now always present; target the explicit value instead' },
+      { line: 2, message: '"[data-state]" is now always present; target the explicit value instead' },
+    ])
+  })
+})
+
+describe('safety', () => {
+  it('does not touch unrelated attributes or plain words', () => {
+    const source = [
+      '<div class="hidden data-[side=top]:mt-2 data-[orientation=horizontal]:flex-row on off visible" />',
+      '[data-orientation=vertical] { display: flex; }',
+      '[data-side="top"] { top: 0; }',
+      '[data-state=open] { display: block; }',
+      '[data-state=checked] { display: block; }',
+      'const state = "on"',
+      'toggle.on()',
+    ].join('\n')
+    const result = transformDataState(source)
+    assert.equal(result.code, source)
+    assert.equal(result.changed, false)
+    assert.deepEqual(result.warnings, [])
+  })
+
+  it('does not rewrite part of a longer value', () => {
+    assert.equal(code('data-[state=on-hover]:x [data-state=offline] {}'), 'data-[state=on-hover]:x [data-state=offline] {}')
+  })
+
+  it('is idempotent', () => {
+    const source = [
+      '<Toggle class="data-[state=on]:bg-x group-data-[state=delayed-open]:block" />',
+      `.TabsTrigger[data-state='active'] {}`,
+      `.TooltipContent[data-state="delayed-open"] {}`,
+      '.RatingItemIndicator:not([data-state]) {}',
+    ].join('\n')
+    const first = transformDataState(source)
+    assert.equal(first.changed, true)
+    const second = transformDataState(first.code)
+    assert.equal(second.code, first.code)
+    assert.equal(second.changed, false)
+    assert.deepEqual(second.warnings, first.warnings)
+  })
+
+  it('reports changed: false and preserves the source when nothing matches', () => {
+    const result = transformDataState('body { margin: 0 }')
+    assert.equal(result.code, 'body { margin: 0 }')
+    assert.equal(result.changed, false)
+  })
+})

--- a/packages/core/src/AlertDialog/AlertDialog.test.ts
+++ b/packages/core/src/AlertDialog/AlertDialog.test.ts
@@ -1,9 +1,10 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { findAllByText, findByRole, findByText, fireEvent } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
+import { AlertDialogRoot } from '.'
 import AlertDialog from './story/_AlertDialog.vue'
 
 describe('given a default Dialog', async () => {
@@ -50,5 +51,81 @@ describe('given a default Dialog', async () => {
       expect(document.body.style.pointerEvents).toBe('none')
       expect(content.style.pointerEvents).toBe('auto')
     })
+  })
+})
+
+// #2828 — `AlertDialogRoot` re-declares `DialogRootEmits`, so the forwarded
+// `beforeUpdate:open` / `update:open` carry the same `(value, details)` and
+// `AlertDialogCancel` / `AlertDialogAction` (both `DialogClose`) report 'close-press'.
+describe('alertDialogRoot change events (v3 foundation contract)', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AlertDialog>>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(AlertDialog, { attachTo: document.body })
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+    document.body.innerHTML = ''
+    document.body.style.cssText = ''
+  })
+
+  it('forwards update:open with (value, details) and reason "trigger-press" on open', async () => {
+    await fireEvent.click(await findByText(wrapper.element as HTMLElement, 'Open'))
+
+    const root = wrapper.findComponent(AlertDialogRoot)
+    const keys = Object.keys(root.emitted()).filter(k => k.endsWith(':open'))
+    expect(keys).toEqual(['beforeUpdate:open', 'update:open'])
+    const [value, details] = root.emitted('update:open')![0]
+    expect(value).toBe(true)
+    expect(details).toMatchObject({ reason: 'trigger-press', isCanceled: false })
+    expect(details.event).toBeInstanceOf(MouseEvent)
+    // the story binds `v-model:open`, so the round-trip lands on the parent
+    expect((wrapper.vm as any).isOpen).toBe(true)
+  })
+
+  it('reports reason "close-press" when AlertDialogCancel is clicked', async () => {
+    await fireEvent.click(await findByText(wrapper.element as HTMLElement, 'Open'))
+    const cancelButton = (await findAllByText(document.body, 'Cancel')).at(-1)!
+
+    await fireEvent.click(cancelButton)
+    await nextTick()
+
+    const [value, details] = wrapper.findComponent(AlertDialogRoot).emitted('update:open')!.at(-1)!
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'close-press' })
+    expect(details.event).toBeInstanceOf(MouseEvent)
+    expect((wrapper.vm as any).isOpen).toBe(false)
+  })
+
+  it('reports reason "close-press" when AlertDialogAction is clicked', async () => {
+    await fireEvent.click(await findByText(wrapper.element as HTMLElement, 'Open'))
+    const actionButton = (await findAllByText(document.body, 'Yes, delete account')).at(-1)!
+
+    await fireEvent.click(actionButton)
+    await nextTick()
+
+    const [value, details] = wrapper.findComponent(AlertDialogRoot).emitted('update:open')!.at(-1)!
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'close-press' })
+    expect((wrapper.vm as any).isOpen).toBe(false)
+  })
+
+  it('details.cancel() in beforeUpdate:open keeps the alert dialog open', async () => {
+    wrapper.unmount()
+    const onBefore = vi.fn((_value: boolean, details: { cancel: () => void }) => details.cancel())
+    wrapper = mount(AlertDialog, {
+      attachTo: document.body,
+      // The story's single root is `AlertDialogRoot`, so the listener falls through to it as an attr.
+      attrs: { 'onBeforeUpdate:open': onBefore },
+    })
+    await fireEvent.click(await findByText(wrapper.element as HTMLElement, 'Open'))
+    await nextTick()
+
+    expect(onBefore).toHaveBeenCalledTimes(1)
+    expect(wrapper.findComponent(AlertDialogRoot).emitted('update:open')).toBeUndefined()
+    expect((wrapper.vm as any).isOpen).toBe(false)
+    expect(document.body.innerHTML).not.toContain('Title')
   })
 })

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -51,7 +51,11 @@ export type DatePickerRootProps = Omit<DateFieldRootProps, 'as' | 'asChild'> & P
   closeOnSelect?: boolean
 }
 
-/** Why the picker's `open` state changed (#2828): the popover's reasons plus a date selection closing it. */
+/**
+ * Why the picker's `open` state changed (#2828): the popover's reasons, plus
+ * `date-select` when `closeOnSelect` closes it because the model value changed
+ * (a calendar pick, or the parent writing the model while the picker is open).
+ */
 export type DatePickerOpenChangeReason = PopoverOpenChangeReason | 'date-select'
 
 export type DatePickerRootEmits = {

--- a/packages/core/src/DatePicker/DatePickerRoot.vue
+++ b/packages/core/src/DatePicker/DatePickerRoot.vue
@@ -1,14 +1,15 @@
 <script lang="ts">
 import type { DateValue } from '@internationalized/date'
 
-import type { Ref } from 'vue'
-import type { CalendarRootProps, DateFieldRoot, DateFieldRootProps, PopoverRootEmits, PopoverRootProps } from '..'
+import type { ComputedRef, Ref } from 'vue'
+import type { CalendarRootProps, DateFieldRoot, DateFieldRootProps, PopoverOpenChangeReason, PopoverRootProps } from '..'
 import type { Matcher, WeekDayFormat, WeekStartsOn } from '@/date'
+import type { ChangeEventDetails } from '@/shared'
 import type { DateStep, Granularity, HourCycle } from '@/shared/date'
 import type { Direction } from '@/shared/types'
 import { computed, ref, toRefs, watch } from 'vue'
 import { getWeekStartsOn } from '@/date'
-import { createContext, useDirection, useLocale } from '@/shared'
+import { createContext, useControllableState, useDirection, useLocale } from '@/shared'
 import { getDefaultDate } from '@/shared/date'
 import { PopoverRoot } from '..'
 
@@ -36,7 +37,7 @@ type DatePickerRootContext = {
   isDateDisabled?: Matcher
   isDateUnavailable?: Matcher
   defaultOpen: Ref<boolean>
-  open: Ref<boolean>
+  open: ComputedRef<boolean>
   modal: Ref<boolean>
   onDateChange: (date: DateValue | undefined) => void
   onPlaceholderChange: (date: DateValue) => void
@@ -50,7 +51,14 @@ export type DatePickerRootProps = Omit<DateFieldRootProps, 'as' | 'asChild'> & P
   closeOnSelect?: boolean
 }
 
-export type DatePickerRootEmits = PopoverRootEmits & {
+/** Why the picker's `open` state changed (#2828): the popover's reasons plus a date selection closing it. */
+export type DatePickerOpenChangeReason = PopoverOpenChangeReason | 'date-select'
+
+export type DatePickerRootEmits = {
+  /** Called before the open state changes; `details.cancel()` keeps the current state. */
+  'beforeUpdate:open': [value: boolean, details: ChangeEventDetails<DatePickerOpenChangeReason>]
+  /** Event handler called when the open state of the popover changes. */
+  'update:open': [value: boolean, details: ChangeEventDetails<DatePickerOpenChangeReason>]
   /** Event handler called whenever the model value changes */
   'update:modelValue': [date: DateValue | undefined]
   /** Event handler called whenever the placeholder value changes */
@@ -133,10 +141,14 @@ const placeholder = useVModel(props, 'placeholder', emits, {
   passive: (props.placeholder === undefined) as false,
 }) as Ref<DateValue>
 
-const open = useVModel(props, 'open', emits, {
+// The inner `PopoverRoot` is controlled by this model, so a `beforeUpdate:open`
+// cancel here keeps both in sync; the popover's reason and event are forwarded.
+const { state: open, setState: setOpen } = useControllableState<boolean, DatePickerOpenChangeReason>({
+  prop: () => props.open,
   defaultValue: defaultOpen.value,
-  passive: (props.open === undefined) as false,
-}) as Ref<boolean>
+  name: 'open',
+  emit: emits,
+})
 
 const dateFieldRef = ref<InstanceType<typeof DateFieldRoot> | undefined>()
 
@@ -158,7 +170,7 @@ watch(modelValue, (value) => {
     placeholder.value = resetTime(placeholder.value)
   }
   if (closeOnSelect.value) {
-    open.value = false
+    setOpen(false, 'date-select')
   }
 })
 
@@ -213,9 +225,9 @@ provideDatePickerRootContext({
 
 <template>
   <PopoverRoot
-    v-model:open="open"
-    :default-open="defaultOpen"
+    :open="open"
     :modal="modal"
+    @update:open="(value, details) => setOpen(value, details.reason, details.event)"
   >
     <slot />
   </PopoverRoot>

--- a/packages/core/src/DatePicker/index.ts
+++ b/packages/core/src/DatePicker/index.ts
@@ -25,5 +25,5 @@ export { default as DatePickerHeading, type DatePickerHeadingProps } from './Dat
 export { default as DatePickerInput, type DatePickerInputProps } from './DatePickerInput.vue'
 export { default as DatePickerNext, type DatePickerNextProps } from './DatePickerNext.vue'
 export { default as DatePickerPrev, type DatePickerPrevProps } from './DatePickerPrev.vue'
-export { default as DatePickerRoot, type DatePickerRootEmits, type DatePickerRootProps, injectDatePickerRootContext } from './DatePickerRoot.vue'
+export { type DatePickerOpenChangeReason, default as DatePickerRoot, type DatePickerRootEmits, type DatePickerRootProps, injectDatePickerRootContext } from './DatePickerRoot.vue'
 export { default as DatePickerTrigger, type DatePickerTriggerProps } from './DatePickerTrigger.vue'

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -1,14 +1,15 @@
 <script lang="ts">
 import type { DateValue } from '@internationalized/date'
 
-import type { Ref } from 'vue'
-import type { DateRangeFieldRoot, DateRangeFieldRootProps, PopoverRootEmits, PopoverRootProps, RangeCalendarRootProps } from '..'
+import type { ComputedRef, Ref } from 'vue'
+import type { DateRangeFieldRoot, DateRangeFieldRootProps, PopoverOpenChangeReason, PopoverRootProps, RangeCalendarRootProps } from '..'
 import type { Matcher, WeekDayFormat, WeekStartsOn } from '@/date'
+import type { ChangeEventDetails } from '@/shared'
 import type { DateRange, DateStep, Granularity, HourCycle } from '@/shared/date'
 
 import type { Direction } from '@/shared/types'
 import { getWeekStartsOn } from '@/date'
-import { createContext, useDirection, useLocale } from '@/shared'
+import { createContext, useControllableState, useDirection, useLocale } from '@/shared'
 import { getDefaultDate } from '@/shared/date'
 import { PopoverRoot } from '..'
 
@@ -37,7 +38,7 @@ type DateRangePickerRootContext = {
   isDateUnavailable?: Matcher
   isDateHighlightable?: Matcher
   defaultOpen: Ref<boolean>
-  open: Ref<boolean>
+  open: ComputedRef<boolean>
   modal: Ref<boolean>
   onDateChange: (date: DateRange) => void
   onPlaceholderChange: (date: DateValue) => void
@@ -55,7 +56,14 @@ export type DateRangePickerRootProps = Omit<DateRangeFieldRootProps, 'as' | 'asC
   closeOnSelect?: boolean
 }
 
-export type DateRangePickerRootEmits = PopoverRootEmits & {
+/** Why the picker's `open` state changed (#2828): the popover's reasons plus a date selection closing it. */
+export type DateRangePickerOpenChangeReason = PopoverOpenChangeReason | 'date-select'
+
+export type DateRangePickerRootEmits = {
+  /** Called before the open state changes; `details.cancel()` keeps the current state. */
+  'beforeUpdate:open': [value: boolean, details: ChangeEventDetails<DateRangePickerOpenChangeReason>]
+  /** Event handler called when the open state of the popover changes. */
+  'update:open': [value: boolean, details: ChangeEventDetails<DateRangePickerOpenChangeReason>]
   /** Event handler called whenever the model value changes */
   'update:modelValue': [date: DateRange]
   /** Event handler called whenever the placeholder value changes */
@@ -147,10 +155,14 @@ const placeholder = useVModel(props, 'placeholder', emits, {
   passive: (props.placeholder === undefined) as false,
 }) as Ref<DateValue>
 
-const open = useVModel(props, 'open', emits, {
+// The inner `PopoverRoot` is controlled by this model, so a `beforeUpdate:open`
+// cancel here keeps both in sync; the popover's reason and event are forwarded.
+const { state: open, setState: setOpen } = useControllableState<boolean, DateRangePickerOpenChangeReason>({
+  prop: () => props.open,
   defaultValue: defaultOpen.value,
-  passive: (props.open === undefined) as false,
-}) as Ref<boolean>
+  name: 'open',
+  emit: emits,
+})
 
 const dateFieldRef = ref<InstanceType<typeof DateRangeFieldRoot> | undefined>()
 
@@ -161,7 +173,7 @@ watch(modelValue, (value) => {
 
   if (value.start && value.end) {
     if (closeOnSelect.value) {
-      open.value = false
+      setOpen(false, 'date-select')
     }
   }
 })
@@ -213,9 +225,9 @@ provideDateRangePickerRootContext({
 
 <template>
   <PopoverRoot
-    v-model:open="open"
-    :default-open="defaultOpen"
+    :open="open"
     :modal="modal"
+    @update:open="(value, details) => setOpen(value, details.reason, details.event)"
   >
     <slot
       :model-value="modelValue"

--- a/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
+++ b/packages/core/src/DateRangePicker/DateRangePickerRoot.vue
@@ -56,7 +56,11 @@ export type DateRangePickerRootProps = Omit<DateRangeFieldRootProps, 'as' | 'asC
   closeOnSelect?: boolean
 }
 
-/** Why the picker's `open` state changed (#2828): the popover's reasons plus a date selection closing it. */
+/**
+ * Why the picker's `open` state changed (#2828): the popover's reasons, plus
+ * `date-select` when `closeOnSelect` closes it because the model value changed
+ * (a calendar pick, or the parent writing the model while the picker is open).
+ */
 export type DateRangePickerOpenChangeReason = PopoverOpenChangeReason | 'date-select'
 
 export type DateRangePickerRootEmits = {

--- a/packages/core/src/DateRangePicker/index.ts
+++ b/packages/core/src/DateRangePicker/index.ts
@@ -25,5 +25,5 @@ export { default as DateRangePickerHeading, type DateRangePickerHeadingProps } f
 export { default as DateRangePickerInput, type DateRangePickerInputProps } from './DateRangePickerInput.vue'
 export { default as DateRangePickerNext, type DateRangePickerNextProps } from './DateRangePickerNext.vue'
 export { default as DateRangePickerPrev, type DateRangePickerPrevProps } from './DateRangePickerPrev.vue'
-export { default as DateRangePickerRoot, type DateRangePickerRootEmits, type DateRangePickerRootProps, injectDateRangePickerRootContext } from './DateRangePickerRoot.vue'
+export { type DateRangePickerOpenChangeReason, default as DateRangePickerRoot, type DateRangePickerRootEmits, type DateRangePickerRootProps, injectDateRangePickerRootContext } from './DateRangePickerRoot.vue'
 export { default as DateRangePickerTrigger, type DateRangePickerTriggerProps } from './DateRangePickerTrigger.vue'

--- a/packages/core/src/Dialog/Dialog.test.ts
+++ b/packages/core/src/Dialog/Dialog.test.ts
@@ -4,7 +4,7 @@ import { createEvent, findByText, fireEvent, render } from '@testing-library/vue
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
 import { sleep } from '@/test'
 import { DialogClose, DialogContent, DialogOverlay, DialogRoot, DialogTitle, DialogTrigger } from '.'
 
@@ -539,5 +539,162 @@ describe('given a Dialog with content nested inside the overlay', () => {
 
       expect(document.body.innerHTML).toContain(CLOSE_TEXT)
     })
+  })
+})
+
+// #2828 — `beforeUpdate:open` / `update:open` carry `(value, details)`; every
+// open/close path reports its reason and the native event, and a synchronous
+// `details.cancel()` in `beforeUpdate:open` keeps the current state.
+describe('dialogRoot change events (v3 foundation contract)', () => {
+  const ChangeEventsDialog = defineComponent({
+    components: { DialogRoot, DialogTrigger, DialogContent, DialogClose, DialogTitle },
+    props: ['defaultOpen', 'onBeforeUpdateOpen'],
+    template: `<DialogRoot :default-open="defaultOpen" @before-update:open="onBeforeUpdateOpen">
+  <DialogTrigger>${OPEN_TEXT}</DialogTrigger>
+  <DialogContent>
+    <DialogTitle>${TITLE_TEXT}</DialogTitle>
+    <DialogClose>${CLOSE_TEXT}</DialogClose>
+  </DialogContent>
+</DialogRoot>`,
+  })
+
+  // `any`: the v-model / controlled cases below mount ad-hoc wrapper components.
+  let wrapper: VueWrapper<any>
+  let consoleWarnMock: MockInstance
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    consoleWarnMock.mockRestore()
+  })
+
+  it('emits beforeUpdate:open then update:open with (value, details) on trigger click', async () => {
+    wrapper = mount(ChangeEventsDialog, { attachTo: document.body })
+    await fireEvent.click(wrapper.find('button').element)
+
+    const root = wrapper.findComponent(DialogRoot)
+    const keys = Object.keys(root.emitted()).filter(k => k.endsWith(':open'))
+    expect(keys).toEqual(['beforeUpdate:open', 'update:open'])
+    const [beforeValue, beforeDetails] = root.emitted('beforeUpdate:open')![0]
+    const [value, details] = root.emitted('update:open')![0]
+    expect(beforeValue).toBe(true)
+    expect(value).toBe(true)
+    expect(beforeDetails).toBe(details)
+    expect(details).toMatchObject({ reason: 'trigger-press', isCanceled: false })
+    expect(details.event).toBeInstanceOf(MouseEvent)
+    expect(typeof details.cancel).toBe('function')
+  })
+
+  it('reports reason "escape-key" with the KeyboardEvent when Escape closes the dialog', async () => {
+    wrapper = mount(ChangeEventsDialog, { attachTo: document.body, props: { defaultOpen: true } })
+    await findByText(document.body, CLOSE_TEXT)
+    await nextTick()
+
+    await fireEvent.keyDown(document.activeElement!, { key: 'Escape' })
+    await nextTick()
+
+    const [value, details] = wrapper.findComponent(DialogRoot).emitted('update:open')![0]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'escape-key' })
+    expect(details.event).toBeInstanceOf(KeyboardEvent)
+    expect(document.body.innerHTML).not.toContain(CLOSE_TEXT)
+  })
+
+  it('reports reason "close-press" with the MouseEvent when DialogClose is clicked', async () => {
+    wrapper = mount(ChangeEventsDialog, { attachTo: document.body, props: { defaultOpen: true } })
+    const closeButton = await findByText(document.body, CLOSE_TEXT)
+
+    await fireEvent.click(closeButton)
+    await nextTick()
+
+    const [value, details] = wrapper.findComponent(DialogRoot).emitted('update:open')![0]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'close-press' })
+    expect(details.event).toBeInstanceOf(MouseEvent)
+    expect(document.body.innerHTML).not.toContain(CLOSE_TEXT)
+  })
+
+  it('details.cancel() in beforeUpdate:open keeps the dialog open and skips update:open', async () => {
+    const onBeforeUpdateOpen = vi.fn((_value: boolean, details: { cancel: () => void }) => details.cancel())
+    wrapper = mount(ChangeEventsDialog, { attachTo: document.body, props: { defaultOpen: true, onBeforeUpdateOpen } })
+    const closeButton = await findByText(document.body, CLOSE_TEXT)
+
+    await fireEvent.click(closeButton)
+    await nextTick()
+
+    expect(onBeforeUpdateOpen).toHaveBeenCalledTimes(1)
+    expect(onBeforeUpdateOpen.mock.calls[0][0]).toBe(false)
+    const root = wrapper.findComponent(DialogRoot)
+    expect(root.emitted('beforeUpdate:open')).toHaveLength(1)
+    expect(root.emitted('update:open')).toBeUndefined()
+    expect(document.body.innerHTML).toContain(CLOSE_TEXT)
+    expect(wrapper.find('button').attributes('data-state')).toBe('open')
+  })
+
+  it('details.cancel() in beforeUpdate:open keeps a closed dialog closed', async () => {
+    const onBeforeUpdateOpen = vi.fn((_value: boolean, details: { cancel: () => void }) => details.cancel())
+    wrapper = mount(ChangeEventsDialog, { attachTo: document.body, props: { onBeforeUpdateOpen } })
+
+    await fireEvent.click(wrapper.find('button').element)
+    await nextTick()
+
+    const root = wrapper.findComponent(DialogRoot)
+    expect(root.emitted('update:open')).toBeUndefined()
+    expect(document.body.innerHTML).not.toContain(CLOSE_TEXT)
+    expect(wrapper.find('button').attributes('data-state')).toBe('closed')
+  })
+
+  it('v-model:open round-trips through update:open', async () => {
+    wrapper = mount(defineComponent({
+      components: { DialogRoot, DialogTrigger, DialogContent, DialogClose, DialogTitle },
+      setup() {
+        return { open: ref(false) }
+      },
+      template: `<DialogRoot v-model:open="open">
+  <DialogTrigger>${OPEN_TEXT}</DialogTrigger>
+  <DialogContent>
+    <DialogTitle>${TITLE_TEXT}</DialogTitle>
+    <DialogClose>${CLOSE_TEXT}</DialogClose>
+  </DialogContent>
+</DialogRoot>`,
+    }), { attachTo: document.body })
+
+    await fireEvent.click(wrapper.find('button').element)
+    const closeButton = await findByText(document.body, CLOSE_TEXT)
+    expect(wrapper.vm.open).toBe(true)
+    expect(wrapper.find('button').attributes('data-state')).toBe('open')
+
+    await fireEvent.click(closeButton)
+    await nextTick()
+    expect(wrapper.vm.open).toBe(false)
+    expect(document.body.innerHTML).not.toContain(CLOSE_TEXT)
+    expect(wrapper.find('button').attributes('data-state')).toBe('closed')
+  })
+
+  it('does not mutate a controlled open prop; the parent owns the write', async () => {
+    wrapper = mount(defineComponent({
+      components: { DialogRoot, DialogTrigger, DialogContent, DialogClose, DialogTitle },
+      template: `<DialogRoot :open="false">
+  <DialogTrigger>${OPEN_TEXT}</DialogTrigger>
+  <DialogContent>
+    <DialogTitle>${TITLE_TEXT}</DialogTitle>
+    <DialogClose>${CLOSE_TEXT}</DialogClose>
+  </DialogContent>
+</DialogRoot>`,
+    }), { attachTo: document.body })
+
+    await fireEvent.click(wrapper.find('button').element)
+    await nextTick()
+
+    const root = wrapper.findComponent(DialogRoot)
+    expect(root.emitted('update:open')?.[0]?.[0]).toBe(true)
+    expect(root.emitted('update:open')?.[0]?.[1]).toMatchObject({ reason: 'trigger-press' })
+    // controlled: the rendered state stays until the parent updates the prop
+    expect(wrapper.find('button').attributes('data-state')).toBe('closed')
+    expect(document.body.innerHTML).not.toContain(CLOSE_TEXT)
   })
 })

--- a/packages/core/src/Dialog/DialogClose.vue
+++ b/packages/core/src/Dialog/DialogClose.vue
@@ -21,7 +21,7 @@ const rootContext = injectDialogRootContext()
   <Primitive
     v-bind="props"
     :type="as === 'button' ? 'button' : undefined"
-    @click="rootContext.onOpenChange(false)"
+    @click="(event: MouseEvent) => rootContext.onOpenChange(false, 'close-press', event)"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Dialog/DialogContentImpl.vue
+++ b/packages/core/src/Dialog/DialogContentImpl.vue
@@ -95,7 +95,7 @@ if (process.env.NODE_ENV !== 'production') {
       :aria-labelledby="rootContext.titleId"
       :data-state="disclosureState(rootContext.open.value)"
       v-bind="$attrs"
-      @dismiss="rootContext.onOpenChange(false)"
+      @dismiss="(details) => rootContext.onOpenChange(false, details.reason, details.event)"
       @escape-key-down="emits('escapeKeyDown', $event)"
       @focus-outside="emits('focusOutside', $event)"
       @interact-outside="emits('interactOutside', $event)"

--- a/packages/core/src/Dialog/DialogRoot.vue
+++ b/packages/core/src/Dialog/DialogRoot.vue
@@ -1,6 +1,15 @@
 <script lang="ts">
-import type { Ref } from 'vue'
-import { createContext } from '@/shared'
+import type { ComputedRef, Ref } from 'vue'
+import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
+import { createContext, useControllableState } from '@/shared'
+
+/** Why the dialog's `open` state changed (#2828); the `reason` of `ChangeEventDetails`. */
+export type DialogOpenChangeReason
+  = | 'trigger-press'
+    | 'close-press'
+    | 'escape-key'
+    | 'outside-press'
+    | 'focus-outside'
 
 export interface DialogRootProps {
   /** The controlled open state of the dialog. Can be binded as `v-model:open`. */
@@ -21,17 +30,22 @@ export interface DialogRootProps {
 }
 
 export type DialogRootEmits = {
+  /** Called before the open state changes; `details.cancel()` keeps the current state. */
+  'beforeUpdate:open': [value: boolean, details: ChangeEventDetails<DialogOpenChangeReason>]
   /** Event handler called when the open state of the dialog changes. */
-  'update:open': [value: boolean]
+  'update:open': [value: boolean, details: ChangeEventDetails<DialogOpenChangeReason>]
 }
 
 export interface DialogRootContext {
-  open: Readonly<Ref<boolean>>
+  open: ComputedRef<boolean>
   modal: Ref<boolean>
   unmountOnHide: Ref<boolean>
-  openModal: () => void
-  onOpenChange: (value: boolean) => void
-  onOpenToggle: () => void
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  openModal: (reason?: DialogOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenChange: (value: boolean, reason?: DialogOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenToggle: (reason?: DialogOpenChangeReason | BaseChangeReason, event?: Event) => boolean
   triggerElement: Ref<HTMLElement | undefined>
   contentElement: Ref<HTMLElement | undefined>
   contentId: string
@@ -44,7 +58,6 @@ export const [injectDialogRootContext, provideDialogRootContext]
 </script>
 
 <script setup lang="ts">
-import { useVModel } from '@vueuse/core'
 import { ref, toRefs } from 'vue'
 
 defineOptions({
@@ -62,16 +75,20 @@ const emit = defineEmits<DialogRootEmits>()
 defineSlots<{
   default?: (props: {
     /** Current open state */
-    open: typeof open.value
+    open: boolean
     /** Close the dialog */
     close: () => void
   }) => any
 }>()
 
-const open = useVModel(props, 'open', emit, {
+// Every open/close path (trigger, close button, dismiss) goes through one
+// `setState` so `beforeUpdate:open` can cancel it and the details reach the consumer.
+const { state: open, setState } = useControllableState<boolean, DialogOpenChangeReason>({
+  prop: () => props.open,
   defaultValue: props.defaultOpen,
-  passive: (props.open === undefined) as false,
-}) as Ref<boolean>
+  name: 'open',
+  emit,
+})
 
 const triggerElement = ref<HTMLElement>()
 const contentElement = ref<HTMLElement>()
@@ -81,15 +98,9 @@ provideDialogRootContext({
   open,
   modal,
   unmountOnHide,
-  openModal: () => {
-    open.value = true
-  },
-  onOpenChange: (value) => {
-    open.value = value
-  },
-  onOpenToggle: () => {
-    open.value = !open.value
-  },
+  openModal: (reason, event) => setState(true, reason, event),
+  onOpenChange: (value, reason, event) => setState(value, reason, event),
+  onOpenToggle: (reason, event) => setState(!open.value, reason, event),
   contentId: '',
   titleId: '',
   descriptionId: '',
@@ -101,6 +112,6 @@ provideDialogRootContext({
 <template>
   <slot
     :open="open"
-    :close="() => open = false"
+    :close="() => setState(false)"
   />
 </template>

--- a/packages/core/src/Dialog/DialogTrigger.vue
+++ b/packages/core/src/Dialog/DialogTrigger.vue
@@ -31,7 +31,7 @@ onMounted(() => {
     :aria-expanded="rootContext.open.value || false"
     :aria-controls="rootContext.open.value ? rootContext.contentId : undefined"
     :data-state="disclosureState(rootContext.open.value)"
-    @click="rootContext.onOpenToggle"
+    @click="(event: MouseEvent) => rootContext.onOpenToggle('trigger-press', event)"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Dialog/index.ts
+++ b/packages/core/src/Dialog/index.ts
@@ -20,6 +20,7 @@ export {
   type DialogPortalProps,
 } from './DialogPortal.vue'
 export {
+  type DialogOpenChangeReason,
   default as DialogRoot,
   type DialogRootEmits,
   type DialogRootProps,

--- a/packages/core/src/Popover/Popover.test.ts
+++ b/packages/core/src/Popover/Popover.test.ts
@@ -1,5 +1,5 @@
 import type { VueWrapper } from '@vue/test-utils'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { defineComponent, nextTick, ref } from 'vue'
@@ -124,7 +124,8 @@ describe('popoverRoot change events (v3 foundation contract)', () => {
     await nextTick()
 
     close().element.click()
-    await nextTick()
+    // Presence resolves the exit after its own `nextTick`; flush so the content is gone.
+    await flushPromises()
 
     const [value, details] = root.emitted('update:open')![1]
     expect(value).toBe(false)
@@ -147,7 +148,8 @@ describe('popoverRoot change events (v3 foundation contract)', () => {
     onBeforeUpdateOpen.mockClear()
 
     close().element.click()
-    await nextTick()
+    // Presence resolves the exit after its own `nextTick`; flush so the content is gone.
+    await flushPromises()
 
     expect(onBeforeUpdateOpen).toHaveBeenCalledTimes(1)
     expect(onBeforeUpdateOpen.mock.calls[0][1]).toMatchObject({ reason: 'close-press', isCanceled: true })
@@ -170,7 +172,8 @@ describe('popoverRoot change events (v3 foundation contract)', () => {
     expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
 
     close().element.click()
-    await nextTick()
+    // Presence resolves the exit after its own `nextTick`; flush so the content is gone.
+    await flushPromises()
     expect(vm.open).toBe(false)
     expect(trigger().attributes('data-state')).toBe('closed')
     expect(wrapper.find('[role="dialog"]').exists()).toBe(false)

--- a/packages/core/src/Popover/Popover.test.ts
+++ b/packages/core/src/Popover/Popover.test.ts
@@ -1,8 +1,9 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
-import { nextTick } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
+import { PopoverClose, PopoverContent, PopoverRoot, PopoverTrigger } from '.'
 import Popover from './story/_Popover.vue'
 
 describe('given default Popover', () => {
@@ -38,5 +39,170 @@ describe('given default Popover', () => {
         },
       })).toHaveNoViolations()
     })
+  })
+})
+
+describe('popoverRoot change events (v3 foundation contract)', () => {
+  // No Portal: keeps the content inside `wrapper` so DOM assertions stay local.
+  const PopoverWithModel = defineComponent({
+    components: { PopoverRoot, PopoverTrigger, PopoverContent, PopoverClose },
+    props: {
+      onBeforeUpdateOpen: { type: Function, default: undefined },
+    },
+    setup() {
+      return { open: ref(false) }
+    },
+    template: `
+      <PopoverRoot v-model:open="open" @before-update:open="onBeforeUpdateOpen">
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>
+          Content
+          <PopoverClose>Close</PopoverClose>
+        </PopoverContent>
+      </PopoverRoot>
+    `,
+  })
+
+  const mounted: VueWrapper<any>[] = []
+
+  function mountPopover(props: Record<string, unknown> = {}) {
+    const wrapper = mount(PopoverWithModel, { props, attachTo: document.body })
+    mounted.push(wrapper)
+    const root = wrapper.findComponent(PopoverRoot)
+    const vm = wrapper.vm as unknown as { open: boolean }
+    const trigger = () => wrapper.find('[aria-haspopup="dialog"]')
+    const close = () => wrapper.find('[role="dialog"] button')
+    return { wrapper, root, vm, trigger, close }
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // Unmount (not just clear the DOM) so each layer leaves the shared
+  // DismissableLayer stack and Escape keeps routing to the right popover.
+  afterEach(() => {
+    mounted.splice(0).forEach(w => w.unmount())
+  })
+
+  it('emits beforeUpdate:open then update:open with (value, details) on trigger click', async () => {
+    const { root, trigger } = mountPopover()
+    trigger().element.click()
+    await nextTick()
+
+    const keys = Object.keys(root.emitted()).filter(k => k.endsWith(':open'))
+    expect(keys).toEqual(['beforeUpdate:open', 'update:open'])
+    const [beforeValue, beforeDetails] = root.emitted('beforeUpdate:open')![0]
+    const [value, details] = root.emitted('update:open')![0]
+    expect(beforeValue).toBe(true)
+    expect(value).toBe(true)
+    expect(beforeDetails).toBe(details)
+    expect(details).toMatchObject({ reason: 'trigger-press', isCanceled: false })
+    expect(details.event).toBeInstanceOf(MouseEvent)
+    expect(typeof details.cancel).toBe('function')
+  })
+
+  it('reports reason "escape-key" when Escape closes the popover', async () => {
+    const { wrapper, root, vm, trigger } = mountPopover()
+    trigger().element.click()
+    await nextTick()
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+
+    await wrapper.find('[role="dialog"]').trigger('keydown', { key: 'Escape' })
+    await nextTick()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'escape-key' })
+    expect(details.event).toBeInstanceOf(KeyboardEvent)
+    expect(vm.open).toBe(false)
+  })
+
+  it('reports reason "close-press" when PopoverClose is clicked', async () => {
+    const { wrapper, root, trigger, close } = mountPopover()
+    trigger().element.click()
+    await nextTick()
+
+    close().element.click()
+    await nextTick()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'close-press' })
+    expect(details.event).toBeInstanceOf(MouseEvent)
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+  })
+
+  it('details.cancel() in @before-update:open keeps the popover open and skips update:open', async () => {
+    const onBeforeUpdateOpen = vi.fn((_value: boolean, details: { cancel: () => void }) => details.cancel())
+    const { wrapper, root, vm, trigger, close } = mountPopover({ onBeforeUpdateOpen })
+    trigger().element.click()
+    await nextTick()
+    // The open transition was cancelled too: force the model open directly.
+    expect(onBeforeUpdateOpen).toHaveBeenCalledTimes(1)
+    expect(root.emitted('update:open')).toBeUndefined()
+    vm.open = true
+    await nextTick()
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+    onBeforeUpdateOpen.mockClear()
+
+    close().element.click()
+    await nextTick()
+
+    expect(onBeforeUpdateOpen).toHaveBeenCalledTimes(1)
+    expect(onBeforeUpdateOpen.mock.calls[0][1]).toMatchObject({ reason: 'close-press', isCanceled: true })
+    expect(root.emitted('beforeUpdate:open')).toHaveLength(2)
+    expect(root.emitted('update:open')).toBeUndefined()
+    expect(vm.open).toBe(true)
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+    expect(trigger().attributes('data-state')).toBe('open')
+  })
+
+  it('v-model:open round-trips through a wrapper component', async () => {
+    const { wrapper, root, vm, trigger, close } = mountPopover()
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+
+    trigger().element.click()
+    await nextTick()
+    expect(vm.open).toBe(true)
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(true)
+
+    close().element.click()
+    await nextTick()
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+    expect(wrapper.find('[role="dialog"]').exists()).toBe(false)
+
+    // Parent-driven change: the prop wins and nothing is emitted for it.
+    vm.open = true
+    await nextTick()
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(root.emitted('update:open')).toHaveLength(2)
+  })
+
+  it('slot `close` closes with the default "imperative-action" reason', async () => {
+    const wrapper = mount(defineComponent({
+      components: { PopoverRoot, PopoverTrigger },
+      template: `
+        <PopoverRoot :default-open="true" v-slot="{ open, close }">
+          <PopoverTrigger>{{ open }}</PopoverTrigger>
+          <button data-testid="slot-close" @click="close()">slot close</button>
+        </PopoverRoot>
+      `,
+    }), { attachTo: document.body })
+    mounted.push(wrapper)
+    const root = wrapper.findComponent(PopoverRoot)
+    expect(wrapper.find('[aria-haspopup="dialog"]').text()).toBe('true')
+
+    wrapper.find('[data-testid="slot-close"]').element.click()
+    await nextTick()
+
+    const [value, details] = root.emitted('update:open')![0]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'imperative-action' })
+    expect(details.event).toBeUndefined()
+    expect(wrapper.find('[aria-haspopup="dialog"]').text()).toBe('false')
   })
 })

--- a/packages/core/src/Popover/PopoverClose.vue
+++ b/packages/core/src/Popover/PopoverClose.vue
@@ -24,7 +24,7 @@ const rootContext = injectPopoverRootContext()
     :type="as === 'button' ? 'button' : undefined"
     :as="as"
     :as-child="props.asChild"
-    @click="rootContext.onOpenChange(false)"
+    @click="rootContext.onOpenChange(false, 'close-press', $event)"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Popover/PopoverContentImpl.vue
+++ b/packages/core/src/Popover/PopoverContentImpl.vue
@@ -63,7 +63,7 @@ useFocusGuards(currentElement)
       @interact-outside="emits('interactOutside', $event)"
       @escape-key-down="emits('escapeKeyDown', $event)"
       @focus-outside="emits('focusOutside', $event)"
-      @dismiss="rootContext.onOpenChange(false)"
+      @dismiss="(details) => rootContext.onOpenChange(false, details.reason, details.event)"
     >
       <PopperContent
         v-bind="forwarded"

--- a/packages/core/src/Popover/PopoverRoot.vue
+++ b/packages/core/src/Popover/PopoverRoot.vue
@@ -1,6 +1,15 @@
 <script lang="ts">
-import type { Ref } from 'vue'
-import { createContext } from '@/shared'
+import type { ComputedRef, Ref } from 'vue'
+import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
+import { createContext, useControllableState } from '@/shared'
+
+/** Why the popover's `open` state changed (#2828); the `reason` of `ChangeEventDetails`. */
+export type PopoverOpenChangeReason
+  = | 'trigger-press'
+    | 'close-press'
+    | 'escape-key'
+    | 'outside-press'
+    | 'focus-outside'
 
 export interface PopoverRootProps {
   /**
@@ -20,19 +29,25 @@ export interface PopoverRootProps {
 }
 export type PopoverRootEmits = {
   /**
+   * Event handler called before the open state of the popover changes; `details.cancel()` keeps the current state.
+   */
+  'beforeUpdate:open': [value: boolean, details: ChangeEventDetails<PopoverOpenChangeReason>]
+  /**
    * Event handler called when the open state of the popover changes.
    */
-  'update:open': [value: boolean]
+  'update:open': [value: boolean, details: ChangeEventDetails<PopoverOpenChangeReason>]
 }
 
 export interface PopoverRootContext {
   triggerElement: Ref<HTMLElement | undefined>
   triggerId: string
   contentId: string
-  open: Ref<boolean>
+  open: ComputedRef<boolean>
   modal: Ref<boolean>
-  onOpenChange: (value: boolean) => void
-  onOpenToggle: () => void
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenChange: (value: boolean, reason?: PopoverOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenToggle: (reason?: PopoverOpenChangeReason | BaseChangeReason, event?: Event) => boolean
   hasCustomAnchor: Ref<boolean>
 }
 
@@ -41,7 +56,6 @@ export const [injectPopoverRootContext, providePopoverRootContext]
 </script>
 
 <script setup lang="ts">
-import { useVModel } from '@vueuse/core'
 import { ref, toRefs } from 'vue'
 import { PopperRoot } from '@/Popper'
 
@@ -63,10 +77,15 @@ defineSlots<{
 
 const { modal } = toRefs(props)
 
-const open = useVModel(props, 'open', emit, {
+// Every write to `open` — trigger, close button, dismiss, slot `close` — goes
+// through one `setState`, so `beforeUpdate:open` can cancel any of them and
+// `update:open` always carries the reason (#2828).
+const { state: open, setState } = useControllableState<boolean, PopoverOpenChangeReason>({
+  prop: () => props.open,
   defaultValue: props.defaultOpen,
-  passive: (props.open === undefined) as false,
-}) as Ref<boolean>
+  name: 'open',
+  emit,
+})
 
 const triggerElement = ref<HTMLElement>()
 const hasCustomAnchor = ref(false)
@@ -76,12 +95,8 @@ providePopoverRootContext({
   triggerId: '',
   modal,
   open,
-  onOpenChange: (value) => {
-    open.value = value
-  },
-  onOpenToggle: () => {
-    open.value = !open.value
-  },
+  onOpenChange: (value, reason, event) => setState(value, reason, event),
+  onOpenToggle: (reason, event) => setState(!open.value, reason, event),
   triggerElement,
   hasCustomAnchor,
 })
@@ -91,7 +106,7 @@ providePopoverRootContext({
   <PopperRoot>
     <slot
       :open="open"
-      :close="() => open = false"
+      :close="() => setState(false)"
     />
   </PopperRoot>
 </template>

--- a/packages/core/src/Popover/PopoverTrigger.vue
+++ b/packages/core/src/Popover/PopoverTrigger.vue
@@ -40,7 +40,7 @@ onMounted(() => {
       :data-state="disclosureState(rootContext.open.value)"
       :as="as"
       :as-child="props.asChild"
-      @click="rootContext.onOpenToggle"
+      @click="rootContext.onOpenToggle('trigger-press', $event)"
     >
       <slot />
     </Primitive>

--- a/packages/core/src/Popover/index.ts
+++ b/packages/core/src/Popover/index.ts
@@ -21,8 +21,8 @@ export {
 } from './PopoverPortal.vue'
 export {
   injectPopoverRootContext,
-  default as PopoverRoot,
   type PopoverOpenChangeReason,
+  default as PopoverRoot,
   type PopoverRootEmits,
   type PopoverRootProps,
 } from './PopoverRoot.vue'

--- a/packages/core/src/Popover/index.ts
+++ b/packages/core/src/Popover/index.ts
@@ -22,6 +22,7 @@ export {
 export {
   injectPopoverRootContext,
   default as PopoverRoot,
+  type PopoverOpenChangeReason,
   type PopoverRootEmits,
   type PopoverRootProps,
 } from './PopoverRoot.vue'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,8 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.8.3)
 
+  packages/codemod: {}
+
   packages/core:
     dependencies:
       '@floating-ui/dom':


### PR DESCRIPTION
### 🔗 Linked issue

Closes out the codemod item of #2823 and extends the #2828 change-event contract to the Dialog and Popover families. Part of the v3 roadmap #2721.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Three pieces, one commit each plus docs.

**`@reka-ui/codemod`** (`packages/codemod`). A zero-dependency Node ≥ 22 CLI: `npx @reka-ui/codemod data-state ./src [--dry-run] [--ext ...]`. It applies the #2823 mapping to Tailwind variants (`data-[state=on]:`, `group-`/`peer-` prefixed, quoted forms) and CSS attribute selectors in all three quoting styles, splits `delayed-open` into `open` + `[data-delayed]`, and is deliberately conservative where the rename is ambiguous: `active`/`inactive` are rewritten only in files that mention Tabs, TagsInput or Rating and not Stepper or Splitter, and presence-only `:not([data-state])` selectors are left alone; both cases print a `file:line` warning. Plain `.mjs`, no build step, no dependencies, so the lockfile only gains a dependency-less importer entry (`packages/codemod: {}`). 24 `node:test` cases pass; the CI test job runs them. Package name and version (`3.0.0-alpha.0`) are a proposal; publishing is not configured.

**Dialog** (`DialogRoot`, `AlertDialogRoot` via the shared emits). `useVModel` is gone; every open/close path goes through one `setState`, so `beforeUpdate:open` can cancel it and `update:open` carries `ChangeEventDetails<DialogOpenChangeReason>`. Reasons: `trigger-press` (DialogTrigger), `close-press` (DialogClose, AlertDialogCancel, AlertDialogAction), `escape-key` / `outside-press` / `focus-outside` (forwarded from DismissableLayer's `dismiss` details). The slot's `close()` reports `imperative-action`. `onOpenChange` / `onOpenToggle` / `openModal` return `false` when unchanged or cancelled. Tests cover each reason, cancellation on open and close, and the `v-model:open` round-trip.

**Popover** (`PopoverRoot`), same contract with `PopoverOpenChangeReason`. `DatePickerRoot` and `DateRangePickerRoot` intersected `PopoverRootEmits` into their own emits, so they follow: each owns its `open` model through `useControllableState`, controls the inner PopoverRoot and forwards its reason and event, and adds `date-select` for the close-on-select path. Because the inner popover is controlled, a `beforeUpdate:open` cancel on the picker keeps both in sync.

**Docs.** The v3 migration guide gains a "Codemod" subsection and a "Change events carry details" section listing the converted families and what to check.

Not in this PR: converting Dialog/Popover into `useDialog` / `usePopover` composables (separate #2723 task), and `docs:gen` for the touched families (the generator needs a build).

**Validation note:** the npm registry is blocked in the authoring environment, so vitest, vue-tsc and eslint could not run for `packages/core`; the codemod's own tests ran with `node --test`. CI is the first full execution.

### 📸 Screenshots (if appropriate)

n/a

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a codemod CLI to migrate `data-state` selectors between major versions, with dry-run support, warnings, and summaries.
  * Dialog, Popover, Date Picker, and Date Range Picker state-change events now include reasons and originating events.
  * Added cancellable `beforeUpdate:open` events for open-state transitions.

* **Documentation**
  * Added codemod usage guidance and documented updated state-change behavior.

* **Tests**
  * Expanded coverage for codemod transformations and reason-aware, cancellable state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->