### PR TITLE
feat(v3)!: useDialog and usePopover composables, Tooltip/HoverCard change details, docs generator fix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup (Install node & pnpm)
         uses: ./.github/actions/setup

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,37 @@ jobs:
           path: packages/core/coverage
           retention-days: 7
 
+  docs-meta:
+    # Informational: `pnpm docs:gen` still regresses a few generic components
+    # (see the note in docs/scripts/autogen.ts), so drift never blocks a PR.
+    # The full diff is printed so it can be applied to the branch by hand.
+    needs: build
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup (Install node & pnpm)
+        uses: ./.github/actions/setup
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: reka-ui-dist
+          path: packages/core/dist
+
+      - name: Regenerate component meta
+        run: pnpm docs:gen
+
+      - name: Report drift in docs/content/meta
+        run: |
+          git add -N docs/content/meta
+          git --no-pager diff --stat -- docs/content/meta
+          git --no-pager diff -- docs/content/meta
+          git diff --quiet -- docs/content/meta
+
   size:
     needs: build
     runs-on: ubuntu-latest

--- a/docs/content/docs/guides/migration-v3.md
+++ b/docs/content/docs/guides/migration-v3.md
@@ -76,9 +76,9 @@ The `@reka-ui/codemod` package automates the mechanical part: `npx @reka-ui/code
 
 `update:*` events on stateful roots now receive a second argument, a `ChangeEventDetails` object, and a cancellable `beforeUpdate:*` event fires before every change. `v-model` keeps working unchanged. The details tell you *why* the state changed (`details.reason`) and which native event caused it (`details.event`), and `details.cancel()` inside `beforeUpdate:*` keeps the current state.
 
-Converted so far: `SwitchRoot`, `TabsRoot` (`modelValue`), `MenuRoot`, `ContextMenuRoot`, `DialogRoot`, `AlertDialogRoot`, `PopoverRoot`, `DatePickerRoot` and `DateRangePickerRoot` (`open`). The remaining families follow as they move to their headless composables.
+Converted so far: `SwitchRoot`, `TabsRoot` (`modelValue`), `MenuRoot`, `ContextMenuRoot`, `DialogRoot`, `AlertDialogRoot`, `PopoverRoot`, `TooltipRoot`, `HoverCardRoot`, `DatePickerRoot` and `DateRangePickerRoot` (`open`). The remaining families follow as they move to their headless composables.
 
-Each family exports its reason union, for example `DialogOpenChangeReason` (`'trigger-press' | 'close-press' | 'escape-key' | 'outside-press' | 'focus-outside'`); every family also reports `'imperative-action'` for programmatic changes such as the slot's `close()`.
+Each family exports its reason union, for example `DialogOpenChangeReason` (`'trigger-press' | 'close-press' | 'escape-key' | 'outside-press' | 'focus-outside'`) or `TooltipOpenChangeReason` (`'trigger-hover' | 'trigger-leave' | 'trigger-focus' | 'trigger-blur' | 'trigger-press' | 'content-leave' | 'escape-key' | 'outside-press'`); every family also reports `'imperative-action'` for programmatic changes such as the slot's `close()`. A delayed hover open on Tooltip and HoverCard reports `trigger-hover` with the pointer event that armed the timer.
 
 What to check in your code:
 

--- a/docs/content/docs/guides/migration-v3.md
+++ b/docs/content/docs/guides/migration-v3.md
@@ -78,7 +78,7 @@ The `@reka-ui/codemod` package automates the mechanical part: `npx @reka-ui/code
 
 Converted so far: `SwitchRoot`, `TabsRoot` (`modelValue`), `MenuRoot`, `ContextMenuRoot`, `DialogRoot`, `AlertDialogRoot`, `PopoverRoot`, `TooltipRoot`, `HoverCardRoot`, `DatePickerRoot` and `DateRangePickerRoot` (`open`). The remaining families follow as they move to their headless composables.
 
-Each family exports its reason union, for example `DialogOpenChangeReason` (`'trigger-press' | 'close-press' | 'escape-key' | 'outside-press' | 'focus-outside'`) or `TooltipOpenChangeReason` (`'trigger-hover' | 'trigger-leave' | 'trigger-focus' | 'trigger-blur' | 'trigger-press' | 'content-leave' | 'escape-key' | 'outside-press'`); every family also reports `'imperative-action'` for programmatic changes such as the slot's `close()`. A delayed hover open on Tooltip and HoverCard reports `trigger-hover` with the pointer event that armed the timer.
+Each family exports its reason union, for example `DialogOpenChangeReason` (`'trigger-press' | 'close-press' | 'escape-key' | 'outside-press' | 'focus-outside'`) or `TooltipOpenChangeReason` (`'trigger-hover' | 'trigger-leave' | 'trigger-focus' | 'trigger-blur' | 'trigger-press' | 'content-leave' | 'escape-key' | 'outside-press'`). Those unions only list the interaction reasons: `details.reason` is typed as the family union plus the shared `BaseChangeReason`, so every family also reports `'imperative-action'` for programmatic changes such as the slot's `close()`, and a `switch` written against the family union alone misses it. A delayed hover open on Tooltip and HoverCard reports `trigger-hover` with the pointer event that armed the timer.
 
 What to check in your code:
 

--- a/docs/content/meta/AlertDialogRoot.md
+++ b/docs/content/meta/AlertDialogRoot.md
@@ -24,9 +24,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Called before the open state changes; <code>details.cancel()</code> keeps the current state.</p>\n',
+    'type': '[value: boolean, details: ChangeEventDetails&lt;DialogOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the dialog changes.</p>\n',
-    'type': '[value: boolean]'
+    'type': '[value: boolean, details: ChangeEventDetails&lt;DialogOpenChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -58,7 +63,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the dialog changes. | `[value: boolean]` |
+| `beforeUpdate:open` | Called before the open state changes; details.cancel() keeps the current state. | `[value: boolean, details: ChangeEventDetails<DialogOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the dialog changes. | `[value: boolean, details: ChangeEventDetails<DialogOpenChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/ContextMenuRoot.md
+++ b/docs/content/meta/ContextMenuRoot.md
@@ -3,6 +3,12 @@
 <llm-exclude>
 <PropsTable :data="[
   {
+    'name': 'defaultOpen',
+    'description': '<p>The open state of the menu when it is initially rendered. Use when you do not need to control its open state.</p>\n',
+    'type': 'boolean',
+    'required': false
+  },
+  {
     'name': 'dir',
     'description': '<p>The reading direction of the combobox when applicable.</p>\n<p>If omitted, inherits globally from <code>ConfigProvider</code> or assumes LTR (left-to-right) reading mode.</p>\n',
     'type': '\'ltr\' | \'rtl\'',
@@ -26,9 +32,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Called before the open state of the submenu changes; <code>details.cancel()</code> vetoes the change.</p>\n',
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the submenu changes.</p>\n',
-    'type': '[payload: boolean]'
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
   }
 ]" />
 </llm-exclude>
@@ -39,6 +50,7 @@
 
 | Name | Description | Type | Required | Default |
 | --- | --- | --- | --- | --- |
+| `defaultOpen` | The open state of the menu when it is initially rendered. Use when you do not need to control its open state. | `boolean` | No | - |
 | `dir` | The reading direction of the combobox when applicable. If omitted, inherits globally from ConfigProvider or assumes LTR (left-to-right) reading mode. | `"ltr" \| "rtl"` | No | - |
 | `modal` | The modality of the dropdown menu. When set to true, interaction with outside elements will be disabled and only menu content will be visible to screen readers. | `boolean` | No | `true` |
 | `pressOpenDelay` | The duration from when the trigger is pressed until the menu opens. | `number` | No | `700` |
@@ -47,6 +59,7 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean]` |
+| `beforeUpdate:open` | Called before the open state of the submenu changes; details.cancel() vetoes the change. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
 
 </llm-only>

--- a/docs/content/meta/ContextMenuSub.md
+++ b/docs/content/meta/ContextMenuSub.md
@@ -18,9 +18,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Called before the open state of the submenu changes; <code>details.cancel()</code> vetoes the change.</p>\n',
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the submenu changes.</p>\n',
-    'type': '[payload: boolean]'
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -46,7 +51,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean]` |
+| `beforeUpdate:open` | Called before the open state of the submenu changes; details.cancel() vetoes the change. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/DatePickerRoot.md
+++ b/docs/content/meta/DatePickerRoot.md
@@ -196,14 +196,19 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Called before the open state changes; <code>details.cancel()</code> keeps the current state.</p>\n',
+    'type': '[value: boolean, details: ChangeEventDetails&lt;DatePickerOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:modelValue',
     'description': '<p>Event handler called whenever the model value changes</p>\n',
     'type': '[date: DateValue]'
   },
   {
     'name': 'update:open',
-    'description': '<p>Event handler called when the open state of the submenu changes.</p>\n',
-    'type': '[value: boolean]'
+    'description': '<p>Event handler called when the open state of the popover changes.</p>\n',
+    'type': '[value: boolean, details: ChangeEventDetails&lt;DatePickerOpenChangeReason, Event&gt;]'
   },
   {
     'name': 'update:placeholder',
@@ -254,8 +259,9 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
+| `beforeUpdate:open` | Called before the open state changes; details.cancel() keeps the current state. | `[value: boolean, details: ChangeEventDetails<DatePickerOpenChangeReason, Event>]` |
 | `update:modelValue` | Event handler called whenever the model value changes | `[date: DateValue]` |
-| `update:open` | Event handler called when the open state of the submenu changes. | `[value: boolean]` |
+| `update:open` | Event handler called when the open state of the popover changes. | `[value: boolean, details: ChangeEventDetails<DatePickerOpenChangeReason, Event>]` |
 | `update:placeholder` | Event handler called whenever the placeholder value changes | `[date: DateValue]` |
 
 </llm-only>

--- a/docs/content/meta/DateRangePickerRoot.md
+++ b/docs/content/meta/DateRangePickerRoot.md
@@ -216,14 +216,19 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Called before the open state changes; <code>details.cancel()</code> keeps the current state.</p>\n',
+    'type': '[value: boolean, details: ChangeEventDetails&lt;DateRangePickerOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:modelValue',
     'description': '<p>Event handler called whenever the model value changes</p>\n',
     'type': '[date: DateRange]'
   },
   {
     'name': 'update:open',
-    'description': '<p>Event handler called when the open state of the submenu changes.</p>\n',
-    'type': '[value: boolean]'
+    'description': '<p>Event handler called when the open state of the popover changes.</p>\n',
+    'type': '[value: boolean, details: ChangeEventDetails&lt;DateRangePickerOpenChangeReason, Event&gt;]'
   },
   {
     'name': 'update:placeholder',
@@ -295,8 +300,9 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
+| `beforeUpdate:open` | Called before the open state changes; details.cancel() keeps the current state. | `[value: boolean, details: ChangeEventDetails<DateRangePickerOpenChangeReason, Event>]` |
 | `update:modelValue` | Event handler called whenever the model value changes | `[date: DateRange]` |
-| `update:open` | Event handler called when the open state of the submenu changes. | `[value: boolean]` |
+| `update:open` | Event handler called when the open state of the popover changes. | `[value: boolean, details: ChangeEventDetails<DateRangePickerOpenChangeReason, Event>]` |
 | `update:placeholder` | Event handler called whenever the placeholder value changes | `[date: DateValue]` |
 | `update:startValue` | Event handler called whenever the start value changes | `[date: DateValue]` |
 

--- a/docs/content/meta/DialogRoot.md
+++ b/docs/content/meta/DialogRoot.md
@@ -33,9 +33,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Called before the open state changes; <code>details.cancel()</code> keeps the current state.</p>\n',
+    'type': '[value: boolean, details: ChangeEventDetails&lt;DialogOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the dialog changes.</p>\n',
-    'type': '[value: boolean]'
+    'type': '[value: boolean, details: ChangeEventDetails&lt;DialogOpenChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -68,7 +73,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the dialog changes. | `[value: boolean]` |
+| `beforeUpdate:open` | Called before the open state changes; details.cancel() keeps the current state. | `[value: boolean, details: ChangeEventDetails<DialogOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the dialog changes. | `[value: boolean, details: ChangeEventDetails<DialogOpenChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/DropdownMenuRoot.md
+++ b/docs/content/meta/DropdownMenuRoot.md
@@ -31,9 +31,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Called before the open state of the submenu changes; <code>details.cancel()</code> vetoes the change.</p>\n',
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the submenu changes.</p>\n',
-    'type': '[payload: boolean]'
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -61,7 +66,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean]` |
+| `beforeUpdate:open` | Called before the open state of the submenu changes; details.cancel() vetoes the change. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/DropdownMenuSub.md
+++ b/docs/content/meta/DropdownMenuSub.md
@@ -18,9 +18,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Called before the open state of the submenu changes; <code>details.cancel()</code> vetoes the change.</p>\n',
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the submenu changes.</p>\n',
-    'type': '[payload: boolean]'
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -46,7 +51,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean]` |
+| `beforeUpdate:open` | Called before the open state of the submenu changes; details.cancel() vetoes the change. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/HoverCardRoot.md
+++ b/docs/content/meta/HoverCardRoot.md
@@ -40,9 +40,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Event handler called before the open state of the hover card changes; <code>details.cancel()</code> keeps the current state.</p>\n',
+    'type': '[value: boolean, details: ChangeEventDetails&lt;HoverCardOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the hover card changes.</p>\n',
-    'type': '[value: boolean]'
+    'type': '[value: boolean, details: ChangeEventDetails&lt;HoverCardOpenChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -71,7 +76,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the hover card changes. | `[value: boolean]` |
+| `beforeUpdate:open` | Event handler called before the open state of the hover card changes; details.cancel() keeps the current state. | `[value: boolean, details: ChangeEventDetails<HoverCardOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the hover card changes. | `[value: boolean, details: ChangeEventDetails<HoverCardOpenChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/Label.md
+++ b/docs/content/meta/Label.md
@@ -32,7 +32,7 @@
   {
     'name': 'state',
     'description': '',
-    'type': 'PrimitiveState'
+    'type': 'PartState'
   },
   {
     'name': 'forwardRef',
@@ -57,7 +57,7 @@
 | Name | Description | Type |
 | --- | --- | --- |
 | `props` |  | `Record<string, any>` |
-| `state` |  | `PrimitiveState` |
+| `state` |  | `PartState` |
 | `forwardRef` |  | `(el: Element \| ComponentPublicInstance \| null): void` |
 
 </llm-only>

--- a/docs/content/meta/MenubarSub.md
+++ b/docs/content/meta/MenubarSub.md
@@ -18,9 +18,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Called before the open state of the submenu changes; <code>details.cancel()</code> vetoes the change.</p>\n',
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the submenu changes.</p>\n',
-    'type': '[payload: boolean]'
+    'type': '[payload: boolean, details: ChangeEventDetails&lt;MenuOpenChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -46,7 +51,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean]` |
+| `beforeUpdate:open` | Called before the open state of the submenu changes; details.cancel() vetoes the change. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the submenu changes. | `[payload: boolean, details: ChangeEventDetails<MenuOpenChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/PopoverRoot.md
+++ b/docs/content/meta/PopoverRoot.md
@@ -26,9 +26,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Event handler called before the open state of the popover changes; <code>details.cancel()</code> keeps the current state.</p>\n',
+    'type': '[value: boolean, details: ChangeEventDetails&lt;PopoverOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the popover changes.</p>\n',
-    'type': '[value: boolean]'
+    'type': '[value: boolean, details: ChangeEventDetails&lt;PopoverOpenChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -60,7 +65,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the popover changes. | `[value: boolean]` |
+| `beforeUpdate:open` | Event handler called before the open state of the popover changes; details.cancel() keeps the current state. | `[value: boolean, details: ChangeEventDetails<PopoverOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the popover changes. | `[value: boolean, details: ChangeEventDetails<PopoverOpenChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/SwitchRoot.md
+++ b/docs/content/meta/SwitchRoot.md
@@ -76,9 +76,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:modelValue',
+    'description': '<p>Event handler called before the value of the switch changes; <code>details.cancel()</code> vetoes the change.</p>\n',
+    'type': '[payload: T, details: ChangeEventDetails&lt;SwitchChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:modelValue',
     'description': '<p>Event handler called when the value of the switch changes.</p>\n',
-    'type': '[payload: T]'
+    'type': '[payload: T, details: ChangeEventDetails&lt;SwitchChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -118,7 +123,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:modelValue` | Event handler called when the value of the switch changes. | `[payload: T]` |
+| `beforeUpdate:modelValue` | Event handler called before the value of the switch changes; details.cancel() vetoes the change. | `[payload: T, details: ChangeEventDetails<SwitchChangeReason, Event>]` |
+| `update:modelValue` | Event handler called when the value of the switch changes. | `[payload: T, details: ChangeEventDetails<SwitchChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/TabsRoot.md
+++ b/docs/content/meta/TabsRoot.md
@@ -58,9 +58,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:modelValue',
+    'description': '<p>Event handler called before the value changes; call <code>details.cancel()</code> to keep the current value</p>\n',
+    'type': '[payload: T, details: ChangeEventDetails&lt;TabsChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:modelValue',
     'description': '<p>Event handler called when the value changes</p>\n',
-    'type': '[payload: T]'
+    'type': '[payload: T, details: ChangeEventDetails&lt;TabsChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -92,7 +97,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:modelValue` | Event handler called when the value changes | `[payload: T]` |
+| `beforeUpdate:modelValue` | Event handler called before the value changes; call details.cancel() to keep the current value | `[payload: T, details: ChangeEventDetails<TabsChangeReason, Event>]` |
+| `update:modelValue` | Event handler called when the value changes | `[payload: T, details: ChangeEventDetails<TabsChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/Toggle.md
+++ b/docs/content/meta/Toggle.md
@@ -65,7 +65,7 @@
   {
     'name': 'state',
     'description': '<p>Current state</p>\n',
-    'type': '\'on\' | \'off\''
+    'type': '\'checked\' | \'unchecked\''
   },
   {
     'name': 'pressed',
@@ -105,7 +105,7 @@
 | Name | Description | Type |
 | --- | --- | --- |
 | `modelValue` | Current value | `boolean` |
-| `state` | Current state | `"on" \| "off"` |
+| `state` | Current state | `"checked" \| "unchecked"` |
 | `pressed` | Current pressed state | `boolean` |
 | `disabled` | Current disabled state | `boolean` |
 

--- a/docs/content/meta/ToggleGroupItem.md
+++ b/docs/content/meta/ToggleGroupItem.md
@@ -38,7 +38,7 @@
   {
     'name': 'state',
     'description': '<p>Current state</p>\n',
-    'type': '\'on\' | \'off\''
+    'type': '\'checked\' | \'unchecked\''
   },
   {
     'name': 'pressed',
@@ -69,7 +69,7 @@
 | Name | Description | Type |
 | --- | --- | --- |
 | `modelValue` | Current value | `boolean` |
-| `state` | Current state | `"on" \| "off"` |
+| `state` | Current state | `"checked" \| "unchecked"` |
 | `pressed` | Current pressed state | `boolean` |
 | `disabled` | Current disabled state | `boolean` |
 

--- a/docs/content/meta/TooltipRoot.md
+++ b/docs/content/meta/TooltipRoot.md
@@ -49,9 +49,14 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:open',
+    'description': '<p>Event handler called before the open state of the tooltip changes; <code>details.cancel()</code> keeps the current state.</p>\n',
+    'type': '[value: boolean, details: ChangeEventDetails&lt;TooltipOpenChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:open',
     'description': '<p>Event handler called when the open state of the tooltip changes.</p>\n',
-    'type': '[value: boolean]'
+    'type': '[value: boolean, details: ChangeEventDetails&lt;TooltipOpenChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -82,7 +87,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `update:open` | Event handler called when the open state of the tooltip changes. | `[value: boolean]` |
+| `beforeUpdate:open` | Event handler called before the open state of the tooltip changes; details.cancel() keeps the current state. | `[value: boolean, details: ChangeEventDetails<TooltipOpenChangeReason, Event>]` |
+| `update:open` | Event handler called when the open state of the tooltip changes. | `[value: boolean, details: ChangeEventDetails<TooltipOpenChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/scripts/autogen.ts
+++ b/docs/scripts/autogen.ts
@@ -12,8 +12,13 @@ import { createChecker } from 'vue-component-meta'
 import { babelParse, parse as sfcParse } from 'vue/compiler-sfc'
 import { transformJSDocLinks } from './utils'
 
-// @ts-expect-error ignore
-const traverse = _traverse.default as typeof _traverse
+// `@babel/traverse` is CJS. Depending on the ESM interop in play (tsx, Node's
+// CJS namespace wrapping) the default import is either the function itself or
+// `{ default: fn }`; accept both so `pnpm docs:gen` runs on a clean checkout.
+const traverse: typeof _traverse = typeof _traverse === 'function'
+  ? _traverse
+  // @ts-expect-error CJS interop: the namespace object carries the function on `default`
+  : _traverse.default
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 const md = new MarkdownIt()

--- a/docs/superpowers/recipes/2723-headless-composable-recipe.md
+++ b/docs/superpowers/recipes/2723-headless-composable-recipe.md
@@ -210,6 +210,12 @@ core Menu parts settled the overlay contract:
   instance ref) — inject it as a `getItems` option.
 - **Overlay composables are mount-lifecycle-bound** (`useIsUsingKeyboard`, the content
   watchers/`onUnmounted`) — NOT callable outside `setup()`; test in a mount harness.
+- **Overlay part ids derive from the root's `baseId` in the composable** (Dialog:
+  `contentId`/`titleId`/`descriptionId` = `` `${baseId}-content` `` …), NOT back-filled
+  onto the context by descendant SFCs via `rootContext.x ||= useId(...)`. The context
+  shape stays a plain `string` but is populated up-front, so a standalone consumer —
+  and a trigger-less dialog — get real ids, and every part reads the same value
+  from the context. The one `useId` call still lives in the root SFC.
 
 ## Dependency- and structure-ordered migration (not size)
 

--- a/packages/core/src/Dialog/DialogClose.vue
+++ b/packages/core/src/Dialog/DialogClose.vue
@@ -8,20 +8,24 @@ export interface DialogCloseProps extends PrimitiveProps {}
 import { Primitive } from '@/Primitive'
 import { useForwardExpose } from '@/shared'
 import { injectDialogRootContext } from './DialogRoot.vue'
+import { getDialogCloseSurface } from './useDialog'
 
-const props = withDefaults(defineProps<DialogCloseProps>(), {
+withDefaults(defineProps<DialogCloseProps>(), {
   as: 'button',
 })
 
 useForwardExpose()
 const rootContext = injectDialogRootContext()
+// `onClick` → `onOpenChange(false, 'close-press')` from the shared surface builder.
+const close = getDialogCloseSurface(rootContext)
 </script>
 
 <template>
   <Primitive
-    v-bind="props"
+    :as="as"
+    :as-child="asChild"
     :type="as === 'button' ? 'button' : undefined"
-    @click="(event: MouseEvent) => rootContext.onOpenChange(false, 'close-press', event)"
+    v-bind="close.attrs.value"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Dialog/DialogContentImpl.vue
+++ b/packages/core/src/Dialog/DialogContentImpl.vue
@@ -3,7 +3,7 @@ import type {
   DismissableLayerEmits,
   DismissableLayerProps,
 } from '@/DismissableLayer'
-import { disclosureState, getActiveElement, useForwardExpose, useId } from '@/shared'
+import { getActiveElement, useForwardExpose } from '@/shared'
 
 export type DialogContentImplEmits = DismissableLayerEmits & {
   /**
@@ -34,10 +34,11 @@ export interface DialogContentImplProps extends DismissableLayerProps {
 </script>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { mergeProps, onMounted } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { FocusScope } from '@/FocusScope'
 import { injectDialogRootContext } from './DialogRoot.vue'
+import { getDialogContentSurface } from './useDialog'
 import { useWarning } from './utils'
 
 const props = defineProps<DialogContentImplProps & {
@@ -51,8 +52,12 @@ const emits = defineEmits<DialogContentImplEmits>()
 const rootContext = injectDialogRootContext()
 const { forwardRef, currentElement: contentElement } = useForwardExpose()
 
-rootContext.titleId ||= useId(undefined, 'reka-dialog-title')
-rootContext.descriptionId ||= useId(undefined, 'reka-dialog-description')
+// id/role/aria-labelledby/aria-describedby/data-state come from the shared
+// surface builder (single source with `useDialog()`); the FocusScope +
+// DismissableLayer wrappers, `@dismiss` forwarding and the a11y warnings stay
+// here. `$attrs` merges AFTER the surface so a consumer's
+// `:aria-describedby="undefined"` still wins.
+const content = getDialogContentSurface(rootContext)
 
 onMounted(() => {
   rootContext.contentElement = contentElement
@@ -84,17 +89,12 @@ if (process.env.NODE_ENV !== 'production') {
     @unmount-auto-focus="emits('closeAutoFocus', $event)"
   >
     <DismissableLayer
-      :id="rootContext.contentId"
       :ref="forwardRef"
       :as="as"
       :as-child="asChild"
       :present="props.present"
       :disable-outside-pointer-events="disableOutsidePointerEvents"
-      role="dialog"
-      :aria-describedby="rootContext.descriptionId"
-      :aria-labelledby="rootContext.titleId"
-      :data-state="disclosureState(rootContext.open.value)"
-      v-bind="$attrs"
+      v-bind="mergeProps(content.attrs.value, $attrs)"
       @dismiss="(details) => rootContext.onOpenChange(false, details.reason, details.event)"
       @escape-key-down="emits('escapeKeyDown', $event)"
       @focus-outside="emits('focusOutside', $event)"

--- a/packages/core/src/Dialog/DialogDescription.vue
+++ b/packages/core/src/Dialog/DialogDescription.vue
@@ -8,17 +8,21 @@ export interface DialogDescriptionProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
 import { injectDialogRootContext } from './DialogRoot.vue'
+import { getDialogDescriptionSurface } from './useDialog'
 
-const props = withDefaults(defineProps<DialogDescriptionProps>(), { as: 'p' })
+withDefaults(defineProps<DialogDescriptionProps>(), { as: 'p' })
 
 useForwardExpose()
 const rootContext = injectDialogRootContext()
+// The `id` the content's `aria-describedby` points at, from the shared surface builder.
+const description = getDialogDescriptionSurface(rootContext)
 </script>
 
 <template>
   <Primitive
-    v-bind="props"
-    :id="rootContext.descriptionId"
+    :as="as"
+    :as-child="asChild"
+    v-bind="description.attrs.value"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Dialog/DialogOverlayImpl.vue
+++ b/packages/core/src/Dialog/DialogOverlayImpl.vue
@@ -7,9 +7,10 @@ export interface DialogOverlayImplProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { watch } from 'vue'
 import { Primitive } from '@/Primitive'
-import { disclosureState, useForwardExpose } from '@/shared'
+import { useForwardExpose } from '@/shared'
 import { useBodyScrollLock } from '@/shared/useBodyScrollLock'
 import { injectDialogRootContext } from './DialogRoot.vue'
+import { getDialogOverlaySurface } from './useDialog'
 
 const props = withDefaults(defineProps<DialogOverlayImplProps & { present?: boolean }>(), {
   present: true,
@@ -20,14 +21,17 @@ const scrollLocked = useBodyScrollLock(props.present)
 watch(() => props.present, val => scrollLocked.value = val)
 
 useForwardExpose()
+// `data-state` from the shared surface builder; the scroll lock and the
+// pointerdown guard (#2655/#2660) stay in the SFC.
+const overlay = getDialogOverlaySurface(rootContext)
 </script>
 
 <template>
   <Primitive
     :as="as"
     :as-child="asChild"
-    :data-state="disclosureState(rootContext.open.value)"
     style="pointer-events: auto"
+    v-bind="overlay.attrs.value"
     @pointerdown.left.self.prevent
   >
     <slot />

--- a/packages/core/src/Dialog/DialogRoot.vue
+++ b/packages/core/src/Dialog/DialogRoot.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ComputedRef, Ref } from 'vue'
 import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
-import { createContext, useControllableState } from '@/shared'
+import { createContext, useId } from '@/shared'
 
 /** Why the dialog's `open` state changed (#2828); the `reason` of `ChangeEventDetails`. */
 export type DialogOpenChangeReason
@@ -58,7 +58,7 @@ export const [injectDialogRootContext, provideDialogRootContext]
 </script>
 
 <script setup lang="ts">
-import { ref, toRefs } from 'vue'
+import { useDialog } from './useDialog'
 
 defineOptions({
   inheritAttrs: false,
@@ -81,37 +81,25 @@ defineSlots<{
   }) => any
 }>()
 
-// Every open/close path (trigger, close button, dismiss) goes through one
-// `setState` so `beforeUpdate:open` can cancel it and the details reach the consumer.
-const { state: open, setState } = useControllableState<boolean, DialogOpenChangeReason>({
-  prop: () => props.open,
-  defaultValue: props.defaultOpen,
-  name: 'open',
+// The composable owns the controlled/uncontrolled `open` model (every open/close
+// path goes through its `setState` so `beforeUpdate:open` can cancel it) and
+// builds the context; `useId` (SSR-stable) stays in the shell and seeds the
+// content/title/description ids.
+const { open, onOpenChange, context } = useDialog({
+  open: () => props.open,
+  defaultOpen: props.defaultOpen,
+  modal: () => props.modal,
+  unmountOnHide: () => props.unmountOnHide,
+  baseId: useId(undefined, 'reka-dialog'),
   emit,
 })
 
-const triggerElement = ref<HTMLElement>()
-const contentElement = ref<HTMLElement>()
-const { modal, unmountOnHide } = toRefs(props)
-
-provideDialogRootContext({
-  open,
-  modal,
-  unmountOnHide,
-  openModal: (reason, event) => setState(true, reason, event),
-  onOpenChange: (value, reason, event) => setState(value, reason, event),
-  onOpenToggle: (reason, event) => setState(!open.value, reason, event),
-  contentId: '',
-  titleId: '',
-  descriptionId: '',
-  triggerElement,
-  contentElement,
-})
+provideDialogRootContext(context)
 </script>
 
 <template>
   <slot
     :open="open"
-    :close="() => setState(false)"
+    :close="() => onOpenChange(false)"
   />
 </template>

--- a/packages/core/src/Dialog/DialogTitle.vue
+++ b/packages/core/src/Dialog/DialogTitle.vue
@@ -8,16 +8,20 @@ export interface DialogTitleProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
 import { injectDialogRootContext } from './DialogRoot.vue'
+import { getDialogTitleSurface } from './useDialog'
 
-const props = withDefaults(defineProps<DialogTitleProps>(), { as: 'h2' })
+withDefaults(defineProps<DialogTitleProps>(), { as: 'h2' })
 const rootContext = injectDialogRootContext()
 useForwardExpose()
+// The `id` the content's `aria-labelledby` points at, from the shared surface builder.
+const title = getDialogTitleSurface(rootContext)
 </script>
 
 <template>
   <Primitive
-    v-bind="props"
-    :id="rootContext.titleId"
+    :as="as"
+    :as-child="asChild"
+    v-bind="title.attrs.value"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Dialog/DialogTrigger.vue
+++ b/packages/core/src/Dialog/DialogTrigger.vue
@@ -7,16 +7,22 @@ export interface DialogTriggerProps extends PrimitiveProps {}
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { Primitive } from '@/Primitive'
-import { disclosureState, useForwardExpose, useId } from '@/shared'
+import { useForwardExpose } from '@/shared'
 import { injectDialogRootContext } from './DialogRoot.vue'
+import { getDialogTriggerSurface } from './useDialog'
 
-const props = withDefaults(defineProps<DialogTriggerProps>(), {
+withDefaults(defineProps<DialogTriggerProps>(), {
   as: 'button',
 })
 const rootContext = injectDialogRootContext()
 const { forwardRef, currentElement } = useForwardExpose()
 
-rootContext.contentId ||= useId(undefined, 'reka-dialog-content')
+// aria-haspopup/aria-expanded/aria-controls/data-state + the click handler come
+// from the shared surface builder (single source with `useDialog()`); the
+// tag-dependent `type` stays in the SFC. Consumer listeners fall through as
+// `$attrs` AFTER the surface's handler, so they chain instead of clobbering it.
+const trigger = getDialogTriggerSurface(rootContext)
+
 onMounted(() => {
   rootContext.triggerElement.value = currentElement.value
 })
@@ -24,14 +30,11 @@ onMounted(() => {
 
 <template>
   <Primitive
-    v-bind="props"
     :ref="forwardRef"
+    :as="as"
+    :as-child="asChild"
     :type="as === 'button' ? 'button' : undefined"
-    aria-haspopup="dialog"
-    :aria-expanded="rootContext.open.value || false"
-    :aria-controls="rootContext.open.value ? rootContext.contentId : undefined"
-    :data-state="disclosureState(rootContext.open.value)"
-    @click="(event: MouseEvent) => rootContext.onOpenToggle('trigger-press', event)"
+    v-bind="trigger.attrs.value"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Dialog/index.ts
+++ b/packages/core/src/Dialog/index.ts
@@ -34,3 +34,11 @@ export {
   default as DialogTrigger,
   type DialogTriggerProps,
 } from './DialogTrigger.vue'
+export {
+  type DialogContentState,
+  type DialogOverlayState,
+  type DialogTriggerState,
+  useDialog,
+  type UseDialogProps,
+  type UseDialogReturn,
+} from './useDialog'

--- a/packages/core/src/Dialog/useDialog.test.ts
+++ b/packages/core/src/Dialog/useDialog.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import * as Reka from '../index'
+import { useDialog } from './useDialog'
+
+function noDataAttrs(props: Record<string, any>) {
+  return Object.keys(props).every(k => !k.startsWith('data-'))
+}
+
+describe('useDialog — state', () => {
+  it('defaults to closed, modal, unmountOnHide, uncontrolled', () => {
+    const d = useDialog()
+    expect(d.open.value).toBe(false)
+    expect(d.modal.value).toBe(true)
+    expect(d.unmountOnHide.value).toBe(true)
+    expect(d.isControlled.value).toBe(false)
+    expect(d.lastChangeDetails.value.reason).toBe('none')
+  })
+
+  it('honours defaultOpen / modal / unmountOnHide getters', () => {
+    const modal = ref(false)
+    const d = useDialog({ defaultOpen: true, modal, unmountOnHide: () => false })
+    expect(d.open.value).toBe(true)
+    expect(d.modal.value).toBe(false)
+    expect(d.unmountOnHide.value).toBe(false)
+    modal.value = true
+    expect(d.modal.value).toBe(true)
+    expect(d.context.modal.value).toBe(true)
+  })
+
+  it('onOpenChange / onOpenToggle / openModal drive the model and report imperative-action', () => {
+    const d = useDialog()
+    expect(d.onOpenChange(true)).toBe(true)
+    expect(d.open.value).toBe(true)
+    expect(d.lastChangeDetails.value.reason).toBe('imperative-action')
+    // Unchanged → false, no new details.
+    expect(d.onOpenChange(true)).toBe(false)
+    expect(d.onOpenToggle()).toBe(true)
+    expect(d.open.value).toBe(false)
+    expect(d.openModal()).toBe(true)
+    expect(d.open.value).toBe(true)
+    expect(d.openModal()).toBe(false)
+  })
+
+  it('ref-owned mode writes through the passed ref', () => {
+    const open = ref(false)
+    const d = useDialog({ open })
+    expect(d.isControlled.value).toBe(true)
+    d.onOpenToggle()
+    expect(open.value).toBe(true)
+    expect(d.open.value).toBe(true)
+  })
+
+  it('controlled getter + emit: emits beforeUpdate:open then update:open and does not write locally', () => {
+    const emit = vi.fn()
+    const d = useDialog({ open: () => false, emit })
+    expect(d.isControlled.value).toBe(true)
+    const event = new MouseEvent('click')
+    d.trigger.props.value.onClick(event)
+    expect(d.open.value).toBe(false)
+    expect(emit).toHaveBeenCalledTimes(2)
+    expect(emit).toHaveBeenNthCalledWith(1, 'beforeUpdate:open', true, expect.objectContaining({ reason: 'trigger-press', event }))
+    expect(emit).toHaveBeenNthCalledWith(2, 'update:open', true, expect.objectContaining({ reason: 'trigger-press', event }))
+    expect(emit.mock.calls[0][2]).toBe(emit.mock.calls[1][2])
+  })
+
+  it('cancel() in onBeforeUpdate vetoes the change and skips onUpdate', () => {
+    const onUpdate = vi.fn()
+    const d = useDialog({ defaultOpen: true, onBeforeUpdate: (_value, details) => details.cancel(), onUpdate })
+    expect(d.close.props.value.onClick(new MouseEvent('click'))).toBe(false)
+    expect(d.open.value).toBe(true)
+    expect(d.lastChangeDetails.value).toMatchObject({ reason: 'close-press', isCanceled: true })
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(d.trigger.attrs.value['data-state']).toBe('open')
+  })
+})
+
+describe('useDialog — ids', () => {
+  it('derives content/title/description ids from baseId', () => {
+    const d = useDialog({ baseId: 'x' })
+    expect(d.context.contentId).toBe('x-content')
+    expect(d.context.titleId).toBe('x-title')
+    expect(d.context.descriptionId).toBe('x-description')
+    expect(d.content.props.value).toMatchObject({
+      'id': 'x-content',
+      'aria-labelledby': 'x-title',
+      'aria-describedby': 'x-description',
+    })
+    expect(d.title.props.value).toEqual({ id: 'x-title' })
+    expect(d.description.props.value).toEqual({ id: 'x-description' })
+  })
+
+  it('two standalone calls without a baseId get different ids', () => {
+    const a = useDialog()
+    const b = useDialog()
+    expect(a.context.contentId).toMatch(/^reka-dialog-\d+-content$/)
+    expect(b.context.contentId).toMatch(/^reka-dialog-\d+-content$/)
+    expect(a.context.contentId).not.toBe(b.context.contentId)
+    expect(a.title.props.value.id).not.toBe(b.title.props.value.id)
+  })
+})
+
+describe('useDialog — trigger surface', () => {
+  it('exposes aria-haspopup/aria-expanded/aria-controls + onClick with NO data-*', () => {
+    const d = useDialog({ baseId: 'x' })
+    expect(d.trigger.props.value).toMatchObject({ 'aria-haspopup': 'dialog', 'aria-expanded': false })
+    // `aria-controls` only points at the content while open (ported verbatim).
+    expect(d.trigger.props.value['aria-controls']).toBeUndefined()
+    expect(noDataAttrs(d.trigger.props.value)).toBe(true)
+    expect(typeof d.trigger.props.value.onClick).toBe('function')
+  })
+
+  it('onClick toggles with reason trigger-press and the original event', () => {
+    const onUpdate = vi.fn()
+    const d = useDialog({ baseId: 'x', onUpdate })
+    const event = new MouseEvent('click')
+    expect(d.trigger.props.value.onClick(event)).toBe(true)
+    expect(d.open.value).toBe(true)
+    expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-press', event, isCanceled: false }))
+    expect(d.trigger.props.value['aria-expanded']).toBe(true)
+    expect(d.trigger.props.value['aria-controls']).toBe('x-content')
+    d.trigger.props.value.onClick(new MouseEvent('click'))
+    expect(d.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenLastCalledWith(false, expect.objectContaining({ reason: 'trigger-press' }))
+  })
+
+  it('attrs merges props with data-state derived from state', () => {
+    const d = useDialog({ baseId: 'x' })
+    expect(d.trigger.state.value).toEqual({ state: 'closed' })
+    expect(d.trigger.attrs.value).toMatchObject({ 'aria-haspopup': 'dialog', 'data-state': 'closed' })
+    d.openModal()
+    expect(d.trigger.state.value.state).toBe('open')
+    expect(d.trigger.attrs.value['data-state']).toBe('open')
+  })
+})
+
+describe('useDialog — close, content, overlay, title & description surfaces', () => {
+  it('close.props.onClick closes with reason close-press; no data-*', () => {
+    const onUpdate = vi.fn()
+    const d = useDialog({ defaultOpen: true, onUpdate })
+    const event = new MouseEvent('click')
+    expect(d.close.props.value.onClick(event)).toBe(true)
+    expect(d.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenCalledWith(false, expect.objectContaining({ reason: 'close-press', event }))
+    expect(d.lastChangeDetails.value.reason).toBe('close-press')
+    expect(Object.keys(d.close.attrs.value)).toEqual(['onClick'])
+    // Already closed → no-op.
+    expect(d.close.props.value.onClick(new MouseEvent('click'))).toBe(false)
+  })
+
+  it('content.attrs carries id/role="dialog"/aria + data-state', () => {
+    const d = useDialog({ baseId: 'x' })
+    expect(noDataAttrs(d.content.props.value)).toBe(true)
+    expect(d.content.attrs.value).toEqual({
+      'id': 'x-content',
+      'role': 'dialog',
+      'aria-describedby': 'x-description',
+      'aria-labelledby': 'x-title',
+      'data-state': 'closed',
+    })
+    d.openModal()
+    expect(d.content.state.value).toEqual({ state: 'open' })
+    expect(d.content.attrs.value['data-state']).toBe('open')
+  })
+
+  it('overlay is state-only', () => {
+    const d = useDialog({ baseId: 'x' })
+    expect(d.overlay.props.value).toEqual({})
+    expect(d.overlay.attrs.value).toEqual({ 'data-state': 'closed' })
+    d.openModal()
+    expect(d.overlay.attrs.value).toEqual({ 'data-state': 'open' })
+  })
+
+  it('title/description attrs are their ids only', () => {
+    const d = useDialog({ baseId: 'x' })
+    expect(d.title.attrs.value).toEqual({ id: 'x-title' })
+    expect(d.description.attrs.value).toEqual({ id: 'x-description' })
+  })
+})
+
+describe('useDialog — context', () => {
+  it('exposes the frozen DialogRootContext shape', () => {
+    const d = useDialog({ baseId: 'x' })
+    expect(Object.keys(d.context).sort()).toEqual([
+      'contentElement',
+      'contentId',
+      'descriptionId',
+      'modal',
+      'onOpenChange',
+      'onOpenToggle',
+      'open',
+      'openModal',
+      'titleId',
+      'triggerElement',
+      'unmountOnHide',
+    ])
+    expect(d.context.triggerElement.value).toBeUndefined()
+    expect(d.context.contentElement.value).toBeUndefined()
+    expect(d.context.onOpenToggle()).toBe(true)
+    expect(d.context.open.value).toBe(true)
+    expect(d.open.value).toBe(true)
+    expect(d.context.onOpenChange(false, 'escape-key')).toBe(true)
+    expect(d.lastChangeDetails.value.reason).toBe('escape-key')
+  })
+})
+
+describe('useDialog — public export', () => {
+  it('is exported from the package barrel; the surface builders are internal', () => {
+    expect(typeof Reka.useDialog).toBe('function')
+    expect('getDialogTriggerSurface' in Reka).toBe(false)
+    expect('getDialogContentSurface' in Reka).toBe(false)
+  })
+})

--- a/packages/core/src/Dialog/useDialog.test.ts
+++ b/packages/core/src/Dialog/useDialog.test.ts
@@ -1,5 +1,7 @@
+import { fireEvent, render } from '@testing-library/vue'
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { axe } from 'vitest-axe'
+import { defineComponent, ref } from 'vue'
 import * as Reka from '../index'
 import { useDialog } from './useDialog'
 
@@ -201,6 +203,51 @@ describe('useDialog — context', () => {
     expect(d.open.value).toBe(true)
     expect(d.context.onOpenChange(false, 'escape-key')).toBe(true)
     expect(d.lastChangeDetails.value.reason).toBe('escape-key')
+  })
+})
+
+describe('useDialog — rendered surfaces', () => {
+  // A standalone consumer binding the surfaces to plain elements, without the
+  // Presence / FocusScope / DismissableLayer wrappers: the aria wiring alone
+  // has to satisfy axe, open and closed.
+  const Fixture = defineComponent({
+    setup() {
+      const d = useDialog({ defaultOpen: true, baseId: 'fixture' })
+      return { d }
+    },
+    template: `
+      <button v-bind="d.trigger.attrs.value">Open</button>
+      <div v-if="d.open.value" v-bind="d.content.attrs.value">
+        <h2 v-bind="d.title.attrs.value">Title</h2>
+        <p v-bind="d.description.attrs.value">Description</p>
+        <button v-bind="d.close.attrs.value">Close</button>
+      </div>
+    `,
+  })
+
+  it('wires trigger/content/title/description together and passes axe, open and closed', async () => {
+    const { container, getByRole, getByText, queryByRole } = render(Fixture)
+    const trigger = getByText('Open')
+    const dialog = getByRole('dialog')
+    expect(dialog.id).toBe('fixture-content')
+    expect(dialog.getAttribute('aria-labelledby')).toBe(getByText('Title').id)
+    expect(dialog.getAttribute('aria-describedby')).toBe(getByText('Description').id)
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(trigger.getAttribute('aria-controls')).toBe(dialog.id)
+    expect(trigger.getAttribute('data-state')).toBe('open')
+    expect(dialog.getAttribute('data-state')).toBe('open')
+    expect(await axe(container)).toHaveNoViolations()
+
+    await fireEvent.click(getByText('Close'))
+    expect(queryByRole('dialog')).toBeNull()
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(trigger.getAttribute('aria-controls')).toBeNull()
+    expect(trigger.getAttribute('data-state')).toBe('closed')
+    expect(await axe(container)).toHaveNoViolations()
+
+    await fireEvent.click(trigger)
+    expect(getByRole('dialog').id).toBe('fixture-content')
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
   })
 })
 

--- a/packages/core/src/Dialog/useDialog.ts
+++ b/packages/core/src/Dialog/useDialog.ts
@@ -1,0 +1,245 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
+import type { DialogOpenChangeReason, DialogRootContext } from './DialogRoot.vue'
+import type { BaseChangeReason, ChangeEventDetails, DisclosureState, PartSurface } from '@/shared'
+import { computed, ref, toValue } from 'vue'
+import { createPartSurface, disclosureState, useControllableState } from '@/shared'
+
+// =============================================================================
+// Headless composable for the Dialog (overlay) family — issue #2723.
+//
+// Overlay-root contract (validated on Menu): the root renders no attrs, so
+// `useDialog()` returns `{ state, methods, context }` plus the per-part surfaces
+// that begin at Trigger/Content. Every part surface is a PURE derivation from
+// the root context (`get<Part>Surface(context)`), shared by the part SFCs (which
+// inject the context) and by `useDialog()` itself — one derivation, two callers.
+//
+// What a pure composable cannot absorb stays in the SFCs: `Presence` (mount/
+// unmount + `unmountOnHide`), `FocusScope`/`DismissableLayer` (trap + dismiss),
+// `useHideOthers`/`useBodyScrollLock`, the Teleport portal, and the tag-dependent
+// `type` binding.
+// =============================================================================
+
+/** Semantic state of the trigger part; `state` → `data-state="open|closed"`. */
+export type DialogTriggerState = { state: DisclosureState }
+/** Semantic state of the content part; `state` → `data-state="open|closed"`. */
+export type DialogContentState = { state: DisclosureState }
+/** Semantic state of the overlay part; `state` → `data-state="open|closed"`. */
+export type DialogOverlayState = { state: DisclosureState }
+
+/** Standalone `useDialog()` calls without a `baseId` draw `reka-dialog-<n>` from here. */
+let dialogCount = 0
+
+/**
+ * The trigger surface (`aria-haspopup`/`aria-expanded`/`aria-controls` +
+ * `onClick` → `onOpenToggle('trigger-press')`), derived purely from the context.
+ * The `type` binding is tag-dependent and stays in the SFC.
+ */
+export function getDialogTriggerSurface(
+  context: Pick<DialogRootContext, 'open' | 'contentId' | 'onOpenToggle'>,
+): PartSurface<DialogTriggerState> {
+  return createPartSurface<DialogTriggerState>(
+    () => ({
+      'aria-haspopup': 'dialog',
+      'aria-expanded': context.open.value || false,
+      'aria-controls': context.open.value ? context.contentId : undefined,
+      'onClick': (event: MouseEvent) => context.onOpenToggle('trigger-press', event),
+    }),
+    () => ({ state: disclosureState(context.open.value) }),
+  )
+}
+
+/** The close surface: `onClick` → `onOpenChange(false, 'close-press')`; renders no `data-*`. */
+export function getDialogCloseSurface(
+  context: Pick<DialogRootContext, 'onOpenChange'>,
+): PartSurface<Record<string, never>> {
+  return createPartSurface<Record<string, never>>(
+    () => ({
+      onClick: (event: MouseEvent) => context.onOpenChange(false, 'close-press', event),
+    }),
+    () => ({}),
+  )
+}
+
+/**
+ * The content surface (`id`/`role="dialog"`/`aria-labelledby`/`aria-describedby`
+ * + `data-state`), derived purely from the context. The FocusScope/
+ * DismissableLayer wrappers, the `@dismiss` forwarding and the a11y warnings
+ * stay in `DialogContentImpl`.
+ */
+export function getDialogContentSurface(
+  context: Pick<DialogRootContext, 'open' | 'contentId' | 'titleId' | 'descriptionId'>,
+): PartSurface<DialogContentState> {
+  return createPartSurface<DialogContentState>(
+    () => ({
+      'id': context.contentId,
+      'role': 'dialog',
+      'aria-describedby': context.descriptionId,
+      'aria-labelledby': context.titleId,
+    }),
+    () => ({ state: disclosureState(context.open.value) }),
+  )
+}
+
+/** The overlay surface: state only (`data-state`); scroll-lock + pointerdown guard stay in the SFC. */
+export function getDialogOverlaySurface(
+  context: Pick<DialogRootContext, 'open'>,
+): PartSurface<DialogOverlayState> {
+  return createPartSurface<DialogOverlayState>(
+    () => ({}),
+    () => ({ state: disclosureState(context.open.value) }),
+  )
+}
+
+/** The title surface: the `id` the content's `aria-labelledby` points at. */
+export function getDialogTitleSurface(
+  context: Pick<DialogRootContext, 'titleId'>,
+): PartSurface<Record<string, never>> {
+  return createPartSurface<Record<string, never>>(
+    () => ({ id: context.titleId }),
+    () => ({}),
+  )
+}
+
+/** The description surface: the `id` the content's `aria-describedby` points at. */
+export function getDialogDescriptionSurface(
+  context: Pick<DialogRootContext, 'descriptionId'>,
+): PartSurface<Record<string, never>> {
+  return createPartSurface<Record<string, never>>(
+    () => ({ id: context.descriptionId }),
+    () => ({}),
+  )
+}
+
+export interface UseDialogProps {
+  /**
+   * Controlled open state. A getter/ref resolving to `undefined` is uncontrolled;
+   * a writable `Ref` (with no `emit`/`onUpdate`) is written back ("ref-owned").
+   */
+  open?: MaybeRefOrGetter<boolean | undefined>
+  /** Initial open state when uncontrolled. @defaultValue `false` */
+  defaultOpen?: boolean
+  /**
+   * The modality of the dialog. When `true`, interaction with outside elements
+   * is disabled and only dialog content is visible to screen readers.
+   * @defaultValue `true`
+   */
+  modal?: MaybeRefOrGetter<boolean | undefined>
+  /**
+   * When `false`, the content is hidden with CSS instead of unmounted on close.
+   * @defaultValue `true`
+   */
+  unmountOnHide?: MaybeRefOrGetter<boolean | undefined>
+  /**
+   * Base id the content/title/description ids derive from (`<baseId>-content`,
+   * `<baseId>-title`, `<baseId>-description`). Defaults to `reka-dialog-<n>`
+   * from a per-call counter, which is NOT stable across server and client: SSR
+   * consumers must pass a stable `baseId` (the SFC hands its
+   * `useId(undefined, 'reka-dialog')`).
+   */
+  baseId?: string
+  /** Component `emit`; receives `beforeUpdate:open` then `update:open`. */
+  emit?: (event: any, ...args: any[]) => void
+  /** Called before a change commits; `details.cancel()` vetoes it. */
+  onBeforeUpdate?: (value: boolean, details: ChangeEventDetails<DialogOpenChangeReason>) => void
+  /** Called after a change commits. */
+  onUpdate?: (value: boolean, details: ChangeEventDetails<DialogOpenChangeReason>) => void
+}
+
+export interface UseDialogReturn {
+  open: ComputedRef<boolean>
+  modal: ComputedRef<boolean>
+  unmountOnHide: ComputedRef<boolean>
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenChange: (value: boolean, reason?: DialogOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenToggle: (reason?: DialogOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  openModal: (reason?: DialogOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Details of the last change attempt; initially `{ reason: 'none' }`. */
+  lastChangeDetails: Readonly<Ref<ChangeEventDetails<DialogOpenChangeReason>>>
+  isControlled: ComputedRef<boolean>
+  trigger: PartSurface<DialogTriggerState>
+  close: PartSurface<Record<string, never>>
+  content: PartSurface<DialogContentState>
+  overlay: PartSurface<DialogOverlayState>
+  title: PartSurface<Record<string, never>>
+  description: PartSurface<Record<string, never>>
+  /** The `DialogRootContext` value — the SFC provides this verbatim. */
+  context: DialogRootContext
+}
+
+/**
+ * Headless Dialog logic. The `.vue` shells compose this; a standalone consumer
+ * gets the open model (with `beforeUpdate`/`update` details), ids and the
+ * aria/role/`data-state` surfaces, but must still wrap the content in
+ * `Presence` + `FocusScope`/`DismissableLayer` (or their own equivalents) for
+ * mount/unmount, focus trapping and dismissal — those are component families
+ * a pure composable cannot absorb (see the #2723 recipe's "Overlay families").
+ *
+ * SSR-safe (no `document`/`window` at call scope) and callable outside
+ * `setup()` — computed-only; every mount-bound behaviour stays in the SFCs.
+ *
+ * @experimental Signatures may change in 3.x minors.
+ * @lifecycle pure
+ */
+export function useDialog(props: UseDialogProps = {}): UseDialogReturn {
+  const baseId = props.baseId ?? `reka-dialog-${++dialogCount}`
+
+  // Every open/close path (trigger, close button, dismiss) goes through one
+  // `setState` so `beforeUpdate:open` can cancel it and the details reach the consumer.
+  const { state: open, setState, lastChangeDetails, isControlled } = useControllableState<boolean, DialogOpenChangeReason>({
+    prop: props.open,
+    defaultValue: props.defaultOpen ?? false,
+    name: 'open',
+    emit: props.emit,
+    onBeforeUpdate: props.onBeforeUpdate,
+    onUpdate: props.onUpdate,
+  })
+  const modal = computed<boolean>(() => toValue(props.modal) ?? true)
+  const unmountOnHide = computed<boolean>(() => toValue(props.unmountOnHide) ?? true)
+
+  const triggerElement = ref<HTMLElement>()
+  const contentElement = ref<HTMLElement>()
+
+  function onOpenChange(value: boolean, reason?: DialogOpenChangeReason | BaseChangeReason, event?: Event): boolean {
+    return setState(value, reason, event)
+  }
+  function onOpenToggle(reason?: DialogOpenChangeReason | BaseChangeReason, event?: Event): boolean {
+    return setState(!open.value, reason, event)
+  }
+  function openModal(reason?: DialogOpenChangeReason | BaseChangeReason, event?: Event): boolean {
+    return setState(true, reason, event)
+  }
+
+  const context: DialogRootContext = {
+    open,
+    modal: modal as Ref<boolean>,
+    unmountOnHide: unmountOnHide as Ref<boolean>,
+    openModal,
+    onOpenChange,
+    onOpenToggle,
+    triggerElement,
+    contentElement,
+    contentId: `${baseId}-content`,
+    titleId: `${baseId}-title`,
+    descriptionId: `${baseId}-description`,
+  }
+
+  return {
+    open,
+    modal,
+    unmountOnHide,
+    onOpenChange,
+    onOpenToggle,
+    openModal,
+    lastChangeDetails,
+    isControlled,
+    trigger: getDialogTriggerSurface(context),
+    close: getDialogCloseSurface(context),
+    content: getDialogContentSurface(context),
+    overlay: getDialogOverlaySurface(context),
+    title: getDialogTitleSurface(context),
+    description: getDialogDescriptionSurface(context),
+    context,
+  }
+}

--- a/packages/core/src/HoverCard/HoverCard.test.ts
+++ b/packages/core/src/HoverCard/HoverCard.test.ts
@@ -1,8 +1,10 @@
-import type { VueWrapper } from '@vue/test-utils'
-import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
+import { defineComponent, nextTick, ref } from 'vue'
 import { sleep } from '@/test'
+import { HoverCardContent, HoverCardRoot, HoverCardTrigger } from '.'
 import HoverCard from './story/_HoverCard.vue'
 
 describe('given a default HoverCard', () => {
@@ -85,5 +87,236 @@ describe('given a HoverCard with enableTouch', () => {
     await trigger.trigger('pointerup', { pointerType: 'touch' })
     await sleep(150)
     expect(trigger.attributes('data-state')).toBe('closed')
+  })
+})
+
+describe('hoverCardRoot change events (v3 foundation contract)', () => {
+  // No Portal: keeps the content inside `wrapper` so DOM assertions stay local.
+  const HoverCardWithModel = defineComponent({
+    components: { HoverCardRoot, HoverCardTrigger, HoverCardContent },
+    props: {
+      onBeforeUpdateOpen: { type: Function, default: undefined },
+    },
+    setup() {
+      return { open: ref(false) }
+    },
+    template: `
+      <HoverCardRoot v-model:open="open" :open-delay="700" :close-delay="300" @before-update:open="onBeforeUpdateOpen">
+        <HoverCardTrigger href="#">Trigger</HoverCardTrigger>
+        <HoverCardContent>Content</HoverCardContent>
+      </HoverCardRoot>
+    `,
+  })
+
+  const mounted: VueWrapper<any>[] = []
+
+  function mountHoverCard(props: Record<string, unknown> = {}) {
+    const wrapper = mount(HoverCardWithModel, { props, attachTo: document.body })
+    mounted.push(wrapper)
+    const root = wrapper.findComponent(HoverCardRoot)
+    const vm = wrapper.vm as unknown as { open: boolean }
+    const trigger = () => wrapper.find('[data-grace-area-trigger]')
+    // `DismissableLayer` is `as-child`, so its attribute lands on the content element itself.
+    const content = () => wrapper.find('[data-dismissable-layer]')
+    return { wrapper, root, vm, trigger, content }
+  }
+
+  // Hover, then let `openDelay` elapse. Two ticks: one for the open render, one
+  // for the grace-area listeners that register once the content element exists.
+  async function hoverOpen(trigger: () => DOMWrapper<Element>) {
+    await trigger().trigger('pointerenter', { pointerType: 'mouse' })
+    vi.advanceTimersByTime(700)
+    await nextTick()
+    await nextTick()
+  }
+
+  // Leave `element` at (0, 0), then move outside the grace area. Both rects are
+  // empty in jsdom, so any point away from the origin exits the polygon.
+  async function leaveAndExitGraceArea(element: DOMWrapper<Element>) {
+    await element.trigger('pointerleave', { pointerType: 'mouse', clientX: 0, clientY: 0 })
+    document.body.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 100, clientY: 100 }))
+    await nextTick()
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    document.body.innerHTML = ''
+  })
+
+  // Unmount (not just clear the DOM) so each layer leaves the shared
+  // DismissableLayer stack and Escape keeps routing to the right hover card.
+  afterEach(() => {
+    mounted.splice(0).forEach(w => w.unmount())
+    vi.useRealTimers()
+  })
+
+  it('emits beforeUpdate:open then update:open with (value, details) once openDelay elapses after a hover', async () => {
+    const { root, trigger, content } = mountHoverCard()
+    await trigger().trigger('pointerenter', { pointerType: 'mouse' })
+    vi.advanceTimersByTime(699)
+    await nextTick()
+    // Timer has not fired yet: nothing emitted, still closed.
+    expect(root.emitted('beforeUpdate:open')).toBeUndefined()
+    expect(trigger().attributes('data-state')).toBe('closed')
+
+    vi.advanceTimersByTime(1)
+    await nextTick()
+
+    const keys = Object.keys(root.emitted()).filter(k => k.endsWith(':open'))
+    expect(keys).toEqual(['beforeUpdate:open', 'update:open'])
+    const [beforeValue, beforeDetails] = root.emitted('beforeUpdate:open')![0]
+    const [value, details] = root.emitted('update:open')![0]
+    expect(beforeValue).toBe(true)
+    expect(value).toBe(true)
+    expect(beforeDetails).toBe(details)
+    expect(details).toMatchObject({ reason: 'trigger-hover', isCanceled: false })
+    expect(details.event).toBeInstanceOf(Event)
+    expect(details.event.type).toBe('pointerenter')
+    expect(typeof details.cancel).toBe('function')
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(content().exists()).toBe(true)
+  })
+
+  it('reports reason "trigger-leave" after closeDelay when the pointer leaves the trigger and the grace area', async () => {
+    const { root, vm, trigger, content } = mountHoverCard()
+    await hoverOpen(trigger)
+    expect(vm.open).toBe(true)
+
+    await leaveAndExitGraceArea(trigger())
+    // The close is deferred by `closeDelay`.
+    expect(root.emitted('update:open')).toHaveLength(1)
+    vi.advanceTimersByTime(300)
+    // Presence resolves the exit after its own `nextTick`; flush so the content is gone.
+    await flushPromises()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'trigger-leave' })
+    expect(details.event.type).toBe('pointerleave')
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+    expect(content().exists()).toBe(false)
+  })
+
+  it('reports reason "content-leave" when the pointer last left the content before exiting the grace area', async () => {
+    const { root, vm, trigger, content } = mountHoverCard()
+    await hoverOpen(trigger)
+
+    // Trigger -> content (inside the grace area), then content -> away.
+    await trigger().trigger('pointerleave', { pointerType: 'mouse', clientX: 0, clientY: 0 })
+    await content().trigger('pointerenter', { pointerType: 'mouse' })
+    await leaveAndExitGraceArea(content())
+    vi.advanceTimersByTime(300)
+    await flushPromises()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'content-leave' })
+    expect(details.event.type).toBe('pointerleave')
+    expect(vm.open).toBe(false)
+  })
+
+  it('reports reason "trigger-focus" once openDelay elapses after focus', async () => {
+    const { root, vm, trigger } = mountHoverCard()
+    await trigger().trigger('focus')
+    expect(root.emitted('update:open')).toBeUndefined()
+
+    vi.advanceTimersByTime(700)
+    await nextTick()
+
+    const [value, details] = root.emitted('update:open')![0]
+    expect(value).toBe(true)
+    expect(details).toMatchObject({ reason: 'trigger-focus' })
+    expect(details.event).toBeInstanceOf(FocusEvent)
+    expect(vm.open).toBe(true)
+  })
+
+  it('reports reason "trigger-blur" after closeDelay when the trigger blurs', async () => {
+    const { root, vm, trigger } = mountHoverCard()
+    await trigger().trigger('focus')
+    vi.advanceTimersByTime(700)
+    await nextTick()
+
+    await trigger().trigger('blur')
+    vi.advanceTimersByTime(300)
+    await flushPromises()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'trigger-blur' })
+    expect(details.event).toBeInstanceOf(FocusEvent)
+    expect(vm.open).toBe(false)
+  })
+
+  it('reports reason "escape-key" when Escape dismisses the hover card', async () => {
+    const { root, vm, trigger, content } = mountHoverCard()
+    await hoverOpen(trigger)
+    expect(content().exists()).toBe(true)
+
+    await content().trigger('keydown', { key: 'Escape' })
+    await flushPromises()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'escape-key' })
+    expect(details.event).toBeInstanceOf(KeyboardEvent)
+    expect(vm.open).toBe(false)
+    expect(content().exists()).toBe(false)
+  })
+
+  it('details.cancel() in @before-update:open keeps the current state and skips update:open', async () => {
+    const onBeforeUpdateOpen = vi.fn((_value: boolean, details: { cancel: () => void }) => details.cancel())
+    const { root, vm, trigger, content } = mountHoverCard({ onBeforeUpdateOpen })
+    await hoverOpen(trigger)
+
+    expect(onBeforeUpdateOpen).toHaveBeenCalledTimes(1)
+    expect(onBeforeUpdateOpen.mock.calls[0][1]).toMatchObject({ reason: 'trigger-hover', isCanceled: true })
+    expect(root.emitted('update:open')).toBeUndefined()
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+
+    // The open was cancelled: force the model open directly, then cancel a close.
+    vm.open = true
+    await nextTick()
+    await nextTick()
+    expect(content().exists()).toBe(true)
+    onBeforeUpdateOpen.mockClear()
+
+    await trigger().trigger('blur')
+    vi.advanceTimersByTime(300)
+    await flushPromises()
+
+    expect(onBeforeUpdateOpen).toHaveBeenCalledTimes(1)
+    expect(onBeforeUpdateOpen.mock.calls[0][1]).toMatchObject({ reason: 'trigger-blur', isCanceled: true })
+    expect(root.emitted('beforeUpdate:open')).toHaveLength(2)
+    expect(root.emitted('update:open')).toBeUndefined()
+    expect(vm.open).toBe(true)
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(content().exists()).toBe(true)
+  })
+
+  it('v-model:open round-trips through a wrapper component', async () => {
+    const { root, vm, trigger, content } = mountHoverCard()
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+
+    await hoverOpen(trigger)
+    expect(vm.open).toBe(true)
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(content().exists()).toBe(true)
+
+    await trigger().trigger('blur')
+    vi.advanceTimersByTime(300)
+    // Presence resolves the exit after its own `nextTick`; flush so the content is gone.
+    await flushPromises()
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+    expect(content().exists()).toBe(false)
+
+    // Parent-driven change: the prop wins and nothing is emitted for it.
+    vm.open = true
+    await nextTick()
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(root.emitted('update:open')).toHaveLength(2)
   })
 })

--- a/packages/core/src/HoverCard/HoverCardContent.vue
+++ b/packages/core/src/HoverCard/HoverCardContent.vue
@@ -25,6 +25,12 @@ const forwarded = useForwardPropsEmits(props, emits)
 const { forwardRef } = useForwardExpose()
 
 const rootContext = injectHoverCardRootContext()
+
+// Re-entering the content cancels a pending close; with `forceMount` it also
+// opens a closed card after `openDelay`.
+function handlePointerEnter(event: PointerEvent) {
+  rootContext.onOpen('content-hover', event)
+}
 </script>
 
 <template>
@@ -34,7 +40,7 @@ const rootContext = injectHoverCardRootContext()
     <HoverCardContentImpl
       v-bind="forwarded"
       :ref="forwardRef"
-      @pointerenter="excludeTouch(rootContext.onOpen)($event)"
+      @pointerenter="excludeTouch(handlePointerEnter)($event)"
     >
       <slot />
     </HoverCardContentImpl>

--- a/packages/core/src/HoverCard/HoverCardContentImpl.vue
+++ b/packages/core/src/HoverCard/HoverCardContentImpl.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { DismissableLayerEmits } from '@/DismissableLayer'
+import type { DismissableLayerDismissDetails, DismissableLayerEmits } from '@/DismissableLayer'
 import type { PopperContentProps } from '@/Popper'
 import { syncRef } from '@vueuse/shared'
 import { disclosureState, useForwardExpose, useGraceArea } from '@/shared'
@@ -27,9 +27,40 @@ const { isPointerInTransit, onPointerExit } = useGraceArea(rootContext.triggerEl
 
 syncRef(rootContext.isPointerInTransitRef, isPointerInTransit, { direction: 'rtl' })
 
-onPointerExit(() => {
-  rootContext.onClose()
+// Leaving the grace area is the one pointer path that closes an open card (the
+// trigger's own `pointerleave` only cancels a pending open), so the reason is
+// decided here by whichever element the pointer left last.
+let lastPointerLeave: { reason: 'trigger-leave' | 'content-leave', event: PointerEvent } | undefined
+watchEffect((cleanupFn) => {
+  const trigger = rootContext.triggerElement.value
+  const content = contentElement.value
+  if (!trigger || !content)
+    return
+  const handleTriggerLeave = (event: PointerEvent) => {
+    lastPointerLeave = { reason: 'trigger-leave', event }
+  }
+  const handleContentLeave = (event: PointerEvent) => {
+    lastPointerLeave = { reason: 'content-leave', event }
+  }
+  trigger.addEventListener('pointerleave', handleTriggerLeave)
+  content.addEventListener('pointerleave', handleContentLeave)
+  cleanupFn(() => {
+    trigger.removeEventListener('pointerleave', handleTriggerLeave)
+    content.removeEventListener('pointerleave', handleContentLeave)
+  })
 })
+
+onPointerExit(() => {
+  rootContext.onClose(lastPointerLeave?.reason ?? 'content-leave', lastPointerLeave?.event)
+})
+
+function handleDismiss({ reason, event }: DismissableLayerDismissDetails) {
+  // `focusOutside` is prevented below, so the layer never dismisses for it;
+  // the guard keeps `HoverCardOpenChangeReason` honest without a cast.
+  if (reason === 'focus-outside')
+    return
+  rootContext.onDismiss(reason, event)
+}
 
 const containSelection = ref(false)
 
@@ -91,7 +122,7 @@ onUnmounted(() => {
     @escape-key-down="emits('escapeKeyDown', $event)"
     @pointer-down-outside="emits('pointerDownOutside', $event)"
     @focus-outside.prevent="emits('focusOutside', $event)"
-    @dismiss="rootContext.onDismiss"
+    @dismiss="handleDismiss"
   >
     <PopperContent
       v-bind="{ ...forwarded, ...$attrs }"

--- a/packages/core/src/HoverCard/HoverCardRoot.vue
+++ b/packages/core/src/HoverCard/HoverCardRoot.vue
@@ -1,6 +1,19 @@
 <script lang="ts">
-import type { Ref } from 'vue'
-import { createContext, useForwardExpose } from '@/shared'
+import type { ComputedRef, Ref } from 'vue'
+import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
+import { createContext, useControllableState, useForwardExpose } from '@/shared'
+
+/** Why the hover card's `open` state changed (#2828); the `reason` of `ChangeEventDetails`. */
+export type HoverCardOpenChangeReason
+  = | 'trigger-hover'
+    | 'trigger-leave'
+    | 'trigger-focus'
+    | 'trigger-blur'
+    | 'trigger-press'
+    | 'content-hover'
+    | 'content-leave'
+    | 'escape-key'
+    | 'outside-press'
 
 export interface HoverCardRootProps {
   /** The open state of the hover card when it is initially rendered. Use when you do not need to control its open state. */
@@ -15,16 +28,29 @@ export interface HoverCardRootProps {
   enableTouch?: boolean
 }
 export type HoverCardRootEmits = {
+  /** Event handler called before the open state of the hover card changes; `details.cancel()` keeps the current state. */
+  'beforeUpdate:open': [value: boolean, details: ChangeEventDetails<HoverCardOpenChangeReason>]
   /** Event handler called when the open state of the hover card changes. */
-  'update:open': [value: boolean]
+  'update:open': [value: boolean, details: ChangeEventDetails<HoverCardOpenChangeReason>]
 }
 
 export interface HoverCardRootContext {
-  open: Ref<boolean>
-  onOpenChange: (open: boolean) => void
-  onOpen: () => void
-  onClose: () => void
-  onDismiss: () => void
+  open: ComputedRef<boolean>
+  /** Sets `open` immediately. Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenChange: (value: boolean, reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /**
+   * Cancels a pending close and opens after `openDelay`. The change is deferred,
+   * so its outcome is only known when the timer fires; `reason`/`event` travel
+   * with it into `beforeUpdate:open` / `update:open`.
+   */
+  onOpen: (reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => void
+  /**
+   * Cancels a pending open and closes after `closeDelay`, unless text is being
+   * selected or the pointer is down on the content. Deferred like `onOpen`.
+   */
+  onClose: (reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => void
+  /** Cancels a pending open and closes immediately. Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onDismiss: (reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => boolean
   hasSelectionRef: Ref<boolean>
   isPointerDownOnContentRef: Ref<boolean>
   isPointerInTransitRef: Ref<boolean>
@@ -37,7 +63,6 @@ export const [injectHoverCardRootContext, provideHoverCardRootContext]
 </script>
 
 <script setup lang="ts">
-import { useVModel } from '@vueuse/core'
 import { ref, toRefs } from 'vue'
 import { PopperRoot } from '@/Popper'
 
@@ -60,10 +85,17 @@ defineSlots<{
 const { openDelay, closeDelay, enableTouch } = toRefs(props)
 
 useForwardExpose()
-const open = useVModel(props, 'open', emit, {
+
+// Every write to `open` — the delayed hover/focus timers, the touch toggle and
+// dismiss — goes through one `setState`, so `beforeUpdate:open` can cancel any
+// of them and `update:open` always carries the reason (#2828). The timers
+// capture the reason and event of the interaction that started them.
+const { state: open, setState } = useControllableState<boolean, HoverCardOpenChangeReason>({
+  prop: () => props.open,
   defaultValue: props.defaultOpen,
-  passive: (props.open === undefined) as false,
-}) as Ref<boolean>
+  name: 'open',
+  emit,
+})
 
 const openTimerRef = ref(0)
 const closeTimerRef = ref(0)
@@ -72,27 +104,25 @@ const isPointerDownOnContentRef = ref(false)
 const isPointerInTransitRef = ref(false)
 const triggerElement = ref<HTMLElement>()
 
-function handleOpen() {
+function handleOpen(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
   clearTimeout(closeTimerRef.value)
-  openTimerRef.value = window.setTimeout(() => open.value = true, openDelay.value)
+  openTimerRef.value = window.setTimeout(() => setState(true, reason, event), openDelay.value)
 }
 
-function handleClose() {
+function handleClose(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
   clearTimeout(openTimerRef.value)
   if (!hasSelectionRef.value && !isPointerDownOnContentRef.value)
-    closeTimerRef.value = window.setTimeout(() => open.value = false, closeDelay.value)
+    closeTimerRef.value = window.setTimeout(() => setState(false, reason, event), closeDelay.value)
 }
 
-function handleDismiss() {
+function handleDismiss(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
   clearTimeout(openTimerRef.value)
-  open.value = false
+  return setState(false, reason, event)
 }
 
 provideHoverCardRootContext({
   open,
-  onOpenChange(value) {
-    open.value = value
-  },
+  onOpenChange: (value, reason, event) => setState(value, reason, event),
   onOpen: handleOpen,
   onClose: handleClose,
   onDismiss: handleDismiss,

--- a/packages/core/src/HoverCard/HoverCardRoot.vue
+++ b/packages/core/src/HoverCard/HoverCardRoot.vue
@@ -106,13 +106,13 @@ const triggerElement = ref<HTMLElement>()
 
 function handleOpen(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
   clearTimeout(closeTimerRef.value)
-  openTimerRef.value = window.setTimeout(() => setState(true, reason, event), openDelay.value)
+  openTimerRef.value = window.setTimeout(setState, openDelay.value, true, reason, event)
 }
 
 function handleClose(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
   clearTimeout(openTimerRef.value)
   if (!hasSelectionRef.value && !isPointerDownOnContentRef.value)
-    closeTimerRef.value = window.setTimeout(() => setState(false, reason, event), closeDelay.value)
+    closeTimerRef.value = window.setTimeout(setState, closeDelay.value, false, reason, event)
 }
 
 function handleDismiss(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {

--- a/packages/core/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/core/src/HoverCard/HoverCardTrigger.vue
@@ -18,10 +18,16 @@ const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectHoverCardRootContext()
 rootContext.triggerElement = currentElement
 
-function handleLeave() {
+function handlePointerEnter(event: PointerEvent) {
+  rootContext.onOpen('trigger-hover', event)
+}
+
+// While open, leaving the trigger is handled by the grace area (see
+// HoverCardContentImpl): this only cancels a pending delayed open.
+function handleLeave(event: PointerEvent) {
   setTimeout(() => {
     if (!rootContext.isPointerInTransitRef.value && !rootContext.open.value) {
-      rootContext.onClose()
+      rootContext.onClose('trigger-leave', event)
     }
   }, 0)
 }
@@ -31,9 +37,9 @@ function handleTouch(event: PointerEvent) {
     return
 
   if (rootContext.open.value)
-    rootContext.onDismiss()
+    rootContext.onDismiss('trigger-press', event)
   else
-    rootContext.onOpenChange(true)
+    rootContext.onOpenChange(true, 'trigger-press', event)
 }
 </script>
 
@@ -48,11 +54,11 @@ function handleTouch(event: PointerEvent) {
       :as="as"
       :data-state="disclosureState(rootContext.open.value)"
       data-grace-area-trigger
-      @pointerenter="excludeTouch(rootContext.onOpen)($event)"
+      @pointerenter="excludeTouch(handlePointerEnter)($event)"
       @pointerleave="excludeTouch(handleLeave)($event)"
       @pointerup="handleTouch"
-      @focus="rootContext.onOpen()"
-      @blur="rootContext.onClose()"
+      @focus="rootContext.onOpen('trigger-focus', $event)"
+      @blur="rootContext.onClose('trigger-blur', $event)"
     >
       <slot />
     </Primitive>

--- a/packages/core/src/HoverCard/index.ts
+++ b/packages/core/src/HoverCard/index.ts
@@ -11,6 +11,7 @@ export {
   type HoverCardPortalProps,
 } from './HoverCardPortal.vue'
 export {
+  type HoverCardOpenChangeReason,
   default as HoverCardRoot,
   type HoverCardRootEmits,
   type HoverCardRootProps,

--- a/packages/core/src/HoverCard/utils.ts
+++ b/packages/core/src/HoverCard/utils.ts
@@ -1,5 +1,5 @@
-export function excludeTouch(eventHandler: () => void) {
-  return (event: PointerEvent) => event.pointerType === 'touch' ? undefined : eventHandler()
+export function excludeTouch(eventHandler: (event: PointerEvent) => void) {
+  return (event: PointerEvent) => event.pointerType === 'touch' ? undefined : eventHandler(event)
 }
 
 /**

--- a/packages/core/src/Popover/PopoverClose.vue
+++ b/packages/core/src/Popover/PopoverClose.vue
@@ -7,9 +7,8 @@ export interface PopoverCloseProps extends PrimitiveProps {}
 
 <script setup lang="ts">
 import { Primitive } from '@/Primitive'
-import {
-  injectPopoverRootContext,
-} from './PopoverRoot.vue'
+import { injectPopoverRootContext } from './PopoverRoot.vue'
+import { getPopoverCloseSurface } from './usePopover'
 
 const props = withDefaults(defineProps<PopoverCloseProps>(), {
   as: 'button',
@@ -17,14 +16,19 @@ const props = withDefaults(defineProps<PopoverCloseProps>(), {
 
 useForwardExpose()
 const rootContext = injectPopoverRootContext()
+
+// The closing `onClick` (reason `close-press`) comes from the shared surface
+// builder (single source with `usePopover()`); the tag-dependent `type` stays
+// in the SFC and is bound after the surface so a non-button `as` drops it.
+const close = getPopoverCloseSurface(rootContext)
 </script>
 
 <template>
   <Primitive
-    :type="as === 'button' ? 'button' : undefined"
     :as="as"
     :as-child="props.asChild"
-    @click="rootContext.onOpenChange(false, 'close-press', $event)"
+    v-bind="close.attrs.value"
+    :type="as === 'button' ? 'button' : undefined"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/Popover/PopoverContent.vue
+++ b/packages/core/src/Popover/PopoverContent.vue
@@ -17,7 +17,7 @@ export interface PopoverContentProps extends PopoverContentImplProps {
 
 <script setup lang="ts">
 import { Presence } from '@/Presence'
-import { useForwardExpose, useForwardPropsEmits, useId } from '@/shared'
+import { useForwardExpose, useForwardPropsEmits } from '@/shared'
 import PopoverContentModal from './PopoverContentModal.vue'
 import PopoverContentNonModal from './PopoverContentNonModal.vue'
 import { injectPopoverRootContext } from './PopoverRoot.vue'
@@ -29,8 +29,6 @@ const rootContext = injectPopoverRootContext()
 
 const forwarded = useForwardPropsEmits(props, emits)
 const { forwardRef } = useForwardExpose()
-
-rootContext.contentId ||= useId(undefined, 'reka-popover-content')
 </script>
 
 <template>

--- a/packages/core/src/Popover/PopoverContentImpl.vue
+++ b/packages/core/src/Popover/PopoverContentImpl.vue
@@ -32,11 +32,13 @@ interface PopoverContentImplPrivateProps extends PopoverContentImplProps {
 </script>
 
 <script setup lang="ts">
+import { mergeProps } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { FocusScope } from '@/FocusScope'
 import { PopperContent } from '@/Popper'
-import { disclosureState, useFocusGuards, useForwardExpose, useForwardProps } from '@/shared'
+import { useFocusGuards, useForwardExpose, useForwardProps } from '@/shared'
 import { injectPopoverRootContext } from './PopoverRoot.vue'
+import { getPopoverContentSurface } from './usePopover'
 
 const props = defineProps<PopoverContentImplPrivateProps>()
 const emits = defineEmits<PopoverContentImplEmits>()
@@ -46,6 +48,12 @@ const { forwardRef, currentElement } = useForwardExpose()
 
 const rootContext = injectPopoverRootContext()
 useFocusGuards(currentElement)
+
+// id/role/aria-labelledby/data-state come from the shared surface builder
+// (single source with `usePopover()`); FocusScope, DismissableLayer (which
+// hands the dismiss reason + event to `onOpenChange`), PopperContent and the
+// `--reka-popover-*` CSS variables stay in the SFC.
+const content = getPopoverContentSurface(rootContext)
 </script>
 
 <template>
@@ -66,11 +74,8 @@ useFocusGuards(currentElement)
       @dismiss="(details) => rootContext.onOpenChange(false, details.reason, details.event)"
     >
       <PopperContent
-        v-bind="forwarded"
-        :id="rootContext.contentId"
         :ref="forwardRef"
-        :data-state="disclosureState(rootContext.open.value)"
-        :aria-labelledby="rootContext.triggerId"
+        v-bind="mergeProps(forwarded, content.attrs.value)"
         :style="{
           '--reka-popover-content-transform-origin':
             'var(--reka-popper-transform-origin)',
@@ -81,7 +86,6 @@ useFocusGuards(currentElement)
           '--reka-popover-trigger-width': 'var(--reka-popper-anchor-width)',
           '--reka-popover-trigger-height': 'var(--reka-popper-anchor-height)',
         }"
-        role="dialog"
       >
         <slot />
       </PopperContent>

--- a/packages/core/src/Popover/PopoverRoot.vue
+++ b/packages/core/src/Popover/PopoverRoot.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ComputedRef, Ref } from 'vue'
 import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
-import { createContext, useControllableState } from '@/shared'
+import { createContext, useId } from '@/shared'
 
 /** Why the popover's `open` state changed (#2828); the `reason` of `ChangeEventDetails`. */
 export type PopoverOpenChangeReason
@@ -56,8 +56,8 @@ export const [injectPopoverRootContext, providePopoverRootContext]
 </script>
 
 <script setup lang="ts">
-import { ref, toRefs } from 'vue'
 import { PopperRoot } from '@/Popper'
+import { usePopover } from './usePopover'
 
 const props = withDefaults(defineProps<PopoverRootProps>(), {
   defaultOpen: false,
@@ -75,38 +75,26 @@ defineSlots<{
   }) => any
 }>()
 
-const { modal } = toRefs(props)
-
-// Every write to `open` — trigger, close button, dismiss, slot `close` — goes
-// through one `setState`, so `beforeUpdate:open` can cancel any of them and
-// `update:open` always carries the reason (#2828).
-const { state: open, setState } = useControllableState<boolean, PopoverOpenChangeReason>({
-  prop: () => props.open,
-  defaultValue: props.defaultOpen,
-  name: 'open',
+// Controlled/uncontrolled `open` + the `beforeUpdate:` / `update:` emits live in
+// the composable's `useControllableState` (`open === undefined` → uncontrolled).
+// `useId` (ConfigProvider/SSR-aware) stays in the shell: the trigger/content ids
+// derive from this base inside the composable.
+const { open, onOpenChange, context } = usePopover({
+  open: () => props.open,
+  defaultOpen: props.defaultOpen,
+  modal: () => props.modal,
+  baseId: useId(undefined, 'reka-popover'),
   emit,
 })
 
-const triggerElement = ref<HTMLElement>()
-const hasCustomAnchor = ref(false)
-
-providePopoverRootContext({
-  contentId: '',
-  triggerId: '',
-  modal,
-  open,
-  onOpenChange: (value, reason, event) => setState(value, reason, event),
-  onOpenToggle: (reason, event) => setState(!open.value, reason, event),
-  triggerElement,
-  hasCustomAnchor,
-})
+providePopoverRootContext(context)
 </script>
 
 <template>
   <PopperRoot>
     <slot
       :open="open"
-      :close="() => setState(false)"
+      :close="() => onOpenChange(false)"
     />
   </PopperRoot>
 </template>

--- a/packages/core/src/Popover/PopoverTrigger.vue
+++ b/packages/core/src/Popover/PopoverTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
-import { disclosureState, useForwardExpose, useId } from '@/shared'
+import { useForwardExpose } from '@/shared'
 
 export interface PopoverTriggerProps extends PrimitiveProps {}
 </script>
@@ -10,6 +10,7 @@ import { onMounted } from 'vue'
 import { PopperAnchor } from '@/Popper'
 import { Primitive } from '@/Primitive'
 import { injectPopoverRootContext } from './PopoverRoot.vue'
+import { getPopoverTriggerSurface } from './usePopover'
 
 const props = withDefaults(defineProps<PopoverTriggerProps>(), {
   as: 'button',
@@ -19,7 +20,15 @@ const rootContext = injectPopoverRootContext()
 
 const { forwardRef, currentElement: triggerElement } = useForwardExpose()
 
-rootContext.triggerId ||= useId(undefined, 'reka-popover-trigger')
+// id/aria/data-state + the toggling `onClick` all come from the shared surface
+// builder (single source with `usePopover()`); the PopperAnchor wrapper (skipped
+// when a `PopoverAnchor` is present), the element registration and the
+// tag-dependent `type` stay in the SFC. Listener order is unchanged: `$attrs`
+// fall through the as-child wrapper and `Slot` merges them BEFORE the inner
+// element's own props, so a consumer `@click` still runs before the surface's
+// `onClick`.
+const trigger = getPopoverTriggerSurface(rootContext)
+
 onMounted(() => {
   rootContext.triggerElement.value = triggerElement.value
 })
@@ -31,16 +40,11 @@ onMounted(() => {
     as-child
   >
     <Primitive
-      :id="rootContext.triggerId"
       :ref="forwardRef"
-      :type="as === 'button' ? 'button' : undefined"
-      aria-haspopup="dialog"
-      :aria-expanded="rootContext.open.value"
-      :aria-controls="rootContext.contentId"
-      :data-state="disclosureState(rootContext.open.value)"
       :as="as"
       :as-child="props.asChild"
-      @click="rootContext.onOpenToggle('trigger-press', $event)"
+      v-bind="trigger.attrs.value"
+      :type="as === 'button' ? 'button' : undefined"
     >
       <slot />
     </Primitive>

--- a/packages/core/src/Popover/index.ts
+++ b/packages/core/src/Popover/index.ts
@@ -30,3 +30,10 @@ export {
   default as PopoverTrigger,
   type PopoverTriggerProps,
 } from './PopoverTrigger.vue'
+export {
+  type PopoverContentState,
+  type PopoverTriggerState,
+  usePopover,
+  type UsePopoverProps,
+  type UsePopoverReturn,
+} from './usePopover'

--- a/packages/core/src/Popover/usePopover.test.ts
+++ b/packages/core/src/Popover/usePopover.test.ts
@@ -1,5 +1,7 @@
+import { fireEvent, render } from '@testing-library/vue'
 import { describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { axe } from 'vitest-axe'
+import { defineComponent, ref } from 'vue'
 import * as Reka from '../index'
 import { usePopover } from './usePopover'
 
@@ -190,6 +192,50 @@ describe('usePopover — context', () => {
     const event = new KeyboardEvent('keydown', { key: 'Escape' })
     expect(p.context.onOpenChange(false, 'escape-key', event)).toBe(true)
     expect(p.lastChangeDetails.value).toMatchObject({ reason: 'escape-key', event })
+  })
+})
+
+describe('usePopover — rendered surfaces', () => {
+  // A standalone consumer binding the surfaces to plain elements, without the
+  // Popper / Presence / FocusScope / DismissableLayer wrappers: the aria wiring
+  // alone has to satisfy axe, closed and open.
+  const Fixture = defineComponent({
+    setup() {
+      const p = usePopover({ baseId: 'fixture' })
+      return { p }
+    },
+    template: `
+      <button v-bind="p.trigger.attrs.value">Toggle</button>
+      <div v-if="p.open.value" v-bind="p.content.attrs.value">
+        <p>Body</p>
+        <button v-bind="p.close.attrs.value">Close</button>
+      </div>
+    `,
+  })
+
+  it('wires trigger and content together and passes axe, closed and open', async () => {
+    const { container, getByRole, getByText, queryByRole } = render(Fixture)
+    const trigger = getByText('Toggle')
+    expect(trigger.id).toBe('fixture-trigger')
+    expect(trigger.getAttribute('aria-haspopup')).toBe('dialog')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(trigger.getAttribute('aria-controls')).toBe('fixture-content')
+    expect(trigger.getAttribute('data-state')).toBe('closed')
+    expect(queryByRole('dialog')).toBeNull()
+    expect(await axe(container)).toHaveNoViolations()
+
+    await fireEvent.click(trigger)
+    const dialog = getByRole('dialog')
+    expect(dialog.id).toBe('fixture-content')
+    expect(dialog.getAttribute('aria-labelledby')).toBe(trigger.id)
+    expect(dialog.getAttribute('data-state')).toBe('open')
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(trigger.getAttribute('data-state')).toBe('open')
+    expect(await axe(container)).toHaveNoViolations()
+
+    await fireEvent.click(getByText('Close'))
+    expect(queryByRole('dialog')).toBeNull()
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
   })
 })
 

--- a/packages/core/src/Popover/usePopover.test.ts
+++ b/packages/core/src/Popover/usePopover.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import * as Reka from '../index'
+import { usePopover } from './usePopover'
+
+function noDataAttrs(props: Record<string, any>) {
+  return Object.keys(props).every(k => !k.startsWith('data-'))
+}
+
+describe('usePopover — state', () => {
+  it('defaults to closed, non-modal and uncontrolled', () => {
+    const p = usePopover({ baseId: 'x' })
+    expect(p.open.value).toBe(false)
+    expect(p.context.modal.value).toBe(false)
+    expect(p.isControlled.value).toBe(false)
+    expect(p.lastChangeDetails.value.reason).toBe('none')
+  })
+
+  it('honours defaultOpen and a reactive modal getter', () => {
+    const modal = ref(false)
+    const p = usePopover({ defaultOpen: true, modal: () => modal.value, baseId: 'x' })
+    expect(p.open.value).toBe(true)
+    expect(p.context.modal.value).toBe(false)
+    modal.value = true
+    expect(p.context.modal.value).toBe(true)
+  })
+
+  it('onOpenChange() sets the state and reports imperative-action by default', () => {
+    const p = usePopover({ baseId: 'x' })
+    expect(p.onOpenChange(true)).toBe(true)
+    expect(p.open.value).toBe(true)
+    expect(p.lastChangeDetails.value.reason).toBe('imperative-action')
+    // Unchanged → false, no new details.
+    expect(p.onOpenChange(true)).toBe(false)
+    expect(p.onOpenChange(false)).toBe(true)
+    expect(p.open.value).toBe(false)
+  })
+
+  it('onOpenToggle() flips the state and carries reason + event', () => {
+    const onUpdate = vi.fn()
+    const p = usePopover({ baseId: 'x', onUpdate })
+    const event = new MouseEvent('click')
+    expect(p.onOpenToggle('trigger-press', event)).toBe(true)
+    expect(p.open.value).toBe(true)
+    expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-press', event, isCanceled: false }))
+    p.onOpenToggle()
+    expect(p.open.value).toBe(false)
+    expect(p.lastChangeDetails.value.reason).toBe('imperative-action')
+  })
+
+  it('ref-owned mode writes through the passed ref', () => {
+    const open = ref(false)
+    const p = usePopover({ open, baseId: 'x' })
+    expect(p.isControlled.value).toBe(true)
+    p.onOpenToggle()
+    expect(open.value).toBe(true)
+    expect(p.open.value).toBe(true)
+  })
+
+  it('controlled getter + emit: emits beforeUpdate/update with details and does not write locally', () => {
+    const emit = vi.fn()
+    const p = usePopover({ open: () => false, emit, baseId: 'x' })
+    expect(p.isControlled.value).toBe(true)
+    p.onOpenChange(true, 'trigger-press')
+    expect(p.open.value).toBe(false)
+    expect(emit).toHaveBeenNthCalledWith(1, 'beforeUpdate:open', true, expect.objectContaining({ reason: 'trigger-press' }))
+    expect(emit).toHaveBeenNthCalledWith(2, 'update:open', true, expect.objectContaining({ reason: 'trigger-press' }))
+    const [, , beforeDetails] = emit.mock.calls[0]
+    const [, , details] = emit.mock.calls[1]
+    expect(beforeDetails).toBe(details)
+  })
+
+  it('cancel() in onBeforeUpdate vetoes the change', () => {
+    const onUpdate = vi.fn()
+    const p = usePopover({ baseId: 'x', onBeforeUpdate: (_value, details) => details.cancel(), onUpdate })
+    expect(p.onOpenChange(true, 'trigger-press')).toBe(false)
+    expect(p.open.value).toBe(false)
+    expect(p.lastChangeDetails.value).toMatchObject({ reason: 'trigger-press', isCanceled: true })
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('usePopover — ids', () => {
+  it('derives trigger/content ids from baseId', () => {
+    const p = usePopover({ baseId: 'x' })
+    expect(p.context.triggerId).toBe('x-trigger')
+    expect(p.context.contentId).toBe('x-content')
+    expect(p.trigger.props.value.id).toBe('x-trigger')
+    expect(p.trigger.props.value['aria-controls']).toBe('x-content')
+    expect(p.content.props.value.id).toBe('x-content')
+    expect(p.content.props.value['aria-labelledby']).toBe('x-trigger')
+  })
+
+  it('two standalone calls without a baseId get different ids', () => {
+    const a = usePopover()
+    const b = usePopover()
+    expect(a.context.triggerId).toMatch(/^reka-popover-\d+-trigger$/)
+    expect(b.context.contentId).toMatch(/^reka-popover-\d+-content$/)
+    expect(a.context.triggerId).not.toBe(b.context.triggerId)
+    expect(a.context.contentId).not.toBe(b.context.contentId)
+  })
+})
+
+describe('usePopover — trigger surface', () => {
+  it('props expose id/aria/handlers but NO data-* (and no tag-dependent type)', () => {
+    const p = usePopover({ baseId: 'x' })
+    expect(p.trigger.props.value).toMatchObject({
+      'id': 'x-trigger',
+      'aria-haspopup': 'dialog',
+      'aria-expanded': false,
+      'aria-controls': 'x-content',
+    })
+    expect(p.trigger.props.value.type).toBeUndefined()
+    expect(noDataAttrs(p.trigger.props.value)).toBe(true)
+    expect(typeof p.trigger.props.value.onClick).toBe('function')
+  })
+
+  it('attrs merge props with the data-state derived from state', () => {
+    const p = usePopover({ baseId: 'x' })
+    expect(p.trigger.state.value).toEqual({ state: 'closed' })
+    expect(p.trigger.attrs.value).toMatchObject({ 'aria-expanded': false, 'data-state': 'closed' })
+    p.onOpenChange(true)
+    expect(p.trigger.state.value).toEqual({ state: 'open' })
+    expect(p.trigger.attrs.value).toMatchObject({ 'aria-expanded': true, 'data-state': 'open' })
+  })
+
+  it('onClick toggles with reason trigger-press and the original event', () => {
+    const onUpdate = vi.fn()
+    const p = usePopover({ baseId: 'x', onUpdate })
+    const event = new MouseEvent('click')
+    p.trigger.props.value.onClick(event)
+    expect(p.open.value).toBe(true)
+    expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-press', event }))
+    p.trigger.props.value.onClick(new MouseEvent('click'))
+    expect(p.open.value).toBe(false)
+    expect(p.lastChangeDetails.value.reason).toBe('trigger-press')
+  })
+})
+
+describe('usePopover — close surface', () => {
+  it('renders only the closing handler and no state', () => {
+    const p = usePopover({ baseId: 'x' })
+    expect(p.close.props.value.type).toBeUndefined()
+    expect(typeof p.close.props.value.onClick).toBe('function')
+    expect(p.close.state.value).toEqual({})
+    expect(noDataAttrs(p.close.attrs.value)).toBe(true)
+  })
+
+  it('onClick closes with reason close-press; a no-op when already closed', () => {
+    const onUpdate = vi.fn()
+    const p = usePopover({ defaultOpen: true, baseId: 'x', onUpdate })
+    const event = new MouseEvent('click')
+    p.close.props.value.onClick(event)
+    expect(p.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenCalledWith(false, expect.objectContaining({ reason: 'close-press', event }))
+    p.close.props.value.onClick(new MouseEvent('click'))
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('usePopover — content surface', () => {
+  it('props expose id/role/aria-labelledby with NO data-*; attrs add data-state', () => {
+    const p = usePopover({ baseId: 'x' })
+    expect(p.content.props.value).toEqual({
+      'id': 'x-content',
+      'role': 'dialog',
+      'aria-labelledby': 'x-trigger',
+    })
+    expect(noDataAttrs(p.content.props.value)).toBe(true)
+    expect(p.content.state.value).toEqual({ state: 'closed' })
+    expect(p.content.attrs.value['data-state']).toBe('closed')
+    p.onOpenChange(true)
+    expect(p.content.attrs.value['data-state']).toBe('open')
+  })
+})
+
+describe('usePopover — context', () => {
+  it('exposes the frozen-shape PopoverRootContext', () => {
+    const p = usePopover({ baseId: 'x' })
+    expect(p.context.open).toBe(p.open)
+    expect(p.context.onOpenChange).toBe(p.onOpenChange)
+    expect(p.context.onOpenToggle).toBe(p.onOpenToggle)
+    expect(p.context.triggerElement.value).toBeUndefined()
+    expect(p.context.hasCustomAnchor.value).toBe(false)
+    expect(p.context.onOpenToggle('trigger-press')).toBe(true)
+    expect(p.context.open.value).toBe(true)
+    // Unchanged → false, so a caller can tell "nothing to do" from "cancelled".
+    expect(p.context.onOpenChange(true)).toBe(false)
+    // Dismissal reasons arrive through `onOpenChange` from the layer the consumer composes.
+    const event = new KeyboardEvent('keydown', { key: 'Escape' })
+    expect(p.context.onOpenChange(false, 'escape-key', event)).toBe(true)
+    expect(p.lastChangeDetails.value).toMatchObject({ reason: 'escape-key', event })
+  })
+})
+
+describe('usePopover — public export', () => {
+  it('is exported from the package barrel; the surface builders are internal', () => {
+    expect(typeof Reka.usePopover).toBe('function')
+    expect('getPopoverTriggerSurface' in Reka).toBe(false)
+    expect('getPopoverCloseSurface' in Reka).toBe(false)
+    expect('getPopoverContentSurface' in Reka).toBe(false)
+  })
+})

--- a/packages/core/src/Popover/usePopover.ts
+++ b/packages/core/src/Popover/usePopover.ts
@@ -1,0 +1,186 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
+import type { PopoverOpenChangeReason, PopoverRootContext } from './PopoverRoot.vue'
+import type { BaseChangeReason, ChangeEventDetails, DisclosureState, PartSurface } from '@/shared'
+import { computed, ref, toValue } from 'vue'
+import { createPartSurface, disclosureState, useControllableState } from '@/shared'
+
+// =============================================================================
+// Headless composable for the Popover (overlay) family — issue #2723.
+//
+// Follows the overlay contract validated on Menu: the root renders NO attrs
+// (`PopoverRoot` is `<PopperRoot><slot/></PopperRoot>`), so `usePopover()`
+// returns state + the context object the SFC provides, and the surfaces begin
+// at Trigger / Close / Content. Unlike Menu's per-item factories, every Popover
+// part derives purely from the root context, so the builders are idempotent
+// `get<Part>Surface(context)` derivations — the SFCs (which inject the context)
+// and `usePopover()` share ONE derivation each. Positioning (`PopperAnchor` /
+// `PopperContent`), `Presence`, `FocusScope`, `DismissableLayer`, the portal and
+// the modal side-effects (`useHideOthers` / `useBodyScrollLock`) stay wrappers.
+// =============================================================================
+
+export type PopoverTriggerState = { state: DisclosureState }
+export type PopoverContentState = { state: DisclosureState }
+
+/** Standalone `usePopover()` calls without a `baseId` draw `reka-popover-<n>` from here. */
+let popoverCount = 0
+
+/**
+ * The trigger surface, derived purely from the root context — the single
+ * derivation shared by `usePopover().trigger` and `PopoverTrigger.vue`.
+ * The tag-dependent `type` binding stays in the SFC.
+ */
+export function getPopoverTriggerSurface(context: PopoverRootContext): PartSurface<PopoverTriggerState> {
+  return createPartSurface<PopoverTriggerState>(
+    () => ({
+      'id': context.triggerId,
+      'aria-haspopup': 'dialog',
+      'aria-expanded': context.open.value,
+      'aria-controls': context.contentId,
+      'onClick': (event: MouseEvent) => context.onOpenToggle('trigger-press', event),
+    }),
+    () => ({ state: disclosureState(context.open.value) }),
+  )
+}
+
+/**
+ * The close-button surface, derived purely from the root context — shared by
+ * `usePopover().close` and `PopoverClose.vue`. Renders no semantic state.
+ */
+export function getPopoverCloseSurface(context: PopoverRootContext): PartSurface<Record<string, never>> {
+  return createPartSurface<Record<string, never>>(
+    () => ({
+      onClick: (event: MouseEvent) => context.onOpenChange(false, 'close-press', event),
+    }),
+    () => ({}),
+  )
+}
+
+/**
+ * The `role="dialog"` content surface, derived purely from the root context —
+ * shared by `usePopover().content` and `PopoverContentImpl.vue`. Only the
+ * id/role/aria bindings live here; the `PopperContent` positioning props, the
+ * `--reka-popover-*` CSS variables and the FocusScope/DismissableLayer wrappers
+ * stay in the SFC.
+ */
+export function getPopoverContentSurface(context: PopoverRootContext): PartSurface<PopoverContentState> {
+  return createPartSurface<PopoverContentState>(
+    () => ({
+      'id': context.contentId,
+      'role': 'dialog',
+      'aria-labelledby': context.triggerId,
+    }),
+    () => ({ state: disclosureState(context.open.value) }),
+  )
+}
+
+export interface UsePopoverProps {
+  /**
+   * Controlled open state. A getter/ref resolving to `undefined` is uncontrolled;
+   * a writable `Ref` (with no `emit`/`onUpdate`) is written back ("ref-owned").
+   */
+  open?: MaybeRefOrGetter<boolean | undefined>
+  /** Initial open state when uncontrolled. @defaultValue `false` */
+  defaultOpen?: boolean
+  /**
+   * When `true`, interaction with outside elements is disabled and only the
+   * popover content is visible to screen readers. @defaultValue `false`
+   */
+  modal?: MaybeRefOrGetter<boolean | undefined>
+  /**
+   * Base id the trigger/content ids derive from (`<baseId>-trigger`,
+   * `<baseId>-content`). Defaults to `reka-popover-<n>` from a per-call counter,
+   * which is NOT stable across server and client: SSR consumers must pass a
+   * stable `baseId` (the SFC hands its `useId(undefined, 'reka-popover')`).
+   */
+  baseId?: string
+  /** Component `emit`; receives `beforeUpdate:open` then `update:open`. */
+  emit?: (event: any, ...args: any[]) => void
+  /** Called before a change commits; `details.cancel()` vetoes it. */
+  onBeforeUpdate?: (value: boolean, details: ChangeEventDetails<PopoverOpenChangeReason>) => void
+  /** Called after a change commits. */
+  onUpdate?: (value: boolean, details: ChangeEventDetails<PopoverOpenChangeReason>) => void
+}
+
+export interface UsePopoverReturn {
+  open: ComputedRef<boolean>
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenChange: (value: boolean, reason?: PopoverOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenToggle: (reason?: PopoverOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Details of the last change attempt; initially `{ reason: 'none' }`. */
+  lastChangeDetails: Readonly<Ref<ChangeEventDetails<PopoverOpenChangeReason>>>
+  isControlled: ComputedRef<boolean>
+  /** `id` / `aria-haspopup` / `aria-expanded` / `aria-controls` + the toggling `onClick`. */
+  trigger: PartSurface<PopoverTriggerState>
+  /** The closing `onClick`; renders no `data-*`. The tag-dependent `type` stays in the SFC. */
+  close: PartSurface<Record<string, never>>
+  /** `id` / `role="dialog"` / `aria-labelledby`. */
+  content: PartSurface<PopoverContentState>
+  /** The `PopoverRootContext` value — the SFC provides this verbatim. */
+  context: PopoverRootContext
+}
+
+/**
+ * Headless Popover logic. The `.vue` shells compose this; a standalone consumer
+ * gets the open model, ids and the trigger/close/content aria + handlers, but
+ * must still wrap the content in `Presence`, `FocusScope`, `DismissableLayer`
+ * and `PopperContent` (and the trigger in `PopperAnchor`) — those are component
+ * families a pure composable cannot absorb (see the #2723 recipe's "Overlay
+ * families"). Dismissal reasons (`escape-key`, `outside-press`, `focus-outside`)
+ * therefore arrive through `onOpenChange(false, reason, event)` from whatever
+ * layer the consumer composes.
+ *
+ * SSR-safe (no `document`/`window` at call scope) and callable outside `setup()`
+ * (computed-only — the trigger element registration stays in the SFC).
+ *
+ * @experimental Signatures may change in 3.x minors.
+ * @lifecycle pure
+ */
+export function usePopover(props: UsePopoverProps = {}): UsePopoverReturn {
+  const baseId = props.baseId ?? `reka-popover-${++popoverCount}`
+
+  const { state: open, setState, lastChangeDetails, isControlled } = useControllableState<boolean, PopoverOpenChangeReason>({
+    prop: props.open,
+    defaultValue: props.defaultOpen ?? false,
+    name: 'open',
+    emit: props.emit,
+    onBeforeUpdate: props.onBeforeUpdate,
+    onUpdate: props.onUpdate,
+  })
+  const modal = computed<boolean>(() => toValue(props.modal) ?? false)
+  const triggerElement = ref<HTMLElement>()
+  const hasCustomAnchor = ref(false)
+
+  // Every write to `open` — trigger, close button, dismiss, slot `close` — goes
+  // through one `setState`, so `beforeUpdate:open` can cancel any of them and
+  // `update:open` always carries the reason (#2828).
+  function onOpenChange(value: boolean, reason?: PopoverOpenChangeReason | BaseChangeReason, event?: Event): boolean {
+    return setState(value, reason, event)
+  }
+  function onOpenToggle(reason?: PopoverOpenChangeReason | BaseChangeReason, event?: Event): boolean {
+    return setState(!open.value, reason, event)
+  }
+
+  const context: PopoverRootContext = {
+    triggerElement,
+    triggerId: `${baseId}-trigger`,
+    contentId: `${baseId}-content`,
+    open,
+    modal: modal as Ref<boolean>,
+    onOpenChange,
+    onOpenToggle,
+    hasCustomAnchor,
+  }
+
+  return {
+    open,
+    onOpenChange,
+    onOpenToggle,
+    lastChangeDetails,
+    isControlled,
+    trigger: getPopoverTriggerSurface(context),
+    close: getPopoverCloseSurface(context),
+    content: getPopoverContentSurface(context),
+    context,
+  }
+}

--- a/packages/core/src/Tooltip/Tooltip.test.ts
+++ b/packages/core/src/Tooltip/Tooltip.test.ts
@@ -373,6 +373,25 @@ describe('tooltipRoot change events (v3 foundation contract)', () => {
     expect(content().exists()).toBe(true)
   })
 
+  it('forgets a delayed open once closed: a later parent-driven open carries no data-delayed', async () => {
+    const { vm, trigger } = mountTooltip()
+    await trigger().trigger('pointermove', { pointerType: 'mouse' })
+    vi.advanceTimersByTime(700)
+    await nextTick()
+    await nextTick()
+    expect(trigger().attributes('data-delayed')).toBe('')
+
+    await trigger().trigger('blur')
+    await nextTick()
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+
+    vm.open = true
+    await nextTick()
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(trigger().attributes('data-delayed')).toBeUndefined()
+  })
+
   it('v-model:open round-trips through a wrapper component', async () => {
     const { root, vm, trigger, content } = mountTooltip()
     expect(vm.open).toBe(false)

--- a/packages/core/src/Tooltip/Tooltip.test.ts
+++ b/packages/core/src/Tooltip/Tooltip.test.ts
@@ -2,9 +2,9 @@ import type { VueWrapper } from '@vue/test-utils'
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
-import { nextTick } from 'vue'
+import { defineComponent, nextTick, ref } from 'vue'
+import { TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from '.'
 import Tooltip from './stories/_Tooltip.vue'
-import TooltipProvider from './TooltipProvider.vue'
 
 describe('given default Tooltip', () => {
   let wrapper: VueWrapper<InstanceType<typeof Tooltip>>
@@ -165,5 +165,236 @@ describe('given tooltip data-state / data-delayed contract', () => {
     await nextTick()
     expect(trigger.attributes('data-state')).toBe('closed')
     expect(trigger.attributes('data-delayed')).toBeUndefined()
+  })
+})
+
+describe('tooltipRoot change events (v3 foundation contract)', () => {
+  // No Portal: keeps the content inside `wrapper` so DOM assertions stay local.
+  const TooltipWithModel = defineComponent({
+    components: { TooltipProvider, TooltipRoot, TooltipTrigger, TooltipContent },
+    props: {
+      disableHoverableContent: { type: Boolean, default: false },
+      onBeforeUpdateOpen: { type: Function, default: undefined },
+    },
+    setup() {
+      return { open: ref(false) }
+    },
+    template: `
+      <TooltipProvider :delay-duration="700" :disable-hoverable-content="disableHoverableContent">
+        <TooltipRoot v-model:open="open" @before-update:open="onBeforeUpdateOpen">
+          <TooltipTrigger>Trigger</TooltipTrigger>
+          <TooltipContent>Content</TooltipContent>
+        </TooltipRoot>
+      </TooltipProvider>
+    `,
+  })
+
+  const mounted: VueWrapper<any>[] = []
+
+  function mountTooltip(props: Record<string, unknown> = {}) {
+    const wrapper = mount(TooltipWithModel, { props, attachTo: document.body })
+    mounted.push(wrapper)
+    const root = wrapper.findComponent(TooltipRoot)
+    const vm = wrapper.vm as unknown as { open: boolean }
+    const trigger = () => wrapper.find('button')
+    const content = () => wrapper.find('[role="tooltip"]')
+    return { wrapper, root, vm, trigger, content }
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    document.body.innerHTML = ''
+  })
+
+  // Unmount (not just clear the DOM) so each layer leaves the shared
+  // DismissableLayer stack and Escape keeps routing to the right tooltip.
+  afterEach(() => {
+    mounted.splice(0).forEach(w => w.unmount())
+    vi.useRealTimers()
+  })
+
+  it('emits beforeUpdate:open then update:open with (value, details) on a delayed hover open', async () => {
+    const { root, trigger } = mountTooltip()
+    await trigger().trigger('pointermove', { pointerType: 'mouse' })
+    // Timer has not fired yet: nothing emitted.
+    expect(root.emitted('beforeUpdate:open')).toBeUndefined()
+    expect(root.emitted('update:open')).toBeUndefined()
+
+    vi.advanceTimersByTime(700)
+    await nextTick()
+    await nextTick()
+
+    expect(root.emitted('beforeUpdate:open')).toHaveLength(1)
+    expect(root.emitted('update:open')).toHaveLength(1)
+    const [beforeValue, beforeDetails] = root.emitted('beforeUpdate:open')![0]
+    const [value, details] = root.emitted('update:open')![0]
+    expect(beforeValue).toBe(true)
+    expect(beforeDetails).toMatchObject({ reason: 'trigger-hover' })
+    expect(value).toBe(true)
+    expect(details).toMatchObject({ reason: 'trigger-hover', isCanceled: false })
+    // The `pointermove` that armed the timer travels with the delayed open.
+    expect(details.event).toBeInstanceOf(Event)
+    expect(details.event.type).toBe('pointermove')
+    expect(typeof details.cancel).toBe('function')
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(trigger().attributes('data-delayed')).toBe('')
+  })
+
+  it('reports reason "trigger-focus" when focus opens the tooltip', async () => {
+    const { root, vm, trigger } = mountTooltip()
+    await trigger().trigger('focus')
+    await nextTick()
+
+    const [value, details] = root.emitted('update:open')![0]
+    expect(value).toBe(true)
+    expect(details).toMatchObject({ reason: 'trigger-focus', isCanceled: false })
+    expect(details.event).toBeInstanceOf(Event)
+    expect(details.event.type).toBe('focus')
+    expect(vm.open).toBe(true)
+    expect(trigger().attributes('data-delayed')).toBeUndefined()
+  })
+
+  it('reports reason "trigger-press" when clicking the trigger closes the tooltip', async () => {
+    const { root, vm, trigger } = mountTooltip()
+    await trigger().trigger('focus')
+    await nextTick()
+    expect(vm.open).toBe(true)
+
+    await trigger().trigger('click')
+    await nextTick()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'trigger-press' })
+    expect(details.event).toBeInstanceOf(MouseEvent)
+    expect(vm.open).toBe(false)
+  })
+
+  it('reports reason "trigger-blur" when the trigger loses focus', async () => {
+    const { root, vm, trigger } = mountTooltip()
+    await trigger().trigger('focus')
+    await nextTick()
+
+    await trigger().trigger('blur')
+    await nextTick()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'trigger-blur' })
+    expect(details.event.type).toBe('blur')
+    expect(vm.open).toBe(false)
+  })
+
+  it('reports reason "trigger-leave" when the pointer leaves a trigger without hoverable content', async () => {
+    const { root, vm, trigger } = mountTooltip({ disableHoverableContent: true })
+    await trigger().trigger('pointermove', { pointerType: 'mouse' })
+    vi.advanceTimersByTime(700)
+    await nextTick()
+    await nextTick()
+    expect(vm.open).toBe(true)
+
+    await trigger().trigger('pointerleave')
+    await nextTick()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'trigger-leave' })
+    expect(details.event).toBeInstanceOf(Event)
+    expect(details.event.type).toBe('pointerleave')
+    expect(vm.open).toBe(false)
+  })
+
+  it('only cancels the pending delayed open when the pointer leaves a hoverable trigger', async () => {
+    const { root, vm, trigger } = mountTooltip()
+    await trigger().trigger('pointermove', { pointerType: 'mouse' })
+    await trigger().trigger('pointerleave')
+    vi.advanceTimersByTime(700)
+    await nextTick()
+    await nextTick()
+
+    expect(root.emitted('beforeUpdate:open')).toBeUndefined()
+    expect(root.emitted('update:open')).toBeUndefined()
+    expect(vm.open).toBe(false)
+  })
+
+  it('reports reason "escape-key" when Escape closes the tooltip', async () => {
+    const { root, vm, trigger, content } = mountTooltip()
+    await trigger().trigger('focus')
+    await nextTick()
+    expect(content().exists()).toBe(true)
+
+    await trigger().trigger('keydown', { key: 'Escape' })
+    await nextTick()
+
+    const [value, details] = root.emitted('update:open')![1]
+    expect(value).toBe(false)
+    expect(details).toMatchObject({ reason: 'escape-key' })
+    expect(details.event).toBeInstanceOf(KeyboardEvent)
+    expect(vm.open).toBe(false)
+  })
+
+  it('details.cancel() in @before-update:open keeps the tooltip closed and skips update:open', async () => {
+    const onBeforeUpdateOpen = vi.fn((_value: boolean, details: { cancel: () => void }) => details.cancel())
+    const { root, vm, trigger, content } = mountTooltip({ onBeforeUpdateOpen })
+    await trigger().trigger('pointermove', { pointerType: 'mouse' })
+    vi.advanceTimersByTime(700)
+    await nextTick()
+    await nextTick()
+
+    expect(onBeforeUpdateOpen).toHaveBeenCalledTimes(1)
+    expect(onBeforeUpdateOpen.mock.calls[0][0]).toBe(true)
+    expect(onBeforeUpdateOpen.mock.calls[0][1]).toMatchObject({ reason: 'trigger-hover', isCanceled: true })
+    expect(root.emitted('beforeUpdate:open')).toHaveLength(1)
+    expect(root.emitted('update:open')).toBeUndefined()
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+    expect(trigger().attributes('data-delayed')).toBeUndefined()
+    expect(content().exists()).toBe(false)
+
+    // A cancelled delayed open must not leave the "delayed" flag behind: a later
+    // parent-driven open is not a delayed one.
+    vm.open = true
+    await nextTick()
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(trigger().attributes('data-delayed')).toBeUndefined()
+    expect(content().exists()).toBe(true)
+    onBeforeUpdateOpen.mockClear()
+
+    // A cancelled close keeps it open.
+    await trigger().trigger('blur')
+    await flushPromises()
+
+    expect(onBeforeUpdateOpen).toHaveBeenCalledTimes(1)
+    expect(onBeforeUpdateOpen.mock.calls[0][1]).toMatchObject({ reason: 'trigger-blur', isCanceled: true })
+    expect(root.emitted('beforeUpdate:open')).toHaveLength(2)
+    expect(root.emitted('update:open')).toBeUndefined()
+    expect(vm.open).toBe(true)
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(content().exists()).toBe(true)
+  })
+
+  it('v-model:open round-trips through a wrapper component', async () => {
+    const { root, vm, trigger, content } = mountTooltip()
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+
+    await trigger().trigger('focus')
+    await nextTick()
+    expect(vm.open).toBe(true)
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(trigger().attributes('aria-describedby')).toBe(content().attributes('id'))
+
+    await trigger().trigger('click')
+    // Presence resolves the exit after its own `nextTick`; flush so the content is gone.
+    await flushPromises()
+    expect(vm.open).toBe(false)
+    expect(trigger().attributes('data-state')).toBe('closed')
+    expect(content().exists()).toBe(false)
+
+    // Parent-driven change: the prop wins and nothing is emitted for it.
+    vm.open = true
+    await nextTick()
+    expect(trigger().attributes('data-state')).toBe('open')
+    expect(root.emitted('update:open')).toHaveLength(2)
   })
 })

--- a/packages/core/src/Tooltip/TooltipContentHoverable.vue
+++ b/packages/core/src/Tooltip/TooltipContentHoverable.vue
@@ -16,7 +16,7 @@ const { isPointerInTransit, onPointerExit } = useGraceArea(trigger, currentEleme
 
 providerContext.isPointerInTransitRef = isPointerInTransit
 onPointerExit(() => {
-  onClose()
+  onClose('content-leave')
 })
 </script>
 

--- a/packages/core/src/Tooltip/TooltipContentImpl.vue
+++ b/packages/core/src/Tooltip/TooltipContentImpl.vue
@@ -42,6 +42,7 @@ export interface TooltipContentImplProps
 </script>
 
 <script setup lang="ts">
+import type { DismissableLayerDismissDetails } from '@/DismissableLayer'
 import { useEventListener } from '@vueuse/core'
 import { computed, onMounted } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
@@ -87,8 +88,16 @@ onMounted(() => {
       rootContext.onClose()
   }, { capture: true })
   // Close this tooltip if another one opens
-  useEventListener(window, TOOLTIP_OPEN, rootContext.onClose)
+  useEventListener(window, TOOLTIP_OPEN, () => rootContext.onClose())
 })
+
+// `focusOutside` is prevented in the template, so the layer only dismisses for
+// `escape-key` / `outside-press`; the guard keeps `TooltipOpenChangeReason` honest.
+function handleDismiss({ reason, event }: DismissableLayerDismissDetails) {
+  if (reason === 'focus-outside')
+    return
+  rootContext.onClose(reason, event)
+}
 </script>
 
 <template>
@@ -103,7 +112,7 @@ onMounted(() => {
       emits('pointerDownOutside', event)
     }"
     @focus-outside.prevent
-    @dismiss="rootContext.onClose()"
+    @dismiss="handleDismiss"
   >
     <PopperContent
       :ref="forwardRef"

--- a/packages/core/src/Tooltip/TooltipRoot.vue
+++ b/packages/core/src/Tooltip/TooltipRoot.vue
@@ -1,7 +1,28 @@
 <script lang="ts">
-import type { Ref } from 'vue'
-import type { DisclosureState } from '@/shared'
-import { createContext, disclosureState, useForwardExpose } from '@/shared'
+import type { ComputedRef, Ref } from 'vue'
+import type { BaseChangeReason, ChangeEventDetails, DisclosureState } from '@/shared'
+import { createContext, disclosureState, useControllableState, useForwardExpose } from '@/shared'
+
+/**
+ * Why the tooltip's `open` state changed (#2828); the `reason` of `ChangeEventDetails`.
+ *
+ * - `trigger-hover` — the pointer entered the trigger (after the delay, or
+ *   instantly while the provider skips it; `data-delayed` tells which).
+ * - `trigger-leave` — the pointer left the trigger while hoverable content is disabled.
+ * - `trigger-focus` / `trigger-blur` — the trigger gained / lost focus.
+ * - `trigger-press` — the trigger was pressed (unless `disableClosingTrigger`).
+ * - `content-leave` — the pointer left the trigger/content grace area of hoverable content.
+ * - `escape-key` / `outside-press` — dismissed by the `DismissableLayer`.
+ */
+export type TooltipOpenChangeReason
+  = | 'trigger-hover'
+    | 'trigger-leave'
+    | 'trigger-focus'
+    | 'trigger-blur'
+    | 'trigger-press'
+    | 'content-leave'
+    | 'escape-key'
+    | 'outside-press'
 
 export interface TooltipRootProps {
   /**
@@ -47,23 +68,29 @@ export interface TooltipRootProps {
 }
 
 export type TooltipRootEmits = {
+  /** Event handler called before the open state of the tooltip changes; `details.cancel()` keeps the current state. */
+  'beforeUpdate:open': [value: boolean, details: ChangeEventDetails<TooltipOpenChangeReason>]
   /** Event handler called when the open state of the tooltip changes. */
-  'update:open': [value: boolean]
+  'update:open': [value: boolean, details: ChangeEventDetails<TooltipOpenChangeReason>]
 }
 
 export interface TooltipContext {
   contentId: string
-  open: Ref<boolean>
+  open: ComputedRef<boolean>
   /** `'open' | 'closed'` — the disclosure axis of `data-state` (#2823). */
   stateAttribute: Ref<DisclosureState>
   /** `true` only while open AND that open came from the delay timer; bound as `data-delayed`. */
   isDelayed: Ref<boolean>
   trigger: Ref<HTMLElement | undefined>
   onTriggerChange: (trigger: HTMLElement | undefined) => void
-  onTriggerEnter: () => void
-  onTriggerLeave: () => void
-  onOpen: () => void
-  onClose: () => void
+  /** Pointer entered the trigger: opens with reason `trigger-hover`, delayed unless the provider is skipping the delay. */
+  onTriggerEnter: (event?: PointerEvent) => void
+  /** Pointer left the trigger: closes with reason `trigger-leave` when hoverable content is disabled, else only cancels a pending delayed open. */
+  onTriggerLeave: (event?: PointerEvent) => void
+  /** Opens instantly. Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpen: (reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Closes and cancels a pending delayed open. Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onClose: (reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event) => boolean
   disableHoverableContent: Ref<boolean>
   disableClosingTrigger: Ref<boolean>
   disabled: Ref<boolean>
@@ -75,7 +102,7 @@ export const [injectTooltipRootContext, provideTooltipRootContext]
 </script>
 
 <script setup lang="ts">
-import { useTimeoutFn, useVModel } from '@vueuse/core'
+import { useTimeoutFn } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 import { PopperRoot } from '@/Popper'
 import { injectTooltipProviderContext } from './TooltipProvider.vue'
@@ -110,10 +137,15 @@ const disableTooltip = computed(() => props.disabled ?? providerContext.disabled
 const delayDuration = computed(() => props.delayDuration ?? providerContext.delayDuration.value)
 const ignoreNonKeyboardFocus = computed(() => props.ignoreNonKeyboardFocus ?? providerContext.ignoreNonKeyboardFocus.value)
 
-const open = useVModel(props, 'open', emit, {
+// Every write to `open` — hover timer, focus/blur, press, grace-area exit,
+// dismiss — goes through one `setState`, so `beforeUpdate:open` can cancel any
+// of them and `update:open` always carries the reason (#2828).
+const { state: open, setState } = useControllableState<boolean, TooltipOpenChangeReason>({
+  prop: () => props.open,
   defaultValue: props.defaultOpen,
-  passive: (props.open === undefined) as false,
-}) as Ref<boolean>
+  name: 'open',
+  emit,
+})
 
 watch(open, (isOpen) => {
   if (!providerContext.onClose)
@@ -135,21 +167,31 @@ const trigger = ref<HTMLElement>()
 const stateAttribute = computed<DisclosureState>(() => disclosureState(open.value))
 const isDelayed = computed(() => open.value && wasOpenDelayedRef.value)
 
+// The `pointermove` that armed the delay timer, handed to `update:open` when it fires.
+let delayedOpenEvent: PointerEvent | undefined
+
 const { start: startTimer, stop: clearTimer } = useTimeoutFn(() => {
+  const event = delayedOpenEvent
+  delayedOpenEvent = undefined
+  // Flag before the write so `isDelayed` is right on the same tick `open` flips;
+  // roll it back when the open was cancelled (or was a no-op).
   wasOpenDelayedRef.value = true
-  open.value = true
+  if (!setState(true, 'trigger-hover', event))
+    wasOpenDelayedRef.value = false
 }, delayDuration, { immediate: false })
 
-function handleOpen() {
+function handleOpen(reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event) {
   clearTimer()
   wasOpenDelayedRef.value = false
-  open.value = true
+  return setState(true, reason, event)
 }
-function handleClose() {
+function handleClose(reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event) {
+  // Cancel a pending delayed open first; a cancelled close then simply stays open.
   clearTimer()
-  open.value = false
+  return setState(false, reason, event)
 }
-function handleDelayedOpen() {
+function handleDelayedOpen(event?: PointerEvent) {
+  delayedOpenEvent = event
   startTimer()
 }
 
@@ -162,14 +204,14 @@ provideTooltipRootContext({
   onTriggerChange(el) {
     trigger.value = el
   },
-  onTriggerEnter() {
+  onTriggerEnter(event) {
     if (providerContext.isOpenDelayed.value)
-      handleDelayedOpen()
-    else handleOpen()
+      handleDelayedOpen(event)
+    else handleOpen('trigger-hover', event)
   },
-  onTriggerLeave() {
+  onTriggerLeave(event) {
     if (disableHoverableContent.value) {
-      handleClose()
+      handleClose('trigger-leave', event)
     }
     else {
       // Clear the timer in case the pointer leaves the trigger before the tooltip is opened.

--- a/packages/core/src/Tooltip/TooltipRoot.vue
+++ b/packages/core/src/Tooltip/TooltipRoot.vue
@@ -167,6 +167,14 @@ const trigger = ref<HTMLElement>()
 const stateAttribute = computed<DisclosureState>(() => disclosureState(open.value))
 const isDelayed = computed(() => open.value && wasOpenDelayedRef.value)
 
+// A closed tooltip keeps no "delayed" history: a later parent-driven or
+// imperative open must not render `data-delayed`. A cancelled close never
+// flips `open`, so the flag survives it.
+watch(open, (isOpen) => {
+  if (!isOpen)
+    wasOpenDelayedRef.value = false
+})
+
 // The `pointermove` that armed the delay timer, handed to `update:open` when it fires.
 let delayedOpenEvent: PointerEvent | undefined
 

--- a/packages/core/src/Tooltip/TooltipTrigger.vue
+++ b/packages/core/src/Tooltip/TooltipTrigger.vue
@@ -54,9 +54,9 @@ function handlePointerUp() {
   }, 1)
 }
 
-function handlePointerDown() {
-  if (rootContext.open && !rootContext.disableClosingTrigger.value) {
-    rootContext.onClose()
+function handlePointerDown(event: PointerEvent) {
+  if (rootContext.open.value && !rootContext.disableClosingTrigger.value) {
+    rootContext.onClose('trigger-press', event)
   }
   isPointerDown.value = true
   document.addEventListener('pointerup', handlePointerUp, { once: true })
@@ -68,13 +68,13 @@ function handlePointerMove(event: PointerEvent) {
   if (
     !hasPointerMoveOpened.value && !providerContext.isPointerInTransitRef.value
   ) {
-    rootContext.onTriggerEnter()
+    rootContext.onTriggerEnter(event)
     hasPointerMoveOpened.value = true
   }
 }
 
-function handlePointerLeave() {
-  rootContext.onTriggerLeave()
+function handlePointerLeave(event: PointerEvent) {
+  rootContext.onTriggerLeave(event)
   hasPointerMoveOpened.value = false
 }
 
@@ -85,16 +85,16 @@ function handleFocus(event: FocusEvent) {
   if (rootContext.ignoreNonKeyboardFocus.value && !(event.target as HTMLElement).matches?.(':focus-visible'))
     return
 
-  rootContext.onOpen()
+  rootContext.onOpen('trigger-focus', event)
 }
 
-function handleBlur() {
-  rootContext.onClose()
+function handleBlur(event: FocusEvent) {
+  rootContext.onClose('trigger-blur', event)
 }
 
-function handleClick() {
+function handleClick(event: MouseEvent) {
   if (!rootContext.disableClosingTrigger.value)
-    rootContext.onClose()
+    rootContext.onClose('trigger-press', event)
 }
 </script>
 

--- a/packages/core/src/Tooltip/index.ts
+++ b/packages/core/src/Tooltip/index.ts
@@ -18,6 +18,7 @@ export {
 } from './TooltipProvider.vue'
 export {
   injectTooltipRootContext,
+  type TooltipOpenChangeReason,
   default as TooltipRoot,
   type TooltipRootEmits,
   type TooltipRootProps,


### PR DESCRIPTION
### 🔗 Linked issue

Continues #2723 (Dialog and Popover conversions) and #2828 (Tooltip and HoverCard change details). Part of the v3 roadmap #2721. Also unblocks the `docs:gen` follow-ups deferred on #2910 and #2915.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

One commit per piece.

**`useDialog` and `usePopover`** (#2723). Each root composable owns the controlled/uncontrolled `open` model, the change details and the root context, and exposes pure part surfaces the SFCs bind through `part.attrs.value`: Dialog gets `trigger`, `close`, `content`, `overlay`, `title`, `description`; Popover gets `trigger`, `close`, `content`. Part ids now derive from the root's `baseId` inside the composable (the SFC passes `useId(undefined, 'reka-dialog')` / `'reka-popover'`) instead of being back-filled onto the context by descendant SFCs, so `aria-controls` is right on first render and a standalone consumer, or a trigger-less dialog, gets real ids. The rendered id strings change shape (`reka-dialog-v0-content` rather than `reka-dialog-content-v0`); nothing in the repo referenced the old form. `Presence`, `FocusScope`, `DismissableLayer`, Popper, `useHideOthers` and the tag-dependent `type` binding stay in the SFCs per the recipe. Public props, emits and slots are unchanged, so AlertDialog, DatePicker and DateRangePicker keep working untouched. Both composables land on the package root through the existing `export *`, tagged `@experimental`, like `useSwitch` and `useTabs`; builders are internal. New `useDialog.test.ts` / `usePopover.test.ts`, plus one recipe bullet on deriving overlay ids from `baseId`.

**Tooltip and HoverCard change details** (#2828). Both roots drop `useVModel`; every write to `open` goes through one `setState`, so `beforeUpdate:open` can cancel it and `update:open` carries `ChangeEventDetails<…OpenChangeReason>`. The delayed hover timers capture the pointer event that armed them and pass it when they fire; Tooltip rolls `data-delayed` back when a hover open is cancelled. Reasons:

| | reasons |
|---|---|
| `TooltipOpenChangeReason` | `trigger-hover`, `trigger-leave`, `trigger-focus`, `trigger-blur`, `trigger-press`, `content-leave`, `escape-key`, `outside-press` |
| `HoverCardOpenChangeReason` | `trigger-hover`, `trigger-leave`, `trigger-focus`, `trigger-blur`, `trigger-press` (touch toggle), `content-hover`, `content-leave`, `escape-key`, `outside-press` |

`focus-outside` is absent from both on purpose: both contents bind `@focus-outside.prevent`, so the layer never dismisses for it. HoverCard's grace-area exit now records which element the pointer last left, so the close reports `trigger-leave` or `content-leave` rather than one label for both. HoverCard's `onOpen` / `onClose` stay `void` because they only schedule a timer; `onOpenChange` / `onDismiss` return the boolean. One pre-existing slip fixed on the way: `TooltipTrigger`'s pointerdown guard tested the `open` ref object rather than its value. Tests added for each reason, cancellation and the `v-model` round-trip, with fake timers.

**Docs generator.** `pnpm docs:gen` failed on a clean checkout with `TypeError: traverse is not a function`: `@babel/traverse` is CJS and, depending on the ESM interop in play, its default import is either the function or `{ default: fn }`; the generator only handled the latter. It now accepts both. A new informational `docs-meta` CI job (`continue-on-error`) runs `docs:gen` against the built package and prints the resulting `docs/content/meta` diff, so generated docs can be refreshed from CI output when a build is not available locally. It never blocks: the generator still regresses a few generic components (see the note in `autogen.ts`). The regenerated meta for the families touched on `v3` will be applied from that job's output on this PR.

**Migration guide** lists Tooltip and HoverCard under the change-event contract.

**Validation note:** the npm registry is blocked in the authoring environment, so vitest, vue-tsc and eslint could not run; CI is the first execution.

### 📸 Screenshots (if appropriate)

n/a

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added headless `useDialog` and `usePopover` composables for custom overlay experiences.
  * Dialog and Popover parts now provide consistent IDs, ARIA attributes, and state behavior.
  * Open-state events across overlays and form controls now include reasons, originating events, and cancellation support.
  * Added exported change-reason types for Dialog, Tooltip, and HoverCard.

* **Documentation**
  * Expanded migration guidance and component event documentation, including cancellable updates and generated IDs.

* **Bug Fixes**
  * Improved delayed hover behavior and cancellation handling for Tooltip and HoverCard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->