### PR TITLE
feat(v3)!: useTooltip and useHoverCard composables, Stepper data-state rename, codemod publishing

### DIFF
--- a/.github/workflows/pkg.pr.new.yaml
+++ b/.github/workflows/pkg.pr.new.yaml
@@ -18,6 +18,6 @@ jobs:
       - name: Build Reka UI and plugins
         run: pnpm run build
 
-      - run: pnpm dlx pkg-pr-new publish --compact ./packages/core
+      - run: pnpm dlx pkg-pr-new publish --compact ./packages/core ./packages/codemod
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,3 +55,10 @@ jobs:
       # Must publish from repo root for provenance to work with OIDC
       - name: Publish to npm
         run: npm publish ./packages/core --access public --provenance
+
+      # `@reka-ui/codemod` is dependency-free (no build) and versioned in
+      # lockstep with `reka-ui` by `pnpm bumpp`, so `npx @reka-ui/codemod@3`
+      # always resolves to the codemods for that major. It needs its own
+      # trusted-publisher entry on npm pointing at this workflow.
+      - name: Publish codemod to npm
+        run: npm publish ./packages/codemod --access public --provenance

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,13 +52,26 @@ jobs:
       - name: Build Packages
         run: pnpm build
 
-      # Must publish from repo root for provenance to work with OIDC
-      - name: Publish to npm
-        run: npm publish ./packages/core --access public --provenance
-
+      # Must publish from repo root for provenance to work with OIDC.
       # `@reka-ui/codemod` is dependency-free (no build) and versioned in
       # lockstep with `reka-ui` by `pnpm bumpp`, so `npx @reka-ui/codemod@3`
       # always resolves to the codemods for that major. It needs its own
       # trusted-publisher entry on npm pointing at this workflow.
-      - name: Publish codemod to npm
-        run: npm publish ./packages/codemod --access public --provenance
+      # npm refuses to publish a version that already exists, so a package
+      # whose version is already on the registry is skipped: a rerun after a
+      # partial failure (the codemod failing after `reka-ui` succeeded) then
+      # gets past the first package instead of dying on it.
+      - name: Publish to npm
+        run: |
+          publish() {
+            local name version
+            name=$(node -p "require('$1/package.json').name")
+            version=$(node -p "require('$1/package.json').version")
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "$name@$version is already on npm, skipping"
+            else
+              npm publish "$1" --access public --provenance
+            fi
+          }
+          publish ./packages/core
+          publish ./packages/codemod

--- a/docs/components/demo/Stepper/css/styles.css
+++ b/docs/components/demo/Stepper/css/styles.css
@@ -40,7 +40,7 @@
   color: #9ca3af;
 }
 
-.StepperItem[data-state="active"] .StepperIndicator {
+.StepperItem[data-state="current"] .StepperIndicator {
   background-color: #000;
   color: #fff;
   box-shadow: 0 0 0 2px #000;
@@ -75,7 +75,7 @@
   background-color: var(--green5);
 }
 
-.StepperItem[data-state="active"] .StepperSeparator {
+.StepperItem[data-state="current"] .StepperSeparator {
   background-color: #000;
 }
 

--- a/docs/components/demo/Stepper/tailwind/index.vue
+++ b/docs/components/demo/Stepper/tailwind/index.vue
@@ -31,7 +31,7 @@ const steps = [{
       class="w-full flex justify-center gap-2 cursor-pointer group relative px-4"
       :step="item.step"
     >
-      <StepperTrigger class="inline-flex border-2 shadow-sm items-center text-white bg-green9 border-green9 group-data-[state=inactive]:border-gray-200 group-data-[state=inactive]:bg-white group-data-[state=inactive]:text-stone-700 group-data-[disabled]:opacity-50 group-data-[disabled]:cursor-not-allowed justify-center rounded-full w-10 h-10 shrink-0 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none">
+      <StepperTrigger class="inline-flex border-2 shadow-sm items-center text-white bg-green9 border-green9 group-data-[state=upcoming]:border-gray-200 group-data-[state=upcoming]:bg-white group-data-[state=upcoming]:text-stone-700 group-data-[disabled]:opacity-50 group-data-[disabled]:cursor-not-allowed justify-center rounded-full w-10 h-10 shrink-0 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none">
         <StepperIndicator>
           <Icon
             :icon="item.icon"

--- a/docs/content/docs/components/stepper.md
+++ b/docs/content/docs/components/stepper.md
@@ -84,7 +84,7 @@ The step item component.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['active', 'inactive', 'completed'],
+      values: ['completed', 'current', 'upcoming'],
     },
     {
       attribute: '[data-disabled]',
@@ -107,7 +107,7 @@ The trigger that toggles the step.
   :data="[
     {
       attribute: '[data-state]',
-      values: ['active', 'inactive', 'completed'],
+      values: ['completed', 'current', 'upcoming'],
     },
     {
       attribute: '[data-disabled]',

--- a/docs/content/docs/guides/migration-v3.md
+++ b/docs/content/docs/guides/migration-v3.md
@@ -15,7 +15,7 @@ Reka UI v3 is still in progress. This page collects the breaking changes as they
 
 In v3, `data-state` answers exactly one of two questions: disclosure ("is this surface revealed?") is reported as `open` or `closed`, and selection ("is this control in its affirmative state?") is reported as `checked` or `unchecked`, with `indeterminate` reserved for tri-state controls that also emit `aria-checked="mixed"`. Both values are always emitted—`data-state` is never absent—and qualifiers such as *how* a surface came to be open live in their own `data-*` attribute rather than in `data-state`.
 
-Parts that were already on `open` / `closed` or `checked` / `unchecked` / `indeterminate` are unchanged. Genuine multi-value machines keep their vocabulary: [Progress](../components/progress) (`indeterminate` / `loading` / `complete`), [Stepper](../components/stepper) (`completed` / `active` / `inactive`) and the [Splitter](../components/splitter) resize handle (`drag` / `hover` / `inactive`) are untouched.
+Parts that were already on `open` / `closed` or `checked` / `unchecked` / `indeterminate` are unchanged. Genuine multi-value machines keep a vocabulary of their own: [Progress](../components/progress) (`indeterminate` / `loading` / `complete`) and the [Splitter](../components/splitter) resize handle (`drag` / `hover` / `inactive`) are untouched, while [Stepper](../components/stepper) keeps `completed` but renames `active` / `inactive` to `current` / `upcoming`, so that its words are neither synonyms of the two axes nor the same as Tabs' old `active` / `inactive`.
 
 | Part | v2 | v3 |
 | --- | --- | --- |
@@ -23,6 +23,7 @@ Parts that were already on `open` / `closed` or `checked` / `unchecked` / `indet
 | `TabsTrigger`, `TabsContent` | `active` / `inactive` | `checked` / `unchecked` |
 | `TagsInputItem`, `TagsInputItemDelete` | `active` / `inactive` | `checked` / `unchecked` |
 | `RatingItemIndicator` | `active` / (absent) | `checked` / `unchecked` |
+| `StepperItem`, `StepperTrigger`, `StepperSeparator` | `completed` / `active` / `inactive` | `completed` / `current` / `upcoming` |
 | `ScrollAreaScrollbar`, `ScrollAreaThumb`, `NavigationMenuIndicator` | `visible` / `hidden` | `open` / `closed` |
 | `SplitterPanel` | `expanded` / `collapsed` / (absent when not collapsible) | `open` / `closed` (non-collapsible panels are always `open`) |
 | `CollapsibleContent` | `open` / `closed` / (absent on the initial animated mount) | `open` / `closed` |
@@ -34,7 +35,8 @@ Parts that were already on `open` / `closed` or `checked` / `unchecked` / `indet
 The rewrites are mechanical. In Tailwind variants:
 
 - `data-[state=on]:` → `data-[state=checked]:`, `data-[state=off]:` → `data-[state=unchecked]:`
-- `data-[state=active]:` → `data-[state=checked]:`, `data-[state=inactive]:` → `data-[state=unchecked]:` — for **Tabs, TagsInput and Rating only**. Stepper keeps `active` / `inactive` / `completed`, so leave selectors on `StepperItem` alone.
+- `data-[state=active]:` → `data-[state=checked]:`, `data-[state=inactive]:` → `data-[state=unchecked]:` — for **Tabs, TagsInput and Rating only**.
+- `data-[state=active]:` → `data-[state=current]:`, `data-[state=inactive]:` → `data-[state=upcoming]:` — for **Stepper only** (`data-[state=completed]:` is unchanged). Only the Splitter resize handle still emits `inactive`, so leave selectors on `SplitterResizeHandle` alone.
 - `data-[state=visible]:` → `data-[state=open]:`, `data-[state=hidden]:` → `data-[state=closed]:`
 - `data-[state=expanded]:` → `data-[state=open]:`, `data-[state=collapsed]:` → `data-[state=closed]:`
 - `data-[state=delayed-open]:` → `data-[state=open]:data-[delayed]:`
@@ -43,7 +45,8 @@ The rewrites are mechanical. In Tailwind variants:
 In plain CSS the same rewrites apply to attribute selectors:
 
 - `[data-state='on']` → `[data-state='checked']`, `[data-state='off']` → `[data-state='unchecked']`
-- `[data-state='active']` → `[data-state='checked']`, `[data-state='inactive']` → `[data-state='unchecked']` — Tabs, TagsInput and Rating only, not Stepper.
+- `[data-state='active']` → `[data-state='checked']`, `[data-state='inactive']` → `[data-state='unchecked']` — Tabs, TagsInput and Rating only.
+- `[data-state='active']` → `[data-state='current']`, `[data-state='inactive']` → `[data-state='upcoming']` — Stepper only; `[data-state='completed']` is unchanged and the Splitter resize handle keeps `inactive`.
 - `[data-state='visible']` → `[data-state='open']`, `[data-state='hidden']` → `[data-state='closed']`
 - `[data-state='expanded']` → `[data-state='open']`, `[data-state='collapsed']` → `[data-state='closed']`
 - `[data-state='delayed-open']` → `[data-state='open'][data-delayed]`
@@ -62,6 +65,11 @@ Because both values are now always emitted, any styles that relied on the attrib
   color: var(--grass-11);
 }
 
+.StepperItem[data-state='active'] .StepperIndicator { /* [!code --] */
+.StepperItem[data-state='current'] .StepperIndicator { /* [!code ++] */
+  background-color: var(--mauve-12);
+}
+
 .TooltipContent[data-state='delayed-open'][data-side='top'] { /* [!code --] */
 .TooltipContent[data-state='open'][data-delayed][data-side='top'] { /* [!code ++] */
   animation-name: slideDownAndFade;
@@ -70,7 +78,7 @@ Because both values are now always emitted, any styles that relied on the attrib
 
 ### Codemod
 
-The `@reka-ui/codemod` package automates the mechanical part: `npx @reka-ui/codemod data-state ./src` applies the mapping above to Tailwind variants and CSS attribute selectors in every `.vue`, `.css`, `.scss`, `.ts`, `.tsx`, `.js`, `.jsx`, `.html` and `.md` file under the given paths. It is deliberately conservative—`active` / `inactive` selectors are only rewritten in files that clearly belong to Tabs, TagsInput or Rating rather than Stepper or Splitter, and presence-only selectors such as `:not([data-state])` are never touched; both cases are left as they are and reported as a `file:line` warning for you to resolve by hand. Run it with `--dry-run` first to review the changes it would make before letting it write to disk.
+The `@reka-ui/codemod` package automates the mechanical part: `npx @reka-ui/codemod data-state ./src` applies the mapping above to Tailwind variants and CSS attribute selectors in every `.vue`, `.css`, `.scss`, `.ts`, `.tsx`, `.js`, `.jsx`, `.html` and `.md` file under the given paths. It is deliberately conservative. Because `active` / `inactive` now mean three different things, the codemod decides once per file from the component names the file mentions: a file that mentions only Tabs, TagsInput or Rating is rewritten to `checked` / `unchecked`, a file that mentions only Stepper is rewritten to `current` / `upcoming`, a file that mentions only the Splitter resize handle is kept, and a file that mentions more than one of those, or none of them, is left as it is and reported as a `file:line` warning for you to resolve by hand. Presence-only selectors such as `:not([data-state])` are never touched and are reported the same way. Run it with `--dry-run` first to review the changes it would make before letting it write to disk.
 
 ## Change events carry details
 

--- a/docs/content/meta/StepperItem.md
+++ b/docs/content/meta/StepperItem.md
@@ -40,8 +40,8 @@
 <SlotsTable :data="[
   {
     'name': 'state',
-    'description': '<p>The current state of the stepper item</p>\n',
-    'type': '\'active\' | \'completed\' | \'inactive\''
+    'description': '<p>The state of the stepper item: <code>completed</code>, <code>current</code> or <code>upcoming</code></p>\n',
+    'type': '\'completed\' | \'current\' | \'upcoming\''
   }
 ]" />
 </llm-exclude>
@@ -62,6 +62,6 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `state` | The current state of the stepper item | `"active" \| "completed" \| "inactive"` |
+| `state` | The state of the stepper item: completed, current or upcoming | `"completed" \| "current" \| "upcoming"` |
 
 </llm-only>

--- a/docs/superpowers/recipes/2723-headless-composable-recipe.md
+++ b/docs/superpowers/recipes/2723-headless-composable-recipe.md
@@ -216,6 +216,16 @@ core Menu parts settled the overlay contract:
   shape stays a plain `string` but is populated up-front, so a standalone consumer —
   and a trigger-less dialog — get real ids, and every part reads the same value
   from the context. The one `useId` call still lives in the root SFC.
+- **Provider-coupled families keep the coupling in the shell** (validated on
+  Tooltip). `useTooltip()` takes every provider-influenced input as a getter
+  (`delayDuration`, `isOpenDelayed`, `isPointerInTransit`, …); `TooltipRoot.vue`
+  resolves `props.x ?? providerContext.x.value` into those getters and keeps the
+  `watch(open)` that notifies the provider / dispatches `TOOLTIP_OPEN`. Read a
+  provider ref through its property on every access (`() => provider.ref.value`),
+  never snapshot it — `TooltipContentHoverable` REASSIGNS the transit ref. A part
+  with per-instance state (the tooltip trigger's `isPointerDown` /
+  `hasPointerMoveOpened`) is a `create<...>Surface` factory even when the family
+  is otherwise pure.
 
 ## Dependency- and structure-ordered migration (not size)
 

--- a/packages/codemod/LICENSE
+++ b/packages/codemod/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 UnoVue <https://github.com/unovue>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -13,7 +13,7 @@ npx @reka-ui/codemod data-state ./src --dry-run
 npx @reka-ui/codemod data-state ./src ./docs --ext vue,css
 ```
 
-The package is versioned and published in lockstep with `reka-ui`, so pin the major you are migrating to (`npx @reka-ui/codemod@3 …`) to get the codemods written for that release. A pull request's build can be tried before it is published with `npx https://pkg.pr.new/unovue/reka-ui/@reka-ui/codemod@<pr-number> data-state ./src`.
+The package is versioned and published in lockstep with `reka-ui` (the release process bumps every workspace package to the same version before tagging, so the codemod's major is always the `reka-ui` major it migrates to), so pin the major you are migrating to (`npx @reka-ui/codemod@3 …`) to get the codemods written for that release. A pull request's build can be tried before it is published with `npx https://pkg.pr.new/unovue/reka-ui/@reka-ui/codemod@<pr-number> data-state ./src`.
 
 ## `data-state`
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -13,7 +13,7 @@ npx @reka-ui/codemod data-state ./src --dry-run
 npx @reka-ui/codemod data-state ./src ./docs --ext vue,css
 ```
 
-The package is versioned and published in lockstep with `reka-ui`, so pin the major you are migrating to (`npx @reka-ui/codemod@3 …`) to get the codemods written for that release. A pull request's build can be tried before it is published with `npx https://pkg.pr.new/@reka-ui/codemod@<pr-number> data-state ./src`.
+The package is versioned and published in lockstep with `reka-ui`, so pin the major you are migrating to (`npx @reka-ui/codemod@3 …`) to get the codemods written for that release. A pull request's build can be tried before it is published with `npx https://pkg.pr.new/unovue/reka-ui/@reka-ui/codemod@<pr-number> data-state ./src`.
 
 ## `data-state`
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -13,6 +13,8 @@ npx @reka-ui/codemod data-state ./src --dry-run
 npx @reka-ui/codemod data-state ./src ./docs --ext vue,css
 ```
 
+The package is versioned and published in lockstep with `reka-ui`, so pin the major you are migrating to (`npx @reka-ui/codemod@3 …`) to get the codemods written for that release. A pull request's build can be tried before it is published with `npx https://pkg.pr.new/@reka-ui/codemod@<pr-number> data-state ./src`.
+
 ## `data-state`
 
 Rewrites the v2 `data-state` values to the [v3 vocabulary](https://reka-ui.com/docs/guides/migration-v3) in Tailwind variants (`data-[state=…]:`, `group-data-[state=…]:`, `peer-data-[state=…]:`) and CSS attribute selectors (`[data-state=…]`, `[data-state='…']`, `[data-state="…"]`):

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -24,7 +24,7 @@ Rewrites the v2 `data-state` values to the [v3 vocabulary](https://reka-ui.com/d
 | `expanded` / `collapsed` | `open` / `closed` |
 | `instant-open` | `open` |
 | `delayed-open` | `open` + `data-delayed` (`data-[state=open]:data-[delayed]:` / `[data-state=open][data-delayed]`) |
-| `active` / `inactive` | `checked` / `unchecked` — only when the file is clearly about Tabs, TagsInput or Rating |
+| `active` / `inactive` | `checked` / `unchecked` when the file is clearly about Tabs, TagsInput or Rating; `current` / `upcoming` when it is clearly about Stepper; kept when it is clearly about the Splitter resize handle |
 
 Everything else — `data-[side=…]`, `data-orientation`, values already on `open` / `closed` / `checked` / `unchecked` — is left as is, and running the codemod twice makes no further changes.
 
@@ -32,5 +32,5 @@ Everything else — `data-[side=…]`, `data-orientation`, values already on `op
 
 Two situations cannot be decided mechanically. The codemod leaves the source untouched and prints a `file:line: message` warning for each so you can finish the migration by hand:
 
-- `ambiguous data-state "active": rewrite to "checked" for Tabs/TagsInput/Rating, keep for Stepper/Splitter` — Tabs, TagsInput and Rating moved from `active` / `inactive` to `checked` / `unchecked`, but Stepper still emits `active` / `inactive` / `completed` and the Splitter resize handle still emits `inactive`. The decision is made per file from the component names it mentions: a file that mentions `Tabs`, `TagsInput` or `Rating` (and not `Stepper` or `SplitterResizeHandle`) is rewritten, a file that only mentions `Stepper` or `SplitterResizeHandle` is kept, and a file that mentions both or neither gets this warning.
+- `ambiguous data-state "active": rewrite to "checked" for Tabs/TagsInput/Rating, rewrite to "current" for Stepper, keep for SplitterResizeHandle` — `active` / `inactive` now mean three different things: Tabs, TagsInput and Rating moved to `checked` / `unchecked`, Stepper moved to `current` / `upcoming` (keeping `completed`), and the Splitter resize handle still emits `inactive`. The decision is made once per file from the component names it mentions: a file that mentions only `Tabs`, `TagsInput` or `Rating` is rewritten to `checked` / `unchecked`, a file that mentions only `Stepper` is rewritten to `current` / `upcoming`, a file that mentions only `SplitterResizeHandle` is kept, and a file that mentions more than one of those groups, or none of them, gets this warning (with `"inactive"` / `"unchecked"` / `"upcoming"` for the `inactive` value).
 - `"[data-state]" is now always present, so a presence-only selector matches every part; target the explicit value instead` — a bare `[data-state]` or `:not([data-state])` selector relied on the attribute being present or absent (for example a `RatingItemIndicator` that was active, or a non-collapsible `SplitterPanel`). In v3 both values are always emitted, so `[data-state]` matches every part and `:not([data-state])` matches nothing; target `checked` / `unchecked` or `open` / `closed` instead.

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reka-ui/codemod",
   "type": "module",
-  "version": "3.0.0-alpha.0",
+  "version": "2.10.1",
   "description": "Codemods for migrating a codebase between Reka UI major versions.",
   "author": "UnoVue Contributors (https://github.com/unovue)",
   "license": "MIT",
@@ -33,6 +33,10 @@
   ],
   "engines": {
     "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "test": "node --test"

--- a/packages/codemod/src/data-state.mjs
+++ b/packages/codemod/src/data-state.mjs
@@ -5,6 +5,11 @@
  * `peer-data-[state=on]:`, quoted or not) and CSS attribute selectors
  * (`[data-state=on]`, `[data-state='on']`, `[data-state="on"]`).
  *
+ * `active` / `inactive` mean three different things in v3 (`checked` /
+ * `unchecked` for Tabs, TagsInput and Rating; `current` / `upcoming` for
+ * Stepper; unchanged for the Splitter resize handle), so they are decided once
+ * per file from the component names the file mentions.
+ *
  * Anything that cannot be decided mechanically is left untouched and reported
  * as a warning so a human can finish the job.
  */
@@ -20,20 +25,29 @@ const RENAMES = {
   'instant-open': 'open',
 }
 
-/** Values whose meaning depends on the component the file is styling. */
+/**
+ * Values whose meaning depends on the component the file is styling, keyed by
+ * the group of components that share a rewrite. Each group lists the component
+ * names that identify it and the v3 value for each ambiguous v2 value (`null`
+ * keeps the v2 value, for components that still emit it).
+ */
 const AMBIGUOUS = {
-  active: 'checked',
-  inactive: 'unchecked',
+  selection: {
+    components: ['Tabs', 'TagsInput', 'Rating'],
+    values: { active: 'checked', inactive: 'unchecked' },
+  },
+  stepper: {
+    components: ['Stepper'],
+    values: { active: 'current', inactive: 'upcoming' },
+  },
+  splitter: {
+    components: ['SplitterResizeHandle'],
+    values: { active: null, inactive: null },
+  },
 }
 
-/** Components that moved `active` / `inactive` to `checked` / `unchecked`. */
-const SELECTION_COMPONENTS = ['Tabs', 'TagsInput', 'Rating']
-
-/** Components that still emit `active` / `inactive`. */
-const MULTI_STATE_COMPONENTS = ['Stepper', 'SplitterResizeHandle']
-
 const ALWAYS_VALUES = Object.keys(RENAMES)
-const AMBIGUOUS_VALUES = Object.keys(AMBIGUOUS)
+const AMBIGUOUS_VALUES = ['active', 'inactive']
 
 /**
  * `data-[state=X]` / `data-[state='X']` / `data-[state="X"]`, optionally
@@ -70,24 +84,24 @@ function mentionsAny(source, names) {
 }
 
 /**
- * Decide, once per file, what to do with `active` / `inactive`.
- * @returns {'rewrite' | 'keep' | 'warn'}
+ * Decide, once per file, what to do with `active` / `inactive` from the
+ * component names the file mentions: exactly one group → that group's
+ * mapping (a `null` entry keeps the value); more than one, or none → `null`,
+ * and every occurrence is reported instead of rewritten.
+ * @returns {Record<string, string | null> | null}
  */
 function decideAmbiguous(source) {
-  const selection = mentionsAny(source, SELECTION_COMPONENTS)
-  const multiState = mentionsAny(source, MULTI_STATE_COMPONENTS)
-  if (selection && !multiState)
-    return 'rewrite'
-  if (multiState && !selection)
-    return 'keep'
-  return 'warn'
+  const groups = Object.values(AMBIGUOUS).filter(group => mentionsAny(source, group.components))
+  return groups.length === 1 ? groups[0].values : null
 }
 
 function ambiguousWarning(value) {
-  return `ambiguous data-state "${value}": rewrite to "${AMBIGUOUS[value]}" for Tabs/TagsInput/Rating, keep for Stepper/Splitter`
+  const outcomes = Object.values(AMBIGUOUS)
+    .map(({ components, values }) => `${values[value] === null ? 'keep' : `rewrite to "${values[value]}"`} for ${components.join('/')}`)
+  return `ambiguous data-state "${value}": ${outcomes.join(', ')}`
 }
 
-function transformLine(line, mode) {
+function transformLine(line, mapping) {
   const warnings = []
 
   let out = line
@@ -97,12 +111,12 @@ function transformLine(line, mode) {
     .replace(TAILWIND_RENAME, (_, prefix = '', quote, value) => `${prefix}data-[state=${quote}${RENAMES[value]}${quote}]`)
     .replace(CSS_RENAME, (_, open, quote, value, close) => `${open}${quote}${RENAMES[value]}${quote}${close}`)
 
-  if (mode === 'rewrite') {
+  if (mapping) {
     out = out
-      .replace(TAILWIND_AMBIGUOUS, (_, prefix = '', quote, value) => `${prefix}data-[state=${quote}${AMBIGUOUS[value]}${quote}]`)
-      .replace(CSS_AMBIGUOUS, (_, open, quote, value, close) => `${open}${quote}${AMBIGUOUS[value]}${quote}${close}`)
+      .replace(TAILWIND_AMBIGUOUS, (_, prefix = '', quote, value) => `${prefix}data-[state=${quote}${mapping[value] ?? value}${quote}]`)
+      .replace(CSS_AMBIGUOUS, (_, open, quote, value, close) => `${open}${quote}${mapping[value] ?? value}${quote}${close}`)
   }
-  else if (mode === 'warn') {
+  else {
     const found = new Set()
     for (const pattern of [TAILWIND_AMBIGUOUS, CSS_AMBIGUOUS]) {
       for (const match of out.matchAll(pattern))
@@ -128,13 +142,13 @@ function transformLine(line, mode) {
  * @returns {{ code: string, changed: boolean, warnings: Array<{ line: number, message: string }> }}
  */
 export function transformDataState(source, _options = {}) {
-  const mode = decideAmbiguous(source)
+  const mapping = decideAmbiguous(source)
   const warnings = []
   const lines = source.split('\n')
 
   const code = lines
     .map((line, index) => {
-      const result = transformLine(line, mode)
+      const result = transformLine(line, mapping)
       for (const message of result.warnings)
         warnings.push({ line: index + 1, message })
       return result.line

--- a/packages/codemod/test/data-state.test.mjs
+++ b/packages/codemod/test/data-state.test.mjs
@@ -108,10 +108,10 @@ describe('delayed-open', () => {
 })
 
 describe('active / inactive', () => {
-  const activeWarning = 'ambiguous data-state "active": rewrite to "checked" for Tabs/TagsInput/Rating, keep for Stepper/Splitter'
-  const inactiveWarning = 'ambiguous data-state "inactive": rewrite to "unchecked" for Tabs/TagsInput/Rating, keep for Stepper/Splitter'
+  const activeWarning = 'ambiguous data-state "active": rewrite to "checked" for Tabs/TagsInput/Rating, rewrite to "current" for Stepper, keep for SplitterResizeHandle'
+  const inactiveWarning = 'ambiguous data-state "inactive": rewrite to "unchecked" for Tabs/TagsInput/Rating, rewrite to "upcoming" for Stepper, keep for SplitterResizeHandle'
 
-  it('rewrites when the file only mentions Tabs, TagsInput or Rating', () => {
+  it('rewrites to checked / unchecked when the file only mentions Tabs, TagsInput or Rating', () => {
     const source = [
       '<TabsTrigger class="data-[state=active]:text-grass-11 data-[state=inactive]:text-gray-11" />',
       `.TagsInputItem[data-state='active'] {}`,
@@ -126,9 +126,27 @@ describe('active / inactive', () => {
     assert.deepEqual(result.warnings, [])
   })
 
-  it('keeps active and inactive when the file only mentions Stepper or SplitterResizeHandle', () => {
+  it('rewrites to current / upcoming when the file only mentions Stepper', () => {
     const source = [
-      '<StepperItem class="data-[state=active]:font-bold data-[state=inactive]:opacity-50 data-[state=completed]:text-green" />',
+      '<StepperItem class="group data-[state=active]:font-bold data-[state=inactive]:opacity-50 data-[state=completed]:text-green" />',
+      '<StepperTrigger class="group-data-[state=active]:bg-black group-data-[state=inactive]:bg-white" />',
+      `.StepperItem[data-state='active'] .StepperIndicator {}`,
+      `.StepperSeparator[data-state="inactive"] {}`,
+    ].join('\n')
+    const result = transformDataState(source)
+    assert.equal(result.code, [
+      '<StepperItem class="group data-[state=current]:font-bold data-[state=upcoming]:opacity-50 data-[state=completed]:text-green" />',
+      '<StepperTrigger class="group-data-[state=current]:bg-black group-data-[state=upcoming]:bg-white" />',
+      `.StepperItem[data-state='current'] .StepperIndicator {}`,
+      `.StepperSeparator[data-state="upcoming"] {}`,
+    ].join('\n'))
+    assert.equal(result.changed, true)
+    assert.deepEqual(result.warnings, [])
+  })
+
+  it('keeps active and inactive when the file only mentions SplitterResizeHandle', () => {
+    const source = [
+      '<SplitterResizeHandle class="data-[state=inactive]:bg-gray-3 data-[state=active]:bg-gray-5" />',
       `.SplitterResizeHandle[data-state='inactive'] {}`,
     ].join('\n')
     const result = transformDataState(source)
@@ -137,7 +155,7 @@ describe('active / inactive', () => {
     assert.deepEqual(result.warnings, [])
   })
 
-  it('warns per line when the file mentions both families', () => {
+  it('warns per line when the file mentions more than one group', () => {
     const source = [
       '<TabsTrigger class="data-[state=active]:font-bold" />',
       '<StepperItem class="data-[state=active]:font-bold" />',
@@ -153,7 +171,21 @@ describe('active / inactive', () => {
     ])
   })
 
-  it('warns when the file mentions neither family', () => {
+  it('warns when the file mentions both Stepper and SplitterResizeHandle', () => {
+    const source = [
+      '<StepperItem class="data-[state=inactive]:opacity-50" />',
+      `.SplitterResizeHandle[data-state='inactive'] {}`,
+    ].join('\n')
+    const result = transformDataState(source)
+    assert.equal(result.code, source)
+    assert.equal(result.changed, false)
+    assert.deepEqual(result.warnings, [
+      { line: 1, message: inactiveWarning },
+      { line: 2, message: inactiveWarning },
+    ])
+  })
+
+  it('warns when the file mentions no group', () => {
     const source = `.trigger[data-state="active"] { color: red; }`
     const result = transformDataState(source)
     assert.equal(result.code, source)

--- a/packages/core/src/HoverCard/HoverCardContentImpl.vue
+++ b/packages/core/src/HoverCard/HoverCardContentImpl.vue
@@ -2,7 +2,7 @@
 import type { DismissableLayerDismissDetails, DismissableLayerEmits } from '@/DismissableLayer'
 import type { PopperContentProps } from '@/Popper'
 import { syncRef } from '@vueuse/shared'
-import { disclosureState, useForwardExpose, useGraceArea } from '@/shared'
+import { useForwardExpose, useGraceArea } from '@/shared'
 
 export type HoverCardContentImplEmits = DismissableLayerEmits
 export interface HoverCardContentImplProps extends PopperContentProps {}
@@ -10,11 +10,12 @@ export interface HoverCardContentImplProps extends PopperContentProps {}
 
 <script setup lang="ts">
 import { useEventListener } from '@vueuse/core'
-import { nextTick, onMounted, onUnmounted, ref, watchEffect } from 'vue'
+import { mergeProps, nextTick, onMounted, onUnmounted, ref, watchEffect } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { PopperContent } from '@/Popper'
 import { useForwardProps } from '..'
 import { injectHoverCardRootContext } from './HoverCardRoot.vue'
+import { getHoverCardContentSurface } from './useHoverCard'
 import { getTabbableNodes } from './utils'
 
 const props = defineProps<HoverCardContentImplProps>()
@@ -24,6 +25,13 @@ const forwarded = useForwardProps(props)
 const { forwardRef, currentElement: contentElement } = useForwardExpose()
 const rootContext = injectHoverCardRootContext()
 const { isPointerInTransit, onPointerExit } = useGraceArea(rootContext.triggerElement, contentElement)
+
+// `data-state` comes from the shared surface builder (single source with
+// `useHoverCard()`); the grace area, selection containment, tabbable
+// neutralisation, scroll dismissal, DismissableLayer (which hands the dismiss
+// reason + event to `onDismiss`), PopperContent and the `--reka-hover-card-*`
+// CSS variables stay in the SFC.
+const content = getHoverCardContentSurface(rootContext)
 
 syncRef(rootContext.isPointerInTransitRef, isPointerInTransit, { direction: 'rtl' })
 
@@ -125,9 +133,8 @@ onUnmounted(() => {
     @dismiss="handleDismiss"
   >
     <PopperContent
-      v-bind="{ ...forwarded, ...$attrs }"
+      v-bind="mergeProps(forwarded, $attrs, content.attrs.value)"
       :ref="forwardRef"
-      :data-state="disclosureState(rootContext.open.value)"
       :style="{
         'userSelect': containSelection ? 'text' : undefined,
         // Safari requires prefix

--- a/packages/core/src/HoverCard/HoverCardRoot.vue
+++ b/packages/core/src/HoverCard/HoverCardRoot.vue
@@ -39,7 +39,7 @@ export interface HoverCardRootContext {
   /** Sets `open` immediately. Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
   onOpenChange: (value: boolean, reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => boolean
   /**
-   * Cancels a pending close and opens after `openDelay`. The change is deferred,
+   * Cancels a pending open or close and opens after `openDelay`. The change is deferred,
    * so its outcome is only known when the timer fires; `reason`/`event` travel
    * with it into `beforeUpdate:open` / `update:open`.
    */

--- a/packages/core/src/HoverCard/HoverCardRoot.vue
+++ b/packages/core/src/HoverCard/HoverCardRoot.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ComputedRef, Ref } from 'vue'
 import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
-import { createContext, useControllableState, useForwardExpose } from '@/shared'
+import { createContext, useForwardExpose } from '@/shared'
 
 /** Why the hover card's `open` state changed (#2828); the `reason` of `ChangeEventDetails`. */
 export type HoverCardOpenChangeReason
@@ -63,8 +63,8 @@ export const [injectHoverCardRootContext, provideHoverCardRootContext]
 </script>
 
 <script setup lang="ts">
-import { ref, toRefs } from 'vue'
 import { PopperRoot } from '@/Popper'
+import { useHoverCard } from './useHoverCard'
 
 const props = withDefaults(defineProps<HoverCardRootProps>(), {
   defaultOpen: false,
@@ -82,56 +82,22 @@ defineSlots<{
   }) => any
 }>()
 
-const { openDelay, closeDelay, enableTouch } = toRefs(props)
-
 useForwardExpose()
 
-// Every write to `open` — the delayed hover/focus timers, the touch toggle and
-// dismiss — goes through one `setState`, so `beforeUpdate:open` can cancel any
-// of them and `update:open` always carries the reason (#2828). The timers
-// capture the reason and event of the interaction that started them.
-const { state: open, setState } = useControllableState<boolean, HoverCardOpenChangeReason>({
-  prop: () => props.open,
-  defaultValue: props.defaultOpen,
-  name: 'open',
+// Controlled/uncontrolled `open`, the `beforeUpdate:` / `update:` emits and the
+// `openDelay` / `closeDelay` timers all live in the composable (`open ===
+// undefined` → uncontrolled). The delays and `enableTouch` are handed in as
+// getters so a prop change is picked up by the next timer / tap.
+const { open, context } = useHoverCard({
+  open: () => props.open,
+  defaultOpen: props.defaultOpen,
+  openDelay: () => props.openDelay,
+  closeDelay: () => props.closeDelay,
+  enableTouch: () => props.enableTouch,
   emit,
 })
 
-const openTimerRef = ref(0)
-const closeTimerRef = ref(0)
-const hasSelectionRef = ref(false)
-const isPointerDownOnContentRef = ref(false)
-const isPointerInTransitRef = ref(false)
-const triggerElement = ref<HTMLElement>()
-
-function handleOpen(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
-  clearTimeout(closeTimerRef.value)
-  openTimerRef.value = window.setTimeout(setState, openDelay.value, true, reason, event)
-}
-
-function handleClose(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
-  clearTimeout(openTimerRef.value)
-  if (!hasSelectionRef.value && !isPointerDownOnContentRef.value)
-    closeTimerRef.value = window.setTimeout(setState, closeDelay.value, false, reason, event)
-}
-
-function handleDismiss(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
-  clearTimeout(openTimerRef.value)
-  return setState(false, reason, event)
-}
-
-provideHoverCardRootContext({
-  open,
-  onOpenChange: (value, reason, event) => setState(value, reason, event),
-  onOpen: handleOpen,
-  onClose: handleClose,
-  onDismiss: handleDismiss,
-  hasSelectionRef,
-  isPointerDownOnContentRef,
-  isPointerInTransitRef,
-  triggerElement,
-  enableTouch,
-})
+provideHoverCardRootContext(context)
 </script>
 
 <template>

--- a/packages/core/src/HoverCard/HoverCardTrigger.vue
+++ b/packages/core/src/HoverCard/HoverCardTrigger.vue
@@ -6,9 +6,9 @@ export interface HoverCardTriggerProps extends PopperAnchorProps {}
 import type { PopperAnchorProps } from '@/Popper'
 import { PopperAnchor } from '@/Popper'
 import { Primitive } from '@/Primitive'
-import { disclosureState, useForwardExpose } from '@/shared'
+import { useForwardExpose } from '@/shared'
 import { injectHoverCardRootContext } from './HoverCardRoot.vue'
-import { excludeTouch } from './utils'
+import { getHoverCardTriggerSurface } from './useHoverCard'
 
 withDefaults(defineProps<HoverCardTriggerProps>(), {
   as: 'a',
@@ -18,29 +18,14 @@ const { forwardRef, currentElement } = useForwardExpose()
 const rootContext = injectHoverCardRootContext()
 rootContext.triggerElement = currentElement
 
-function handlePointerEnter(event: PointerEvent) {
-  rootContext.onOpen('trigger-hover', event)
-}
-
-// While open, leaving the trigger is handled by the grace area (see
-// HoverCardContentImpl): this only cancels a pending delayed open.
-function handleLeave(event: PointerEvent) {
-  setTimeout(() => {
-    if (!rootContext.isPointerInTransitRef.value && !rootContext.open.value) {
-      rootContext.onClose('trigger-leave', event)
-    }
-  }, 0)
-}
-
-function handleTouch(event: PointerEvent) {
-  if (!rootContext.enableTouch.value || event.pointerType !== 'touch')
-    return
-
-  if (rootContext.open.value)
-    rootContext.onDismiss('trigger-press', event)
-  else
-    rootContext.onOpenChange(true, 'trigger-press', event)
-}
+// `data-state`, the `data-grace-area-trigger` selector and the hover / leave /
+// touch / focus / blur listeners all come from the shared surface builder
+// (single source with `useHoverCard()`); the PopperAnchor wrapper and the
+// element registration above stay in the SFC. Listener order is unchanged:
+// `$attrs` fall through the as-child wrapper and `Slot` merges them BEFORE the
+// inner element's own props, so a consumer `@pointerenter` still runs before
+// the surface's.
+const trigger = getHoverCardTriggerSurface(rootContext)
 </script>
 
 <template>
@@ -52,13 +37,7 @@ function handleTouch(event: PointerEvent) {
       :ref="forwardRef"
       :as-child="asChild"
       :as="as"
-      :data-state="disclosureState(rootContext.open.value)"
-      data-grace-area-trigger
-      @pointerenter="excludeTouch(handlePointerEnter)($event)"
-      @pointerleave="excludeTouch(handleLeave)($event)"
-      @pointerup="handleTouch"
-      @focus="rootContext.onOpen('trigger-focus', $event)"
-      @blur="rootContext.onClose('trigger-blur', $event)"
+      v-bind="trigger.attrs.value"
     >
       <slot />
     </Primitive>

--- a/packages/core/src/HoverCard/index.ts
+++ b/packages/core/src/HoverCard/index.ts
@@ -21,3 +21,10 @@ export {
   default as HoverCardTrigger,
   type HoverCardTriggerProps,
 } from './HoverCardTrigger.vue'
+export {
+  type HoverCardContentState,
+  type HoverCardTriggerState,
+  useHoverCard,
+  type UseHoverCardProps,
+  type UseHoverCardReturn,
+} from './useHoverCard'

--- a/packages/core/src/HoverCard/useHoverCard.test.ts
+++ b/packages/core/src/HoverCard/useHoverCard.test.ts
@@ -1,0 +1,407 @@
+import { fireEvent, render } from '@testing-library/vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+import { defineComponent, ref } from 'vue'
+import * as Reka from '../index'
+import { useHoverCard } from './useHoverCard'
+
+// jsdom has no reliable `PointerEvent`; a `MouseEvent` with `pointerType`
+// assigned is all `excludeTouch` and the touch toggle read.
+function pointerEvent(type: string, pointerType: 'mouse' | 'touch' = 'mouse'): PointerEvent {
+  return Object.assign(new MouseEvent(type), { pointerType }) as PointerEvent
+}
+
+describe('useHoverCard — state', () => {
+  it('defaults to closed, uncontrolled, touch disabled', () => {
+    const h = useHoverCard()
+    expect(h.open.value).toBe(false)
+    expect(h.isControlled.value).toBe(false)
+    expect(h.context.enableTouch.value).toBe(false)
+    expect(h.lastChangeDetails.value.reason).toBe('none')
+  })
+
+  it('honours defaultOpen and a reactive enableTouch getter', () => {
+    const enableTouch = ref(false)
+    const h = useHoverCard({ defaultOpen: true, enableTouch: () => enableTouch.value })
+    expect(h.open.value).toBe(true)
+    expect(h.context.enableTouch.value).toBe(false)
+    enableTouch.value = true
+    expect(h.context.enableTouch.value).toBe(true)
+  })
+
+  it('onOpenChange() sets the state immediately and reports imperative-action by default', () => {
+    const h = useHoverCard()
+    expect(h.onOpenChange(true)).toBe(true)
+    expect(h.open.value).toBe(true)
+    expect(h.lastChangeDetails.value.reason).toBe('imperative-action')
+    // Unchanged → false, no new details.
+    expect(h.onOpenChange(true)).toBe(false)
+    expect(h.onOpenChange(false)).toBe(true)
+    expect(h.open.value).toBe(false)
+  })
+
+  it('ref-owned mode writes through the passed ref', () => {
+    const open = ref(false)
+    const h = useHoverCard({ open })
+    expect(h.isControlled.value).toBe(true)
+    h.onOpenChange(true, 'trigger-press')
+    expect(open.value).toBe(true)
+    expect(h.open.value).toBe(true)
+  })
+
+  it('controlled getter + emit: emits beforeUpdate/update with the same details and does not write locally', () => {
+    const emit = vi.fn()
+    const h = useHoverCard({ open: () => false, emit })
+    expect(h.isControlled.value).toBe(true)
+    const event = new KeyboardEvent('keydown', { key: 'Escape' })
+    h.onOpenChange(true, 'trigger-press', event)
+    expect(h.open.value).toBe(false)
+    expect(emit).toHaveBeenCalledTimes(2)
+    expect(emit).toHaveBeenNthCalledWith(1, 'beforeUpdate:open', true, expect.objectContaining({ reason: 'trigger-press', event }))
+    expect(emit).toHaveBeenNthCalledWith(2, 'update:open', true, expect.objectContaining({ reason: 'trigger-press', event }))
+    const [, , beforeDetails] = emit.mock.calls[0]
+    const [, , details] = emit.mock.calls[1]
+    expect(beforeDetails).toBe(details)
+  })
+
+  it('cancel() in onBeforeUpdate vetoes the change and skips onUpdate', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ onBeforeUpdate: (_value, details) => details.cancel(), onUpdate })
+    expect(h.onOpenChange(true, 'trigger-press')).toBe(false)
+    expect(h.open.value).toBe(false)
+    expect(h.lastChangeDetails.value).toMatchObject({ reason: 'trigger-press', isCanceled: true })
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('useHoverCard — timers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('onOpen() opens after openDelay (default 700) carrying reason + event', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ onUpdate })
+    const event = pointerEvent('pointerenter')
+    h.onOpen('trigger-hover', event)
+    vi.advanceTimersByTime(699)
+    expect(h.open.value).toBe(false)
+    expect(onUpdate).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(h.open.value).toBe(true)
+    expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-hover', event, isCanceled: false }))
+    expect(h.lastChangeDetails.value.reason).toBe('trigger-hover')
+  })
+
+  it('onClose() closes after closeDelay (default 300) carrying reason + event', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ defaultOpen: true, onUpdate })
+    const event = new FocusEvent('blur')
+    h.onClose('trigger-blur', event)
+    vi.advanceTimersByTime(299)
+    expect(h.open.value).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(h.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenCalledWith(false, expect.objectContaining({ reason: 'trigger-blur', event }))
+  })
+
+  it('reads openDelay / closeDelay through getters at scheduling time', () => {
+    const openDelay = ref(100)
+    const h = useHoverCard({ openDelay, closeDelay: () => 50 })
+    h.onOpen()
+    vi.advanceTimersByTime(100)
+    expect(h.open.value).toBe(true)
+    h.onClose()
+    vi.advanceTimersByTime(50)
+    expect(h.open.value).toBe(false)
+
+    openDelay.value = 10
+    h.onOpen()
+    vi.advanceTimersByTime(10)
+    expect(h.open.value).toBe(true)
+  })
+
+  it('onClose() cancels a pending open', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ onUpdate })
+    h.onOpen('trigger-hover')
+    vi.advanceTimersByTime(500)
+    h.onClose('trigger-leave')
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(false)
+    // The scheduled `setState(false)` on an already-closed card is a no-op.
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('onOpen() cancels a pending close', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ defaultOpen: true, onUpdate })
+    h.onClose('trigger-leave')
+    vi.advanceTimersByTime(200)
+    h.onOpen('content-hover')
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(true)
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('hasSelectionRef / isPointerDownOnContentRef block the delayed close but still cancel a pending open', () => {
+    const h = useHoverCard({ defaultOpen: true })
+    h.context.hasSelectionRef.value = true
+    h.onClose('content-leave')
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(true)
+
+    h.context.hasSelectionRef.value = false
+    h.context.isPointerDownOnContentRef.value = true
+    h.onClose('content-leave')
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(true)
+
+    // A pending open is still cancelled while the close is withheld.
+    h.onOpenChange(false)
+    h.onOpen('trigger-hover')
+    h.onClose('trigger-leave')
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(false)
+
+    h.context.isPointerDownOnContentRef.value = false
+    h.onOpenChange(true)
+    h.onClose('content-leave')
+    vi.advanceTimersByTime(300)
+    expect(h.open.value).toBe(false)
+  })
+
+  it('onDismiss() closes immediately, cancels a pending open and returns false when already closed', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ defaultOpen: true, onUpdate })
+    const event = new KeyboardEvent('keydown', { key: 'Escape' })
+    expect(h.onDismiss('escape-key', event)).toBe(true)
+    expect(h.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenCalledWith(false, expect.objectContaining({ reason: 'escape-key', event }))
+
+    // Already closed → no-op.
+    expect(h.onDismiss('outside-press')).toBe(false)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+
+    // A pending open does not survive a dismiss.
+    h.onOpen('trigger-focus')
+    expect(h.onDismiss('trigger-press')).toBe(false)
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useHoverCard — trigger surface', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('props expose the grace-area selector and the listeners but no semantic data-*', () => {
+    const h = useHoverCard()
+    const props = h.trigger.props.value
+    // `data-grace-area-trigger` is a functional selector `useGraceArea` queries,
+    // not state — the one `data-*` allowed in `props`.
+    expect(props['data-grace-area-trigger']).toBe('')
+    expect(props['data-state']).toBeUndefined()
+    expect(Object.keys(props).filter(k => k.startsWith('data-'))).toEqual(['data-grace-area-trigger'])
+    for (const key of ['onPointerenter', 'onPointerleave', 'onPointerup', 'onFocus', 'onBlur'])
+      expect(typeof props[key]).toBe('function')
+  })
+
+  it('attrs merge props with the data-state derived from state', () => {
+    const h = useHoverCard()
+    expect(h.trigger.state.value).toEqual({ state: 'closed' })
+    expect(h.trigger.attrs.value).toMatchObject({ 'data-state': 'closed', 'data-grace-area-trigger': '' })
+    h.onOpenChange(true)
+    expect(h.trigger.state.value).toEqual({ state: 'open' })
+    expect(h.trigger.attrs.value['data-state']).toBe('open')
+  })
+
+  it('onPointerenter schedules a trigger-hover open; touch pointers are ignored', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ onUpdate })
+    h.trigger.props.value.onPointerenter(pointerEvent('pointerenter', 'touch'))
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(false)
+
+    const event = pointerEvent('pointerenter')
+    h.trigger.props.value.onPointerenter(event)
+    expect(h.open.value).toBe(false)
+    vi.advanceTimersByTime(700)
+    expect(h.open.value).toBe(true)
+    expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-hover', event }))
+  })
+
+  it('onPointerleave only cancels a pending open (a tick later); open cards are left to the grace area', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ onUpdate })
+    h.trigger.props.value.onPointerenter(pointerEvent('pointerenter'))
+    h.trigger.props.value.onPointerleave(pointerEvent('pointerleave'))
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(false)
+    expect(onUpdate).not.toHaveBeenCalled()
+
+    // Touch leave is ignored: the pending open survives.
+    h.trigger.props.value.onPointerenter(pointerEvent('pointerenter'))
+    h.trigger.props.value.onPointerleave(pointerEvent('pointerleave', 'touch'))
+    vi.advanceTimersByTime(700)
+    expect(h.open.value).toBe(true)
+
+    // While open, leaving the trigger schedules nothing.
+    h.trigger.props.value.onPointerleave(pointerEvent('pointerleave'))
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(true)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+
+    // While in transit towards the content, a leave is also ignored.
+    h.onOpenChange(false)
+    h.trigger.props.value.onPointerenter(pointerEvent('pointerenter'))
+    h.context.isPointerInTransitRef.value = true
+    h.trigger.props.value.onPointerleave(pointerEvent('pointerleave'))
+    vi.advanceTimersByTime(700)
+    expect(h.open.value).toBe(true)
+  })
+
+  it('onPointerup toggles immediately on touch only when enableTouch is set', () => {
+    const onUpdate = vi.fn()
+    const enableTouch = ref(false)
+    const h = useHoverCard({ enableTouch, onUpdate })
+    h.trigger.props.value.onPointerup(pointerEvent('pointerup', 'touch'))
+    expect(h.open.value).toBe(false)
+
+    enableTouch.value = true
+    // Non-touch pointers never toggle.
+    h.trigger.props.value.onPointerup(pointerEvent('pointerup', 'mouse'))
+    expect(h.open.value).toBe(false)
+
+    const tap = pointerEvent('pointerup', 'touch')
+    h.trigger.props.value.onPointerup(tap)
+    expect(h.open.value).toBe(true)
+    expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-press', event: tap }))
+
+    // Closing on tap is a dismiss: immediate, and it drops a pending focus open.
+    h.trigger.props.value.onFocus(new FocusEvent('focus'))
+    h.trigger.props.value.onPointerup(pointerEvent('pointerup', 'touch'))
+    expect(h.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenLastCalledWith(false, expect.objectContaining({ reason: 'trigger-press' }))
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(false)
+  })
+
+  it('onFocus / onBlur schedule the delayed open / close with their reasons', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ onUpdate })
+    const focus = new FocusEvent('focus')
+    h.trigger.props.value.onFocus(focus)
+    vi.advanceTimersByTime(700)
+    expect(h.open.value).toBe(true)
+    expect(onUpdate).toHaveBeenLastCalledWith(true, expect.objectContaining({ reason: 'trigger-focus', event: focus }))
+
+    const blur = new FocusEvent('blur')
+    h.trigger.props.value.onBlur(blur)
+    vi.advanceTimersByTime(300)
+    expect(h.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenLastCalledWith(false, expect.objectContaining({ reason: 'trigger-blur', event: blur }))
+  })
+})
+
+describe('useHoverCard — content surface', () => {
+  it('is state-only: no props, data-state in attrs', () => {
+    const h = useHoverCard()
+    expect(h.content.props.value).toEqual({})
+    expect(h.content.state.value).toEqual({ state: 'closed' })
+    expect(h.content.attrs.value).toEqual({ 'data-state': 'closed' })
+    h.onOpenChange(true)
+    expect(h.content.attrs.value).toEqual({ 'data-state': 'open' })
+  })
+})
+
+describe('useHoverCard — context', () => {
+  it('exposes the frozen-shape HoverCardRootContext', () => {
+    const h = useHoverCard()
+    expect(Object.keys(h.context).sort()).toEqual([
+      'enableTouch',
+      'hasSelectionRef',
+      'isPointerDownOnContentRef',
+      'isPointerInTransitRef',
+      'onClose',
+      'onDismiss',
+      'onOpen',
+      'onOpenChange',
+      'open',
+      'triggerElement',
+    ])
+    expect(h.context.open).toBe(h.open)
+    expect(h.context.onOpenChange).toBe(h.onOpenChange)
+    expect(h.context.onOpen).toBe(h.onOpen)
+    expect(h.context.onClose).toBe(h.onClose)
+    expect(h.context.onDismiss).toBe(h.onDismiss)
+    expect(h.context.triggerElement.value).toBeUndefined()
+    expect(h.context.hasSelectionRef.value).toBe(false)
+    expect(h.context.isPointerDownOnContentRef.value).toBe(false)
+    expect(h.context.isPointerInTransitRef.value).toBe(false)
+    expect(h.context.onOpenChange(true, 'trigger-press')).toBe(true)
+    expect(h.open.value).toBe(true)
+    // Dismissal reasons arrive through `onDismiss` from the layer the consumer composes.
+    const event = new KeyboardEvent('keydown', { key: 'Escape' })
+    expect(h.context.onDismiss('escape-key', event)).toBe(true)
+    expect(h.lastChangeDetails.value).toMatchObject({ reason: 'escape-key', event })
+  })
+})
+
+describe('useHoverCard — rendered surfaces', () => {
+  // A standalone consumer binding the surfaces to plain elements, without the
+  // Popper / Presence / DismissableLayer wrappers or the grace area: the
+  // trigger wiring alone has to satisfy axe, closed and open. Zero delays so
+  // the timers resolve on the next macrotask.
+  const Fixture = defineComponent({
+    setup() {
+      const h = useHoverCard({ openDelay: 0, closeDelay: 0 })
+      return { h }
+    },
+    template: `
+      <a href="#" v-bind="h.trigger.attrs.value">Trigger</a>
+      <div v-if="h.open.value" v-bind="h.content.attrs.value">
+        <p>Body</p>
+      </div>
+    `,
+  })
+
+  it('wires trigger and content together and passes axe, closed and open', async () => {
+    const { container, getByText, queryByText } = render(Fixture)
+    const trigger = getByText('Trigger')
+    expect(trigger.getAttribute('data-state')).toBe('closed')
+    expect(trigger.hasAttribute('data-grace-area-trigger')).toBe(true)
+    expect(queryByText('Body')).toBeNull()
+    expect(await axe(container)).toHaveNoViolations()
+
+    await fireEvent.focus(trigger)
+    await vi.waitFor(() => expect(trigger.getAttribute('data-state')).toBe('open'))
+    const content = getByText('Body').parentElement!
+    expect(content.getAttribute('data-state')).toBe('open')
+    expect(await axe(container)).toHaveNoViolations()
+
+    await fireEvent.blur(trigger)
+    await vi.waitFor(() => expect(trigger.getAttribute('data-state')).toBe('closed'))
+    expect(queryByText('Body')).toBeNull()
+  })
+})
+
+describe('useHoverCard — public export', () => {
+  it('is exported from the package barrel; the surface builders are internal', () => {
+    expect(typeof Reka.useHoverCard).toBe('function')
+    expect('getHoverCardTriggerSurface' in Reka).toBe(false)
+    expect('getHoverCardContentSurface' in Reka).toBe(false)
+  })
+})

--- a/packages/core/src/HoverCard/useHoverCard.test.ts
+++ b/packages/core/src/HoverCard/useHoverCard.test.ts
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
-import { defineComponent, ref } from 'vue'
+import { defineComponent, effectScope, ref } from 'vue'
 import * as Reka from '../index'
 import { useHoverCard } from './useHoverCard'
 
@@ -177,6 +177,36 @@ describe('useHoverCard — timers', () => {
     expect(h.open.value).toBe(false)
   })
 
+  it('onOpen() replaces a pending open, so the next onClose() cancels both', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ onUpdate })
+    h.onOpen('trigger-hover')
+    vi.advanceTimersByTime(100)
+    h.onOpen('trigger-focus')
+    h.onClose('trigger-leave')
+    vi.advanceTimersByTime(2000)
+    expect(h.open.value).toBe(false)
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('clears pending timers when the owning effect scope is disposed', () => {
+    const onUpdate = vi.fn()
+    const scope = effectScope()
+    const h = scope.run(() => useHoverCard({ onUpdate }))!
+    h.onOpen('trigger-hover')
+    scope.stop()
+    vi.advanceTimersByTime(1000)
+    expect(h.open.value).toBe(false)
+
+    const scope2 = effectScope()
+    const h2 = scope2.run(() => useHoverCard({ defaultOpen: true, onUpdate }))!
+    h2.onClose('trigger-leave')
+    scope2.stop()
+    vi.advanceTimersByTime(1000)
+    expect(h2.open.value).toBe(true)
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
   it('onDismiss() closes immediately, cancels a pending open and returns false when already closed', () => {
     const onUpdate = vi.fn()
     const h = useHoverCard({ defaultOpen: true, onUpdate })
@@ -241,6 +271,18 @@ describe('useHoverCard — trigger surface', () => {
     vi.advanceTimersByTime(700)
     expect(h.open.value).toBe(true)
     expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-hover', event }))
+  })
+
+  it('a focus that follows a hover leaves one pending open for pointerleave to cancel', () => {
+    const onUpdate = vi.fn()
+    const h = useHoverCard({ onUpdate })
+    h.trigger.props.value.onPointerenter(pointerEvent('pointerenter'))
+    vi.advanceTimersByTime(100)
+    h.trigger.props.value.onFocus(new FocusEvent('focus'))
+    h.trigger.props.value.onPointerleave(pointerEvent('pointerleave'))
+    vi.advanceTimersByTime(2000)
+    expect(h.open.value).toBe(false)
+    expect(onUpdate).not.toHaveBeenCalled()
   })
 
   it('onPointerleave only cancels a pending open (a tick later); open cards are left to the grace area', () => {

--- a/packages/core/src/HoverCard/useHoverCard.ts
+++ b/packages/core/src/HoverCard/useHoverCard.ts
@@ -1,0 +1,239 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
+import type { HoverCardOpenChangeReason, HoverCardRootContext } from './HoverCardRoot.vue'
+import type { BaseChangeReason, ChangeEventDetails, DisclosureState, PartSurface } from '@/shared'
+import { computed, ref, toValue } from 'vue'
+import { createPartSurface, disclosureState, useControllableState } from '@/shared'
+import { excludeTouch } from './utils'
+
+// =============================================================================
+// Headless composable for the HoverCard (overlay) family — issue #2723.
+//
+// Follows the overlay contract validated on Menu and applied to Dialog/Popover:
+// the root renders NO attrs (`HoverCardRoot` is `<PopperRoot><slot/></PopperRoot>`),
+// so `useHoverCard()` returns state + the context object the SFC provides, and
+// the surfaces begin at Trigger / Content. Both parts derive purely from the
+// root context, so the builders are idempotent `get<Part>Surface(context)`
+// derivations — the SFCs (which inject the context) and `useHoverCard()` share
+// ONE derivation each. What differs from Popover is the model: every open and
+// close is DEFERRED by `openDelay` / `closeDelay`, so the timers — not the
+// handlers — are what finally call `setState`, carrying the reason and event
+// of the interaction that started them (#2828).
+//
+// Positioning (`PopperAnchor` / `PopperContent`), `Presence`, the portal, the
+// grace area (`useGraceArea`), text-selection containment, the tabbable
+// neutralisation, the scroll dismissal and `DismissableLayer` stay wrappers /
+// mount-bound code in the SFCs.
+// =============================================================================
+
+/** Semantic state of the trigger part; `state` → `data-state="open|closed"`. */
+export type HoverCardTriggerState = { state: DisclosureState }
+/** Semantic state of the content part; `state` → `data-state="open|closed"`. */
+export type HoverCardContentState = { state: DisclosureState }
+
+/**
+ * Deferred half of the trigger's `pointerleave`: runs a tick later so the
+ * grace area (`HoverCardContentImpl`) has had its own `pointerleave` first.
+ * While open, leaving the trigger is the grace area's business — this only
+ * cancels a pending delayed open (`onClose` clears the open timer; the
+ * scheduled `setState(false)` is a no-op on an already-closed card).
+ */
+function cancelPendingOpenOnLeave(context: HoverCardRootContext, event: PointerEvent) {
+  if (!context.isPointerInTransitRef.value && !context.open.value)
+    context.onClose('trigger-leave', event)
+}
+
+/**
+ * The trigger surface, derived purely from the root context — the single
+ * derivation shared by `useHoverCard().trigger` and `HoverCardTrigger.vue`.
+ *
+ * `data-grace-area-trigger` lives in `props`, not `state`: it is a functional
+ * selector (`useGraceArea` reads `closest('[data-grace-area-trigger]')` to end
+ * one card's grace area when the pointer reaches another card's trigger), not
+ * semantic state — the recipe's one exemption from the no-`data-*` rule.
+ * `pointerenter` / `pointerleave` ignore touch pointers (`excludeTouch`);
+ * `pointerup` is the touch toggle behind `enableTouch`.
+ */
+export function getHoverCardTriggerSurface(context: HoverCardRootContext): PartSurface<HoverCardTriggerState> {
+  return createPartSurface<HoverCardTriggerState>(
+    () => ({
+      'data-grace-area-trigger': '',
+      'onPointerenter': excludeTouch((event: PointerEvent) => context.onOpen('trigger-hover', event)),
+      'onPointerleave': excludeTouch((event: PointerEvent) => {
+        setTimeout(cancelPendingOpenOnLeave, 0, context, event)
+      }),
+      'onPointerup': (event: PointerEvent) => {
+        if (!context.enableTouch.value || event.pointerType !== 'touch')
+          return
+
+        if (context.open.value)
+          context.onDismiss('trigger-press', event)
+        else
+          context.onOpenChange(true, 'trigger-press', event)
+      },
+      'onFocus': (event: FocusEvent) => context.onOpen('trigger-focus', event),
+      'onBlur': (event: FocusEvent) => context.onClose('trigger-blur', event),
+    }),
+    () => ({ state: disclosureState(context.open.value) }),
+  )
+}
+
+/**
+ * The content surface, derived purely from the root context — shared by
+ * `useHoverCard().content` and `HoverCardContentImpl.vue`. State only
+ * (`data-state`): the hover card has no ids or roles, and the grace area,
+ * selection containment, `--reka-hover-card-*` CSS variables and
+ * `DismissableLayer` wrapper stay in the SFC.
+ */
+export function getHoverCardContentSurface(context: HoverCardRootContext): PartSurface<HoverCardContentState> {
+  return createPartSurface<HoverCardContentState>(
+    () => ({}),
+    () => ({ state: disclosureState(context.open.value) }),
+  )
+}
+
+export interface UseHoverCardProps {
+  /**
+   * Controlled open state. A getter/ref resolving to `undefined` is uncontrolled;
+   * a writable `Ref` (with no `emit`/`onUpdate`) is written back ("ref-owned").
+   */
+  open?: MaybeRefOrGetter<boolean | undefined>
+  /** Initial open state when uncontrolled. @defaultValue `false` */
+  defaultOpen?: boolean
+  /** Delay (ms) from hover/focus of the trigger until the card opens. @defaultValue `700` */
+  openDelay?: MaybeRefOrGetter<number | undefined>
+  /** Delay (ms) from leaving the trigger or content until the card closes. @defaultValue `300` */
+  closeDelay?: MaybeRefOrGetter<number | undefined>
+  /**
+   * When `true`, a touch tap on the trigger toggles the card. By default touch
+   * pointers are ignored to match pointer-hover semantics. @defaultValue `false`
+   */
+  enableTouch?: MaybeRefOrGetter<boolean | undefined>
+  /** Component `emit`; receives `beforeUpdate:open` then `update:open`. */
+  emit?: (event: any, ...args: any[]) => void
+  /** Called before a change commits; `details.cancel()` vetoes it. */
+  onBeforeUpdate?: (value: boolean, details: ChangeEventDetails<HoverCardOpenChangeReason>) => void
+  /** Called after a change commits. */
+  onUpdate?: (value: boolean, details: ChangeEventDetails<HoverCardOpenChangeReason>) => void
+}
+
+export interface UseHoverCardReturn {
+  open: ComputedRef<boolean>
+  /** Sets `open` immediately. Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpenChange: (value: boolean, reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /**
+   * Cancels a pending close and opens after `openDelay`. The change is deferred,
+   * so its outcome is only known when the timer fires; `reason`/`event` travel
+   * with it into `beforeUpdate:open` / `update:open`.
+   */
+  onOpen: (reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => void
+  /**
+   * Cancels a pending open and closes after `closeDelay`, unless text is being
+   * selected (`hasSelectionRef`) or the pointer is down on the content
+   * (`isPointerDownOnContentRef`). Deferred like `onOpen`.
+   */
+  onClose: (reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => void
+  /** Cancels a pending open and closes immediately. Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onDismiss: (reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Details of the last change attempt; initially `{ reason: 'none' }`. */
+  lastChangeDetails: Readonly<Ref<ChangeEventDetails<HoverCardOpenChangeReason>>>
+  isControlled: ComputedRef<boolean>
+  /** `data-grace-area-trigger` + the hover/leave/touch/focus/blur listeners. */
+  trigger: PartSurface<HoverCardTriggerState>
+  /** State only (`data-state`). */
+  content: PartSurface<HoverCardContentState>
+  /** The `HoverCardRootContext` value — the SFC provides this verbatim. */
+  context: HoverCardRootContext
+}
+
+/**
+ * Headless HoverCard logic. The `.vue` shells compose this; a standalone
+ * consumer gets the delayed open/close model (with `beforeUpdate`/`update`
+ * details), the trigger listeners and `data-state`, but must still wrap the
+ * content in `Presence`, `DismissableLayer` and `PopperContent` (and the
+ * trigger in `PopperAnchor`) and compose `useGraceArea` for the pointer-transit
+ * grace — those are component families / mount-bound behaviours a pure
+ * composable cannot absorb (see the #2723 recipe's "Overlay families").
+ * Dismissal reasons (`escape-key`, `outside-press`) therefore arrive through
+ * `onDismiss(reason, event)` from whatever layer the consumer composes.
+ *
+ * SSR-safe: no `document`/`window` at call scope — the `window.setTimeout`
+ * calls only run inside `onOpen` / `onClose`, i.e. from browser events. No
+ * lifecycle hooks, so it is callable outside `setup()`; pending timers are
+ * cancelled by the next `onOpen` / `onClose` / `onDismiss`, not on unmount —
+ * a stray timer only reaches `setState`, which the consumer can veto.
+ *
+ * @experimental Signatures may change in 3.x minors.
+ * @lifecycle pure
+ */
+export function useHoverCard(props: UseHoverCardProps = {}): UseHoverCardReturn {
+  // Every write to `open` — the delayed hover/focus timers, the touch toggle
+  // and dismiss — goes through one `setState`, so `beforeUpdate:open` can
+  // cancel any of them and `update:open` always carries the reason (#2828).
+  // The timers capture the reason and event of the interaction that started
+  // them: `setTimeout(setState, delay, value, reason, event)` (no closure —
+  // `e18e/prefer-timer-args`).
+  const { state: open, setState, lastChangeDetails, isControlled } = useControllableState<boolean, HoverCardOpenChangeReason>({
+    prop: props.open,
+    defaultValue: props.defaultOpen ?? false,
+    name: 'open',
+    emit: props.emit,
+    onBeforeUpdate: props.onBeforeUpdate,
+    onUpdate: props.onUpdate,
+  })
+  const openDelay = computed<number>(() => toValue(props.openDelay) ?? 700)
+  const closeDelay = computed<number>(() => toValue(props.closeDelay) ?? 300)
+  const enableTouch = computed<boolean>(() => toValue(props.enableTouch) ?? false)
+
+  let openTimer = 0
+  let closeTimer = 0
+  const hasSelectionRef = ref(false)
+  const isPointerDownOnContentRef = ref(false)
+  const isPointerInTransitRef = ref(false)
+  const triggerElement = ref<HTMLElement>()
+
+  function onOpenChange(value: boolean, reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event): boolean {
+    return setState(value, reason, event)
+  }
+
+  function onOpen(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
+    clearTimeout(closeTimer)
+    openTimer = window.setTimeout(setState, openDelay.value, true, reason, event)
+  }
+
+  function onClose(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
+    clearTimeout(openTimer)
+    if (!hasSelectionRef.value && !isPointerDownOnContentRef.value)
+      closeTimer = window.setTimeout(setState, closeDelay.value, false, reason, event)
+  }
+
+  function onDismiss(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event): boolean {
+    clearTimeout(openTimer)
+    return setState(false, reason, event)
+  }
+
+  const context: HoverCardRootContext = {
+    open,
+    onOpenChange,
+    onOpen,
+    onClose,
+    onDismiss,
+    hasSelectionRef,
+    isPointerDownOnContentRef,
+    isPointerInTransitRef,
+    triggerElement,
+    enableTouch: enableTouch as Ref<boolean>,
+  }
+
+  return {
+    open,
+    onOpenChange,
+    onOpen,
+    onClose,
+    onDismiss,
+    lastChangeDetails,
+    isControlled,
+    trigger: getHoverCardTriggerSurface(context),
+    content: getHoverCardContentSurface(context),
+    context,
+  }
+}

--- a/packages/core/src/HoverCard/useHoverCard.ts
+++ b/packages/core/src/HoverCard/useHoverCard.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
 import type { HoverCardOpenChangeReason, HoverCardRootContext } from './HoverCardRoot.vue'
 import type { BaseChangeReason, ChangeEventDetails, DisclosureState, PartSurface } from '@/shared'
-import { computed, ref, toValue } from 'vue'
+import { computed, getCurrentScope, onScopeDispose, ref, toValue } from 'vue'
 import { createPartSurface, disclosureState, useControllableState } from '@/shared'
 import { excludeTouch } from './utils'
 
@@ -121,9 +121,9 @@ export interface UseHoverCardReturn {
   /** Sets `open` immediately. Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
   onOpenChange: (value: boolean, reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => boolean
   /**
-   * Cancels a pending close and opens after `openDelay`. The change is deferred,
-   * so its outcome is only known when the timer fires; `reason`/`event` travel
-   * with it into `beforeUpdate:open` / `update:open`.
+   * Cancels a pending open or close and opens after `openDelay`. The change is
+   * deferred, so its outcome is only known when the timer fires; `reason`/`event`
+   * travel with it into `beforeUpdate:open` / `update:open`.
    */
   onOpen: (reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) => void
   /**
@@ -158,12 +158,12 @@ export interface UseHoverCardReturn {
  *
  * SSR-safe: no `document`/`window` at call scope — the `window.setTimeout`
  * calls only run inside `onOpen` / `onClose`, i.e. from browser events. No
- * lifecycle hooks, so it is callable outside `setup()`; pending timers are
- * cancelled by the next `onOpen` / `onClose` / `onDismiss`, not on unmount —
- * a stray timer only reaches `setState`, which the consumer can veto.
+ * lifecycle hooks, so it is callable outside `setup()`; inside a component or
+ * `effectScope` the pending timers are cleared when that scope is disposed,
+ * standalone they are cancelled by the next `onOpen` / `onClose` / `onDismiss`.
  *
  * @experimental Signatures may change in 3.x minors.
- * @lifecycle pure
+ * @lifecycle pure — the only scope hook is the guarded timer cleanup above.
  */
 export function useHoverCard(props: UseHoverCardProps = {}): UseHoverCardReturn {
   // Every write to `open` — the delayed hover/focus timers, the touch toggle
@@ -196,6 +196,10 @@ export function useHoverCard(props: UseHoverCardProps = {}): UseHoverCardReturn 
   }
 
   function onOpen(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event) {
+    // Re-arming replaces a pending open too: `pointerenter` then `focus` must
+    // leave ONE timer for the following `onClose` to cancel, or the first one
+    // opens the card after the pointer has left.
+    clearTimeout(openTimer)
     clearTimeout(closeTimer)
     openTimer = window.setTimeout(setState, openDelay.value, true, reason, event)
   }
@@ -209,6 +213,17 @@ export function useHoverCard(props: UseHoverCardProps = {}): UseHoverCardReturn 
   function onDismiss(reason?: HoverCardOpenChangeReason | BaseChangeReason, event?: Event): boolean {
     clearTimeout(openTimer)
     return setState(false, reason, event)
+  }
+
+  // Inside a component or `effectScope`, a pending timer must not outlive its
+  // owner: it would write the model (or emit `update:open`) after unmount.
+  // Standalone calls have no scope to hook, so there the next `onOpen` /
+  // `onClose` / `onDismiss` is what cancels a pending timer.
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      clearTimeout(openTimer)
+      clearTimeout(closeTimer)
+    })
   }
 
   const context: HoverCardRootContext = {

--- a/packages/core/src/Stepper/Stepper.test.ts
+++ b/packages/core/src/Stepper/Stepper.test.ts
@@ -54,6 +54,22 @@ describe('stepper', async () => {
     expect(getByTestId('stepper-item-2')).toHaveAttribute('aria-current', 'true')
   })
 
+  it('reports completed, current and upcoming on data-state', async () => {
+    const { getByTestId, user } = setup({ stepperProps: { defaultValue: 2, steps } })
+
+    for (const part of ['item', 'item-trigger', 'item-separator']) {
+      expect(getByTestId(`stepper-${part}-1`)).toHaveAttribute('data-state', 'completed')
+      expect(getByTestId(`stepper-${part}-2`)).toHaveAttribute('data-state', 'current')
+      expect(getByTestId(`stepper-${part}-3`)).toHaveAttribute('data-state', 'upcoming')
+    }
+    expect(getByTestId('stepper-item-1')).not.toHaveAttribute('aria-current')
+
+    await user.click(getByTestId('stepper-item-trigger-3'))
+    expect(getByTestId('stepper-item-2')).toHaveAttribute('data-state', 'completed')
+    expect(getByTestId('stepper-item-3')).toHaveAttribute('data-state', 'current')
+    expect(getByTestId('stepper-item-4')).toHaveAttribute('data-state', 'upcoming')
+  })
+
   it('navigates horizontally using the keyboard', async () => {
     const { getByTestId, user } = setup({ stepperProps: { steps } })
 

--- a/packages/core/src/Stepper/StepperItem.vue
+++ b/packages/core/src/Stepper/StepperItem.vue
@@ -9,7 +9,15 @@ import { injectStepperRootContext } from './StepperRoot.vue'
 
 export const [injectStepperItemContext, provideStepperItemContext] = createContext<StepperItemContext>('StepperItem')
 
-export type StepperState = 'completed' | 'active' | 'inactive'
+/**
+ * Stepper is one of the multi-value `data-state` machines grandfathered by
+ * #2823: a step is `completed`, `current` or `upcoming`, which neither of the
+ * two normalised axes (`open` / `closed`, `checked` / `unchecked`) can express.
+ * The v2 words `active` / `inactive` were dropped because they read as
+ * synonyms of the axis words and collided with Tabs' old `active` / `inactive`
+ * (which the codemod rewrites to `checked` / `unchecked`).
+ */
+export type StepperState = 'completed' | 'current' | 'upcoming'
 
 export interface StepperItemContext {
   titleId: string
@@ -38,7 +46,7 @@ const props = withDefaults(defineProps<StepperItemProps>(), {
 
 defineSlots<{
   default?: (props: {
-    /** The current state of the stepper item */
+    /** The state of the stepper item: `completed`, `current` or `upcoming` */
     state: StepperState
   }) => any
 }>()
@@ -56,10 +64,10 @@ const itemState = computed(() => {
   if (completed.value)
     return 'completed'
   if (rootContext.modelValue.value === step.value)
-    return 'active'
+    return 'current'
   if (rootContext.modelValue.value! > step.value)
     return 'completed'
-  return 'inactive'
+  return 'upcoming'
 })
 
 const isFocusable = computed(() => {
@@ -86,7 +94,7 @@ provideStepperItemContext({
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"
-    :aria-current="itemState === 'active' ? 'true' : undefined"
+    :aria-current="itemState === 'current' ? 'true' : undefined"
     :data-state="itemState"
     :disabled="disabled || !isFocusable ? '' : undefined"
     :data-disabled="disabled || !isFocusable ? '' : undefined"

--- a/packages/core/src/Stepper/story/StepperDefault.story.vue
+++ b/packages/core/src/Stepper/story/StepperDefault.story.vue
@@ -48,7 +48,7 @@ const steps = [{
         >
           <StepperTrigger class="p-2 flex flex-col items-center text-center gap-2 focus:shadow-[0_0_0_2px] focus:shadow-green11 focus:outline-none rounded-md">
             <StepperIndicator
-              class="inline-flex items-center group-data-[disabled]:text-gray-400 group-data-[state=active]:bg-mauve12 group-data-[state=active]:text-white justify-center rounded-full text-grass11 w-10 h-10 shrink-0 bg-mauve6 group-data-[state=active]:shadow-mauve12 group-data-[state=completed]:bg-green9 group-data-[state=completed]:text-white group-data-[state=completed]:shadow-green9 shadow-[0_0_0_2px] "
+              class="inline-flex items-center group-data-[disabled]:text-gray-400 group-data-[state=current]:bg-mauve12 group-data-[state=current]:text-white justify-center rounded-full text-grass11 w-10 h-10 shrink-0 bg-mauve6 group-data-[state=current]:shadow-mauve12 group-data-[state=completed]:bg-green9 group-data-[state=completed]:text-white group-data-[state=completed]:shadow-green9 shadow-[0_0_0_2px] "
             >
               <Icon
                 :icon="item.icon"

--- a/packages/core/src/Stepper/story/_DummyStepper.vue
+++ b/packages/core/src/Stepper/story/_DummyStepper.vue
@@ -50,7 +50,7 @@ const steps = [{
     >
       <StepperTrigger class="p-1 flex flex-col items-center text-center gap-2 focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none rounded-md">
         <StepperIndicator
-          class="inline-flex items-center group-data-[disabled]:text-gray-400 group-data-[state=active]:bg-mauve12 group-data-[state=active]:text-white justify-center rounded-full text-grass11 w-10 h-10 shrink-0 bg-white group-data-[state=active]:shadow-mauve12 group-data-[state=completed]:bg-green9 group-data-[state=completed]:text-white group-data-[state=completed]:shadow-green9 shadow-[0_0_0_2px] "
+          class="inline-flex items-center group-data-[disabled]:text-gray-400 group-data-[state=current]:bg-mauve12 group-data-[state=current]:text-white justify-center rounded-full text-grass11 w-10 h-10 shrink-0 bg-white group-data-[state=current]:shadow-mauve12 group-data-[state=completed]:bg-green9 group-data-[state=completed]:text-white group-data-[state=completed]:shadow-green9 shadow-[0_0_0_2px] "
         >
           <Icon
             :icon="item.icon"

--- a/packages/core/src/Tooltip/TooltipContentImpl.vue
+++ b/packages/core/src/Tooltip/TooltipContentImpl.vue
@@ -44,11 +44,12 @@ export interface TooltipContentImplProps
 <script setup lang="ts">
 import type { DismissableLayerDismissDetails } from '@/DismissableLayer'
 import { useEventListener } from '@vueuse/core'
-import { computed, onMounted } from 'vue'
+import { computed, mergeProps, onMounted } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { PopperContent } from '@/Popper'
 import { VisuallyHidden } from '@/VisuallyHidden'
 import { injectTooltipRootContext } from './TooltipRoot.vue'
+import { getTooltipContentSurface, getTooltipLabelSurface } from './useTooltip'
 import { TOOLTIP_OPEN } from './utils'
 
 const props = withDefaults(defineProps<TooltipContentImplProps>(), {
@@ -63,6 +64,15 @@ const providerContext = injectTooltipProviderContext()
 
 const { forwardRef, currentElement } = useForwardExpose()
 const ariaLabel = computed(() => props.ariaLabel || currentElement.value?.textContent)
+
+// data-state / data-delayed on the content and id / role="tooltip" on the
+// hidden label come from the shared surface builders (single source with
+// `useTooltip()`); the PopperContent positioning, the CSS variables, the
+// DismissableLayer wrapper and the scroll / TOOLTIP_OPEN listeners stay here.
+// `$attrs` and the positioning props merge AFTER the surface, as before, so a
+// consumer's explicit `data-state` still wins.
+const content = getTooltipContentSurface(rootContext)
+const label = getTooltipLabelSurface(rootContext)
 
 const popperContentProps = computed(() => {
   const { ariaLabel: _, ...restProps } = props
@@ -116,9 +126,7 @@ function handleDismiss({ reason, event }: DismissableLayerDismissDetails) {
   >
     <PopperContent
       :ref="forwardRef"
-      :data-state="rootContext.stateAttribute.value"
-      :data-delayed="rootContext.isDelayed.value ? '' : undefined"
-      v-bind="{ ...$attrs, ...popperContentProps }"
+      v-bind="mergeProps(content.attrs.value, { ...$attrs, ...popperContentProps })"
       :style="{
         '--reka-tooltip-content-transform-origin': 'var(--reka-popper-transform-origin)',
         '--reka-tooltip-content-available-width': 'var(--reka-popper-available-width)',
@@ -128,10 +136,7 @@ function handleDismiss({ reason, event }: DismissableLayerDismissDetails) {
       }"
     >
       <slot />
-      <VisuallyHidden
-        :id="rootContext.contentId"
-        role="tooltip"
-      >
+      <VisuallyHidden v-bind="label.attrs.value">
         {{ ariaLabel }}
       </VisuallyHidden>
     </PopperContent>

--- a/packages/core/src/Tooltip/TooltipRoot.vue
+++ b/packages/core/src/Tooltip/TooltipRoot.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ComputedRef, Ref } from 'vue'
 import type { BaseChangeReason, ChangeEventDetails, DisclosureState } from '@/shared'
-import { createContext, disclosureState, useControllableState, useForwardExpose } from '@/shared'
+import { createContext, useForwardExpose, useId } from '@/shared'
 
 /**
  * Why the tooltip's `open` state changed (#2828); the `reason` of `ChangeEventDetails`.
@@ -75,12 +75,19 @@ export type TooltipRootEmits = {
 }
 
 export interface TooltipContext {
+  /** `<baseId>-content`, populated up-front by `useTooltip()` (#2723) — never back-filled by a descendant. */
   contentId: string
   open: ComputedRef<boolean>
   /** `'open' | 'closed'` — the disclosure axis of `data-state` (#2823). */
   stateAttribute: Ref<DisclosureState>
   /** `true` only while open AND that open came from the delay timer; bound as `data-delayed`. */
   isDelayed: Ref<boolean>
+  /**
+   * The provider's grace-area transit flag (`TooltipContentHoverable` publishes
+   * `useGraceArea`'s `isPointerInTransit` on the provider); the trigger's
+   * `pointermove` does not open while it is `true`. Resolved by the root.
+   */
+  isPointerInTransit: Ref<boolean>
   trigger: Ref<HTMLElement | undefined>
   onTriggerChange: (trigger: HTMLElement | undefined) => void
   /** Pointer entered the trigger: opens with reason `trigger-hover`, delayed unless the provider is skipping the delay. */
@@ -102,10 +109,10 @@ export const [injectTooltipRootContext, provideTooltipRootContext]
 </script>
 
 <script setup lang="ts">
-import { useTimeoutFn } from '@vueuse/core'
-import { computed, ref, watch } from 'vue'
+import { watch } from 'vue'
 import { PopperRoot } from '@/Popper'
 import { injectTooltipProviderContext } from './TooltipProvider.vue'
+import { useTooltip } from './useTooltip'
 import { TOOLTIP_OPEN } from './utils'
 
 const props = withDefaults(defineProps<TooltipRootProps>(), {
@@ -130,23 +137,30 @@ defineSlots<{
 useForwardExpose()
 const providerContext = injectTooltipProviderContext()
 
-const disableHoverableContent = computed(() => props.disableHoverableContent ?? providerContext.disableHoverableContent.value)
-const disableClosingTrigger = computed(() => props.disableClosingTrigger ?? providerContext.disableClosingTrigger.value)
-const disableTooltip = computed(() => props.disabled ?? providerContext.disabled.value)
-
-const delayDuration = computed(() => props.delayDuration ?? providerContext.delayDuration.value)
-const ignoreNonKeyboardFocus = computed(() => props.ignoreNonKeyboardFocus ?? providerContext.ignoreNonKeyboardFocus.value)
-
-// Every write to `open` — hover timer, focus/blur, press, grace-area exit,
-// dismiss — goes through one `setState`, so `beforeUpdate:open` can cancel any
-// of them and `update:open` always carries the reason (#2828).
-const { state: open, setState } = useControllableState<boolean, TooltipOpenChangeReason>({
-  prop: () => props.open,
-  defaultValue: props.defaultOpen,
-  name: 'open',
+// The composable owns the controlled/uncontrolled `open` model (every write goes
+// through its `setState` so `beforeUpdate:open` can cancel it), the delayed-open
+// timer and the context. The shell's job is the provider coupling: each root
+// prop falls back to the `TooltipProvider` value, and the provider's skip-delay
+// and grace-area transit flags are handed in as getters (the transit ref is
+// REASSIGNED on the provider context by `TooltipContentHoverable`, so it must be
+// read through the property on every access, never snapshotted). `useId`
+// (ConfigProvider/SSR-aware) stays here and seeds the content id.
+const { open, context } = useTooltip({
+  open: () => props.open,
+  defaultOpen: props.defaultOpen,
+  delayDuration: () => props.delayDuration ?? providerContext.delayDuration.value,
+  isOpenDelayed: () => providerContext.isOpenDelayed.value,
+  isPointerInTransit: () => providerContext.isPointerInTransitRef.value,
+  disableHoverableContent: () => props.disableHoverableContent ?? providerContext.disableHoverableContent.value,
+  disableClosingTrigger: () => props.disableClosingTrigger ?? providerContext.disableClosingTrigger.value,
+  disabled: () => props.disabled ?? providerContext.disabled.value,
+  ignoreNonKeyboardFocus: () => props.ignoreNonKeyboardFocus ?? providerContext.ignoreNonKeyboardFocus.value,
+  baseId: useId(undefined, 'reka-tooltip'),
   emit,
 })
 
+// Provider coordination stays in the shell: an open arms the provider's
+// skip-delay window and tells every other tooltip to close (`TOOLTIP_OPEN`).
 watch(open, (isOpen) => {
   if (!providerContext.onClose)
     return
@@ -161,78 +175,7 @@ watch(open, (isOpen) => {
   }
 })
 
-const wasOpenDelayedRef = ref(false)
-const trigger = ref<HTMLElement>()
-
-const stateAttribute = computed<DisclosureState>(() => disclosureState(open.value))
-const isDelayed = computed(() => open.value && wasOpenDelayedRef.value)
-
-// A closed tooltip keeps no "delayed" history: a later parent-driven or
-// imperative open must not render `data-delayed`. A cancelled close never
-// flips `open`, so the flag survives it.
-watch(open, (isOpen) => {
-  if (!isOpen)
-    wasOpenDelayedRef.value = false
-})
-
-// The `pointermove` that armed the delay timer, handed to `update:open` when it fires.
-let delayedOpenEvent: PointerEvent | undefined
-
-const { start: startTimer, stop: clearTimer } = useTimeoutFn(() => {
-  const event = delayedOpenEvent
-  delayedOpenEvent = undefined
-  // Flag before the write so `isDelayed` is right on the same tick `open` flips;
-  // roll it back when the open was cancelled (or was a no-op).
-  wasOpenDelayedRef.value = true
-  if (!setState(true, 'trigger-hover', event))
-    wasOpenDelayedRef.value = false
-}, delayDuration, { immediate: false })
-
-function handleOpen(reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event) {
-  clearTimer()
-  wasOpenDelayedRef.value = false
-  return setState(true, reason, event)
-}
-function handleClose(reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event) {
-  // Cancel a pending delayed open first; a cancelled close then simply stays open.
-  clearTimer()
-  return setState(false, reason, event)
-}
-function handleDelayedOpen(event?: PointerEvent) {
-  delayedOpenEvent = event
-  startTimer()
-}
-
-provideTooltipRootContext({
-  contentId: '',
-  open,
-  stateAttribute,
-  isDelayed,
-  trigger,
-  onTriggerChange(el) {
-    trigger.value = el
-  },
-  onTriggerEnter(event) {
-    if (providerContext.isOpenDelayed.value)
-      handleDelayedOpen(event)
-    else handleOpen('trigger-hover', event)
-  },
-  onTriggerLeave(event) {
-    if (disableHoverableContent.value) {
-      handleClose('trigger-leave', event)
-    }
-    else {
-      // Clear the timer in case the pointer leaves the trigger before the tooltip is opened.
-      clearTimer()
-    }
-  },
-  onOpen: handleOpen,
-  onClose: handleClose,
-  disableHoverableContent,
-  disableClosingTrigger,
-  disabled: disableTooltip,
-  ignoreNonKeyboardFocus,
-})
+provideTooltipRootContext(context)
 </script>
 
 <template>

--- a/packages/core/src/Tooltip/TooltipTrigger.vue
+++ b/packages/core/src/Tooltip/TooltipTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { DisclosureState } from '@/shared'
-import { useForwardExpose, useId } from '@/shared'
+import { useForwardExpose } from '@/shared'
 
 export type TooltipTriggerDataState = DisclosureState
 
@@ -9,93 +9,34 @@ export interface TooltipTriggerProps extends PopperAnchorProps {}
 
 <script setup lang="ts">
 import type { PopperAnchorProps } from '@/Popper'
-import { computed, onMounted, ref } from 'vue'
+import { onMounted } from 'vue'
 import { PopperAnchor } from '@/Popper'
 import {
   Primitive,
 } from '@/Primitive'
-import { injectTooltipProviderContext } from './TooltipProvider.vue'
 import { injectTooltipRootContext } from './TooltipRoot.vue'
+import { createTooltipTriggerSurface } from './useTooltip'
 
 const props = withDefaults(defineProps<TooltipTriggerProps>(), {
   as: 'button',
 })
 const rootContext = injectTooltipRootContext()
-const providerContext = injectTooltipProviderContext()
-
-rootContext.contentId ||= useId(undefined, 'reka-tooltip-content')
 
 const { forwardRef, currentElement: triggerElement } = useForwardExpose()
 
-const isPointerDown = ref(false)
-const hasPointerMoveOpened = ref(false)
-
-const tooltipListeners = computed(() => {
-  if (rootContext.disabled.value)
-    return {}
-
-  return {
-    click: handleClick,
-    focus: handleFocus,
-    pointermove: handlePointerMove,
-    pointerleave: handlePointerLeave,
-    pointerdown: handlePointerDown,
-    blur: handleBlur,
-  }
-})
+// aria-describedby / data-state / data-delayed / the grace-area selector and
+// every pointer / focus / click listener come from the shared trigger factory
+// (single source with `useTooltip()`; called ONCE — it owns this instance's
+// pointer state). The content id is populated by the composable, so nothing is
+// back-filled onto the context here any more. Listener order is unchanged:
+// `$attrs` fall through the as-child `PopperAnchor` and `Slot` merges them
+// BEFORE the inner element's own props, so a consumer `@click` still runs
+// before the surface's `onClick`.
+const trigger = createTooltipTriggerSurface(rootContext)
 
 onMounted(() => {
   rootContext.onTriggerChange(triggerElement.value)
 })
-
-function handlePointerUp() {
-  setTimeout(() => {
-    isPointerDown.value = false
-  }, 1)
-}
-
-function handlePointerDown(event: PointerEvent) {
-  if (rootContext.open.value && !rootContext.disableClosingTrigger.value) {
-    rootContext.onClose('trigger-press', event)
-  }
-  isPointerDown.value = true
-  document.addEventListener('pointerup', handlePointerUp, { once: true })
-}
-
-function handlePointerMove(event: PointerEvent) {
-  if (event.pointerType === 'touch')
-    return
-  if (
-    !hasPointerMoveOpened.value && !providerContext.isPointerInTransitRef.value
-  ) {
-    rootContext.onTriggerEnter(event)
-    hasPointerMoveOpened.value = true
-  }
-}
-
-function handlePointerLeave(event: PointerEvent) {
-  rootContext.onTriggerLeave(event)
-  hasPointerMoveOpened.value = false
-}
-
-function handleFocus(event: FocusEvent) {
-  if (isPointerDown.value)
-    return
-
-  if (rootContext.ignoreNonKeyboardFocus.value && !(event.target as HTMLElement).matches?.(':focus-visible'))
-    return
-
-  rootContext.onOpen('trigger-focus', event)
-}
-
-function handleBlur(event: FocusEvent) {
-  rootContext.onClose('trigger-blur', event)
-}
-
-function handleClick(event: MouseEvent) {
-  if (!rootContext.disableClosingTrigger.value)
-    rootContext.onClose('trigger-press', event)
-}
 </script>
 
 <template>
@@ -105,15 +46,9 @@ function handleClick(event: MouseEvent) {
   >
     <Primitive
       :ref="forwardRef"
-      :aria-describedby="
-        rootContext.open.value ? rootContext.contentId : undefined
-      "
-      :data-state="rootContext.stateAttribute.value"
-      :data-delayed="rootContext.isDelayed.value ? '' : undefined"
       :as="as"
       :as-child="props.asChild"
-      data-grace-area-trigger
-      v-on="tooltipListeners"
+      v-bind="trigger.attrs.value"
     >
       <slot />
     </Primitive>

--- a/packages/core/src/Tooltip/index.ts
+++ b/packages/core/src/Tooltip/index.ts
@@ -27,3 +27,10 @@ export {
   default as TooltipTrigger,
   type TooltipTriggerProps,
 } from './TooltipTrigger.vue'
+export {
+  type TooltipContentState,
+  type TooltipTriggerState,
+  useTooltip,
+  type UseTooltipProps,
+  type UseTooltipReturn,
+} from './useTooltip'

--- a/packages/core/src/Tooltip/useTooltip.test.ts
+++ b/packages/core/src/Tooltip/useTooltip.test.ts
@@ -1,0 +1,465 @@
+import { fireEvent, render } from '@testing-library/vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+import { defineComponent, nextTick, ref } from 'vue'
+import * as Reka from '../index'
+import { useTooltip } from './useTooltip'
+
+function dataAttrKeys(props: Record<string, any>) {
+  return Object.keys(props).filter(k => k.startsWith('data-'))
+}
+
+// jsdom has no `PointerEvent`; the handlers only read `pointerType`.
+function pointerEvent(type: string, pointerType = 'mouse'): PointerEvent {
+  return Object.assign(new MouseEvent(type), { pointerType }) as PointerEvent
+}
+
+describe('useTooltip — state', () => {
+  it('defaults to closed, not delayed, hoverable, enabled and uncontrolled', () => {
+    const t = useTooltip({ baseId: 'x' })
+    expect(t.open.value).toBe(false)
+    expect(t.isDelayed.value).toBe(false)
+    expect(t.isControlled.value).toBe(false)
+    expect(t.lastChangeDetails.value.reason).toBe('none')
+    expect(t.context.disableHoverableContent.value).toBe(false)
+    expect(t.context.disableClosingTrigger.value).toBe(false)
+    expect(t.context.disabled.value).toBe(false)
+    expect(t.context.ignoreNonKeyboardFocus.value).toBe(false)
+    expect(t.context.isPointerInTransit.value).toBe(false)
+  })
+
+  it('honours defaultOpen and reactive option getters', () => {
+    const disabled = ref(false)
+    const t = useTooltip({ defaultOpen: true, disabled, disableClosingTrigger: () => true, baseId: 'x' })
+    expect(t.open.value).toBe(true)
+    expect(t.context.disabled.value).toBe(false)
+    expect(t.context.disableClosingTrigger.value).toBe(true)
+    disabled.value = true
+    expect(t.context.disabled.value).toBe(true)
+  })
+
+  it('onOpen / onClose drive the model and report imperative-action by default', () => {
+    const t = useTooltip({ baseId: 'x' })
+    expect(t.onOpen()).toBe(true)
+    expect(t.open.value).toBe(true)
+    expect(t.lastChangeDetails.value.reason).toBe('imperative-action')
+    // Unchanged → false, no new details.
+    expect(t.onOpen()).toBe(false)
+    expect(t.onClose()).toBe(true)
+    expect(t.open.value).toBe(false)
+    expect(t.onClose()).toBe(false)
+  })
+
+  it('ref-owned mode writes through the passed ref', () => {
+    const open = ref(false)
+    const t = useTooltip({ open, baseId: 'x' })
+    expect(t.isControlled.value).toBe(true)
+    t.onOpen('trigger-focus')
+    expect(open.value).toBe(true)
+    expect(t.open.value).toBe(true)
+    t.onClose('trigger-blur')
+    expect(open.value).toBe(false)
+  })
+
+  it('controlled getter + emit: emits beforeUpdate:open then update:open with the same details and does not write locally', () => {
+    const emit = vi.fn()
+    const t = useTooltip({ open: () => false, emit, baseId: 'x' })
+    expect(t.isControlled.value).toBe(true)
+    const event = new FocusEvent('focus')
+    t.trigger.props.value.onFocus(event)
+    expect(t.open.value).toBe(false)
+    expect(emit).toHaveBeenCalledTimes(2)
+    expect(emit).toHaveBeenNthCalledWith(1, 'beforeUpdate:open', true, expect.objectContaining({ reason: 'trigger-focus', event }))
+    expect(emit).toHaveBeenNthCalledWith(2, 'update:open', true, expect.objectContaining({ reason: 'trigger-focus', event }))
+    expect(emit.mock.calls[0][2]).toBe(emit.mock.calls[1][2])
+  })
+
+  it('cancel() in onBeforeUpdate vetoes the change and skips onUpdate', () => {
+    const onUpdate = vi.fn()
+    const t = useTooltip({ defaultOpen: true, baseId: 'x', onBeforeUpdate: (_value, details) => details.cancel(), onUpdate })
+    t.trigger.props.value.onBlur(new FocusEvent('blur'))
+    expect(t.open.value).toBe(true)
+    expect(t.lastChangeDetails.value).toMatchObject({ reason: 'trigger-blur', isCanceled: true })
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(t.trigger.attrs.value['data-state']).toBe('open')
+  })
+})
+
+describe('useTooltip — ids', () => {
+  it('derives the content id from baseId; the label carries it and the open trigger points at it', () => {
+    const t = useTooltip({ baseId: 'x' })
+    expect(t.context.contentId).toBe('x-content')
+    expect(t.label.props.value).toEqual({ id: 'x-content', role: 'tooltip' })
+    expect(t.trigger.props.value['aria-describedby']).toBeUndefined()
+    t.onOpen()
+    expect(t.trigger.props.value['aria-describedby']).toBe('x-content')
+  })
+
+  it('two standalone calls without a baseId get different ids', () => {
+    const a = useTooltip()
+    const b = useTooltip()
+    expect(a.context.contentId).toMatch(/^reka-tooltip-\d+-content$/)
+    expect(b.context.contentId).toMatch(/^reka-tooltip-\d+-content$/)
+    expect(a.context.contentId).not.toBe(b.context.contentId)
+  })
+})
+
+describe('useTooltip — delayed open', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('onTriggerEnter opens after delayDuration with reason trigger-hover and the arming event, flagged data-delayed', () => {
+    const onUpdate = vi.fn()
+    const t = useTooltip({ baseId: 'x', delayDuration: 500, onUpdate })
+    const event = pointerEvent('pointermove')
+    t.onTriggerEnter(event)
+    expect(t.open.value).toBe(false)
+    expect(t.trigger.attrs.value).toMatchObject({ 'data-state': 'closed' })
+    expect(t.trigger.attrs.value['data-delayed']).toBeUndefined()
+
+    vi.advanceTimersByTime(499)
+    expect(t.open.value).toBe(false)
+    vi.advanceTimersByTime(1)
+    expect(t.open.value).toBe(true)
+    expect(t.isDelayed.value).toBe(true)
+    expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-hover', event, isCanceled: false }))
+    // `data-delayed` is the empty-string boolean attribute while delayed (#2823).
+    expect(t.trigger.state.value).toEqual({ state: 'open', delayed: true })
+    expect(t.trigger.attrs.value).toMatchObject({ 'data-state': 'open', 'data-delayed': '' })
+    expect(t.content.state.value).toEqual({ state: 'open', delayed: true })
+    expect(t.content.attrs.value).toEqual({ 'data-state': 'open', 'data-delayed': '' })
+  })
+
+  it('defaults the delay to 700ms and reads a reactive delayDuration getter', () => {
+    const t = useTooltip({ baseId: 'x' })
+    t.onTriggerEnter()
+    vi.advanceTimersByTime(699)
+    expect(t.open.value).toBe(false)
+    vi.advanceTimersByTime(1)
+    expect(t.open.value).toBe(true)
+
+    const delay = ref(100)
+    const u = useTooltip({ baseId: 'y', delayDuration: delay })
+    delay.value = 50
+    u.onTriggerEnter()
+    vi.advanceTimersByTime(50)
+    expect(u.open.value).toBe(true)
+  })
+
+  it('rolls the delayed flag back when the delayed open is cancelled', () => {
+    const onUpdate = vi.fn()
+    const t = useTooltip({ baseId: 'x', onBeforeUpdate: (_value, details) => details.cancel(), onUpdate })
+    t.onTriggerEnter(pointerEvent('pointermove'))
+    vi.advanceTimersByTime(700)
+    expect(t.open.value).toBe(false)
+    expect(t.isDelayed.value).toBe(false)
+    expect(t.lastChangeDetails.value).toMatchObject({ reason: 'trigger-hover', isCanceled: true })
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(t.trigger.attrs.value['data-delayed']).toBeUndefined()
+    expect(t.content.attrs.value).toEqual({ 'data-state': 'closed' })
+  })
+
+  it('opens instantly, without data-delayed, when isOpenDelayed is false', () => {
+    const onUpdate = vi.fn()
+    const t = useTooltip({ baseId: 'x', isOpenDelayed: false, onUpdate })
+    const event = pointerEvent('pointermove')
+    t.onTriggerEnter(event)
+    expect(t.open.value).toBe(true)
+    expect(t.isDelayed.value).toBe(false)
+    expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-hover', event }))
+    expect(t.trigger.attrs.value).toEqual(expect.objectContaining({ 'data-state': 'open' }))
+    expect(t.trigger.attrs.value['data-delayed']).toBeUndefined()
+  })
+
+  it('onOpen cancels a pending delayed open and is never flagged delayed', () => {
+    const onUpdate = vi.fn()
+    const t = useTooltip({ baseId: 'x', onUpdate })
+    t.onTriggerEnter()
+    expect(t.onOpen('trigger-focus')).toBe(true)
+    expect(t.isDelayed.value).toBe(false)
+    vi.advanceTimersByTime(700)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenCalledWith(true, expect.objectContaining({ reason: 'trigger-focus' }))
+  })
+
+  it('onTriggerLeave only cancels the pending open while content is hoverable', () => {
+    const onUpdate = vi.fn()
+    const t = useTooltip({ baseId: 'x', onUpdate })
+    t.onTriggerEnter()
+    t.onTriggerLeave(pointerEvent('pointerleave'))
+    vi.advanceTimersByTime(700)
+    expect(t.open.value).toBe(false)
+    expect(onUpdate).not.toHaveBeenCalled()
+
+    // An open tooltip stays open: the pointer may travel onto the content.
+    t.onOpen()
+    t.onTriggerLeave(pointerEvent('pointerleave'))
+    expect(t.open.value).toBe(true)
+  })
+
+  it('onTriggerLeave closes with reason trigger-leave when hoverable content is disabled', () => {
+    const onUpdate = vi.fn()
+    const t = useTooltip({ baseId: 'x', disableHoverableContent: true, onUpdate })
+    t.onTriggerEnter()
+    vi.advanceTimersByTime(700)
+    expect(t.open.value).toBe(true)
+    const event = pointerEvent('pointerleave')
+    t.onTriggerLeave(event)
+    expect(t.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenLastCalledWith(false, expect.objectContaining({ reason: 'trigger-leave', event }))
+  })
+
+  it('forgets a delayed open once closed: a later ref-driven open carries no data-delayed', async () => {
+    const open = ref(false)
+    const t = useTooltip({ open, baseId: 'x' })
+    t.onTriggerEnter()
+    vi.advanceTimersByTime(700)
+    expect(open.value).toBe(true)
+    expect(t.trigger.attrs.value['data-delayed']).toBe('')
+
+    open.value = false
+    await nextTick()
+    expect(t.trigger.attrs.value).toEqual(expect.objectContaining({ 'data-state': 'closed' }))
+    open.value = true
+    expect(t.isDelayed.value).toBe(false)
+    expect(t.trigger.attrs.value['data-state']).toBe('open')
+    expect(t.trigger.attrs.value['data-delayed']).toBeUndefined()
+  })
+})
+
+describe('useTooltip — trigger surface', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('props expose aria-describedby, the grace-area selector and the listeners; data-state lives in attrs', () => {
+    const t = useTooltip({ baseId: 'x' })
+    const props = t.trigger.props.value
+    expect(props['aria-describedby']).toBeUndefined()
+    // The only `data-*` in props is the functional selector `useGraceArea` scopes with.
+    expect(props['data-grace-area-trigger']).toBe('')
+    expect(dataAttrKeys(props)).toEqual(['data-grace-area-trigger'])
+    for (const name of ['onClick', 'onFocus', 'onPointermove', 'onPointerleave', 'onPointerdown', 'onBlur'])
+      expect(typeof props[name]).toBe('function')
+    expect(t.trigger.state.value).toEqual({ state: 'closed', delayed: false })
+    expect(t.trigger.attrs.value).toMatchObject({ 'data-state': 'closed', 'data-grace-area-trigger': '' })
+    expect(t.trigger.attrs.value['data-delayed']).toBeUndefined()
+  })
+
+  it('renders no listeners while disabled', () => {
+    const disabled = ref(true)
+    const t = useTooltip({ baseId: 'x', disabled })
+    expect(Object.keys(t.trigger.props.value)).toEqual(['aria-describedby', 'data-grace-area-trigger'])
+    disabled.value = false
+    expect(typeof t.trigger.props.value.onFocus).toBe('function')
+  })
+
+  it('onFocus opens with trigger-focus and onBlur closes with trigger-blur', () => {
+    const onUpdate = vi.fn()
+    const t = useTooltip({ baseId: 'x', onUpdate })
+    const focus = new FocusEvent('focus')
+    t.trigger.props.value.onFocus(focus)
+    expect(t.open.value).toBe(true)
+    expect(onUpdate).toHaveBeenLastCalledWith(true, expect.objectContaining({ reason: 'trigger-focus', event: focus }))
+    expect(t.trigger.props.value['aria-describedby']).toBe('x-content')
+    const blur = new FocusEvent('blur')
+    t.trigger.props.value.onBlur(blur)
+    expect(t.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenLastCalledWith(false, expect.objectContaining({ reason: 'trigger-blur', event: blur }))
+  })
+
+  it('ignores the focus that follows a pointerdown until 1ms after pointerup', () => {
+    const t = useTooltip({ baseId: 'x' })
+    t.trigger.props.value.onPointerdown(pointerEvent('pointerdown'))
+    t.trigger.props.value.onFocus(new FocusEvent('focus'))
+    expect(t.open.value).toBe(false)
+
+    document.dispatchEvent(new Event('pointerup'))
+    t.trigger.props.value.onFocus(new FocusEvent('focus'))
+    expect(t.open.value).toBe(false)
+    vi.advanceTimersByTime(1)
+    t.trigger.props.value.onFocus(new FocusEvent('focus'))
+    expect(t.open.value).toBe(true)
+  })
+
+  it('with ignoreNonKeyboardFocus, focus opens only when the target matches :focus-visible', () => {
+    const t = useTooltip({ baseId: 'x', ignoreNonKeyboardFocus: true })
+    const el = document.createElement('button')
+    el.addEventListener('focus', t.trigger.props.value.onFocus)
+    el.matches = () => false
+    el.dispatchEvent(new FocusEvent('focus'))
+    expect(t.open.value).toBe(false)
+    el.matches = (selector: string) => selector === ':focus-visible'
+    el.dispatchEvent(new FocusEvent('focus'))
+    expect(t.open.value).toBe(true)
+  })
+
+  it('onPointerdown and onClick close an open tooltip with trigger-press unless disableClosingTrigger', () => {
+    const onUpdate = vi.fn()
+    const t = useTooltip({ baseId: 'x', defaultOpen: true, onUpdate })
+    const down = pointerEvent('pointerdown')
+    t.trigger.props.value.onPointerdown(down)
+    expect(t.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenLastCalledWith(false, expect.objectContaining({ reason: 'trigger-press', event: down }))
+
+    t.onOpen()
+    const click = new MouseEvent('click')
+    t.trigger.props.value.onClick(click)
+    expect(t.open.value).toBe(false)
+    expect(onUpdate).toHaveBeenLastCalledWith(false, expect.objectContaining({ reason: 'trigger-press', event: click }))
+
+    const u = useTooltip({ baseId: 'y', defaultOpen: true, disableClosingTrigger: true })
+    u.trigger.props.value.onPointerdown(pointerEvent('pointerdown'))
+    u.trigger.props.value.onClick(new MouseEvent('click'))
+    expect(u.open.value).toBe(true)
+  })
+
+  it('onPointermove enters once per hover, never for touch nor while the pointer is in transit', () => {
+    const transit = ref(false)
+    const t = useTooltip({ baseId: 'x', isPointerInTransit: transit })
+    const enter = vi.spyOn(t.context, 'onTriggerEnter')
+
+    t.trigger.props.value.onPointermove(pointerEvent('pointermove', 'touch'))
+    expect(enter).not.toHaveBeenCalled()
+
+    transit.value = true
+    t.trigger.props.value.onPointermove(pointerEvent('pointermove'))
+    expect(enter).not.toHaveBeenCalled()
+
+    transit.value = false
+    const move = pointerEvent('pointermove')
+    t.trigger.props.value.onPointermove(move)
+    expect(enter).toHaveBeenCalledTimes(1)
+    expect(enter).toHaveBeenCalledWith(move)
+    // Subsequent moves over the same hover do not re-arm the timer …
+    t.trigger.props.value.onPointermove(pointerEvent('pointermove'))
+    expect(enter).toHaveBeenCalledTimes(1)
+    // … until the pointer has left.
+    const leave = vi.spyOn(t.context, 'onTriggerLeave')
+    const leaveEvent = pointerEvent('pointerleave')
+    t.trigger.props.value.onPointerleave(leaveEvent)
+    expect(leave).toHaveBeenCalledWith(leaveEvent)
+    t.trigger.props.value.onPointermove(pointerEvent('pointermove'))
+    expect(enter).toHaveBeenCalledTimes(2)
+
+    vi.advanceTimersByTime(700)
+    expect(t.open.value).toBe(true)
+    expect(t.trigger.attrs.value['data-delayed']).toBe('')
+  })
+})
+
+describe('useTooltip — content & label surfaces', () => {
+  it('content is state-only: data-state plus data-delayed while delayed', () => {
+    const t = useTooltip({ baseId: 'x' })
+    expect(t.content.props.value).toEqual({})
+    expect(t.content.state.value).toEqual({ state: 'closed', delayed: false })
+    expect(t.content.attrs.value).toEqual({ 'data-state': 'closed' })
+    t.onOpen()
+    expect(t.content.attrs.value).toEqual({ 'data-state': 'open' })
+  })
+
+  it('label carries the content id and role="tooltip" with no state', () => {
+    const t = useTooltip({ baseId: 'x' })
+    expect(t.label.state.value).toEqual({})
+    expect(t.label.attrs.value).toEqual({ id: 'x-content', role: 'tooltip' })
+  })
+})
+
+describe('useTooltip — context', () => {
+  it('exposes the TooltipContext shape the shell provides', () => {
+    const t = useTooltip({ baseId: 'x' })
+    expect(Object.keys(t.context).sort()).toEqual([
+      'contentId',
+      'disableClosingTrigger',
+      'disableHoverableContent',
+      'disabled',
+      'ignoreNonKeyboardFocus',
+      'isDelayed',
+      'isPointerInTransit',
+      'onClose',
+      'onOpen',
+      'onTriggerChange',
+      'onTriggerEnter',
+      'onTriggerLeave',
+      'open',
+      'stateAttribute',
+      'trigger',
+    ])
+    expect(t.context.open).toBe(t.open)
+    expect(t.context.isDelayed).toBe(t.isDelayed)
+    expect(t.context.onOpen).toBe(t.onOpen)
+    expect(t.context.onClose).toBe(t.onClose)
+    expect(t.context.stateAttribute.value).toBe('closed')
+    expect(t.context.trigger.value).toBeUndefined()
+    const el = document.createElement('button')
+    t.context.onTriggerChange(el)
+    expect(t.context.trigger.value).toBe(el)
+    // Dismissal reasons arrive through `onClose` from the layer the consumer composes.
+    t.onOpen()
+    const event = new KeyboardEvent('keydown', { key: 'Escape' })
+    expect(t.context.onClose('escape-key', event)).toBe(true)
+    expect(t.context.stateAttribute.value).toBe('closed')
+    expect(t.lastChangeDetails.value).toMatchObject({ reason: 'escape-key', event })
+  })
+})
+
+describe('useTooltip — rendered surfaces', () => {
+  // A standalone consumer binding the surfaces to plain elements, without the
+  // Popper / Presence / DismissableLayer wrappers: the aria wiring alone has to
+  // satisfy axe, closed and open.
+  const Fixture = defineComponent({
+    setup() {
+      const t = useTooltip({ baseId: 'fixture' })
+      return { t }
+    },
+    template: `
+      <button v-bind="t.trigger.attrs.value">Hover</button>
+      <div v-if="t.open.value" v-bind="t.content.attrs.value">
+        Body
+        <span v-bind="t.label.attrs.value">Add to library</span>
+      </div>
+    `,
+  })
+
+  it('wires trigger, content and label together and passes axe, closed and open', async () => {
+    const { container, getByRole, getByText, queryByRole } = render(Fixture)
+    const trigger = getByText('Hover')
+    expect(trigger.getAttribute('aria-describedby')).toBeNull()
+    expect(trigger.getAttribute('data-state')).toBe('closed')
+    expect(trigger.hasAttribute('data-delayed')).toBe(false)
+    expect(trigger.hasAttribute('data-grace-area-trigger')).toBe(true)
+    expect(queryByRole('tooltip')).toBeNull()
+    expect(await axe(container)).toHaveNoViolations()
+
+    await fireEvent.focus(trigger)
+    const label = getByRole('tooltip')
+    expect(label.id).toBe('fixture-content')
+    expect(trigger.getAttribute('aria-describedby')).toBe(label.id)
+    expect(trigger.getAttribute('data-state')).toBe('open')
+    expect(getByText('Body', { exact: false }).getAttribute('data-state')).toBe('open')
+    expect(await axe(container)).toHaveNoViolations()
+
+    await fireEvent.blur(trigger)
+    expect(queryByRole('tooltip')).toBeNull()
+    expect(trigger.getAttribute('aria-describedby')).toBeNull()
+    expect(trigger.getAttribute('data-state')).toBe('closed')
+  })
+})
+
+describe('useTooltip — public export', () => {
+  it('is exported from the package barrel; the surface builders are internal', () => {
+    expect(typeof Reka.useTooltip).toBe('function')
+    expect('createTooltipTriggerSurface' in Reka).toBe(false)
+    expect('getTooltipContentSurface' in Reka).toBe(false)
+    expect('getTooltipLabelSurface' in Reka).toBe(false)
+  })
+})

--- a/packages/core/src/Tooltip/useTooltip.ts
+++ b/packages/core/src/Tooltip/useTooltip.ts
@@ -303,11 +303,14 @@ export function useTooltip(props: UseTooltipProps = {}): UseTooltipReturn {
 
   // A closed tooltip keeps no "delayed" history: a later parent-driven or
   // imperative open must not render `data-delayed`. A cancelled close never
-  // flips `open`, so the flag survives it.
+  // flips `open`, so the flag survives it. `flush: 'sync'` because a pre-flush
+  // watcher coalesces an open and a close that land in the same tick (the delay
+  // timer firing, then a synchronous ref-driven close) into "no change" and
+  // never resets the flag.
   watch(open, (isOpen) => {
     if (!isOpen)
       wasOpenDelayedRef.value = false
-  })
+  }, { flush: 'sync' })
 
   // The `pointermove` that armed the delay timer, handed to `update:open` when it fires.
   let delayedOpenEvent: PointerEvent | undefined

--- a/packages/core/src/Tooltip/useTooltip.ts
+++ b/packages/core/src/Tooltip/useTooltip.ts
@@ -1,0 +1,388 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue'
+import type { TooltipContext, TooltipOpenChangeReason } from './TooltipRoot.vue'
+import type { BaseChangeReason, ChangeEventDetails, DisclosureState, PartSurface } from '@/shared'
+import { useTimeoutFn } from '@vueuse/core'
+import { computed, ref, toValue, watch } from 'vue'
+import { createPartSurface, disclosureState, useControllableState } from '@/shared'
+
+// =============================================================================
+// Headless composable for the Tooltip (overlay) family — issue #2723.
+//
+// Follows the overlay contract validated on Menu: the root renders NO attrs
+// (`TooltipRoot` is `<PopperRoot><slot/></PopperRoot>`), so `useTooltip()`
+// returns state + the context object the SFC provides, and the surfaces begin
+// at Trigger / Content. The content and label surfaces are pure
+// `get<Part>Surface(context)` derivations (idempotent, shared by the SFCs and
+// `useTooltip()`); the trigger is a context-scoped FACTORY
+// (`createTooltipTriggerSurface`) because it owns per-instance pointer state —
+// the Menu axiom that pure builders don't survive overlays.
+//
+// The provider coupling stays in the shell: `TooltipRoot.vue` resolves the
+// `TooltipProvider` fallbacks (delay, skip-delay, grace-area transit, …) into
+// getters and hands them in, and keeps the `watch(open)` that notifies the
+// provider and dispatches `TOOLTIP_OPEN`. `PopperAnchor` / `PopperContent`,
+// `Presence`, `DismissableLayer`, the portal, the grace area
+// (`TooltipContentHoverable`) and the scroll / `TOOLTIP_OPEN` listeners stay
+// wrappers.
+// =============================================================================
+
+/**
+ * Semantic state of the trigger part; `state` → `data-state="open|closed"`,
+ * `delayed` → `data-delayed=""` only while `true` (#2823: the disclosure axis
+ * and the "delayed" qualifier are two attributes, not one value).
+ */
+export type TooltipTriggerState = { state: DisclosureState, delayed: boolean }
+/** Semantic state of the content part; same two axes as the trigger. */
+export type TooltipContentState = { state: DisclosureState, delayed: boolean }
+
+/** Standalone `useTooltip()` calls without a `baseId` draw `reka-tooltip-<n>` from here. */
+let tooltipCount = 0
+
+/**
+ * The trigger surface: `aria-describedby` (the content id, only while open),
+ * the `data-grace-area-trigger` selector `useGraceArea` scopes its
+ * `closest()` lookup with (a functional selector, not semantic state — hence
+ * in `props`), and the pointer / focus / click listeners that drive the open
+ * model — none of them while `disabled`.
+ *
+ * A context-SCOPED FACTORY (recipe: "Overlay families"): it owns the
+ * per-instance `isPointerDown` / `hasPointerMoveOpened` refs, so call it
+ * EXACTLY ONCE per trigger instance — `useTooltip()` does for its own
+ * `trigger`, `TooltipTrigger.vue` does for the rendered one. `get<...>` is
+ * reserved for the pure builders.
+ *
+ * Handler bodies are ported verbatim from the pre-#2723 `TooltipTrigger.vue`:
+ * touch pointers never open (the tooltip has no touch affordance), a
+ * `pointermove` opens once until the pointer leaves and never while the
+ * provider's grace area reports the pointer in transit, focus is ignored
+ * while the pointer is down (a click's focus is not a keyboard focus) and,
+ * with `ignoreNonKeyboardFocus`, unless the trigger matches `:focus-visible`;
+ * `pointerdown` / `click` close unless `disableClosingTrigger`.
+ *
+ * @experimental Signatures may change in 3.x minors.
+ * @lifecycle pure — no hooks; the `pointerup` listener is attached to
+ * `document` only from inside `onPointerdown`, never at call scope.
+ */
+export function createTooltipTriggerSurface(context: TooltipContext): PartSurface<TooltipTriggerState> {
+  const isPointerDown = ref(false)
+  const hasPointerMoveOpened = ref(false)
+
+  function resetPointerDown() {
+    isPointerDown.value = false
+  }
+
+  function handlePointerUp() {
+    setTimeout(resetPointerDown, 1)
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (context.open.value && !context.disableClosingTrigger.value) {
+      context.onClose('trigger-press', event)
+    }
+    isPointerDown.value = true
+    document.addEventListener('pointerup', handlePointerUp, { once: true })
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (event.pointerType === 'touch')
+      return
+    if (
+      !hasPointerMoveOpened.value && !context.isPointerInTransit.value
+    ) {
+      context.onTriggerEnter(event)
+      hasPointerMoveOpened.value = true
+    }
+  }
+
+  function handlePointerLeave(event: PointerEvent) {
+    context.onTriggerLeave(event)
+    hasPointerMoveOpened.value = false
+  }
+
+  function handleFocus(event: FocusEvent) {
+    if (isPointerDown.value)
+      return
+
+    if (context.ignoreNonKeyboardFocus.value && !(event.target as HTMLElement).matches?.(':focus-visible'))
+      return
+
+    context.onOpen('trigger-focus', event)
+  }
+
+  function handleBlur(event: FocusEvent) {
+    context.onClose('trigger-blur', event)
+  }
+
+  function handleClick(event: MouseEvent) {
+    if (!context.disableClosingTrigger.value)
+      context.onClose('trigger-press', event)
+  }
+
+  return createPartSurface<TooltipTriggerState>(
+    () => ({
+      'aria-describedby': context.open.value ? context.contentId : undefined,
+      'data-grace-area-trigger': '',
+      // A disabled tooltip renders NO listeners (not inert ones), exactly like
+      // the pre-#2723 `v-on="tooltipListeners"` with its `{}` branch.
+      ...(context.disabled.value
+        ? {}
+        : {
+            onClick: handleClick,
+            onFocus: handleFocus,
+            onPointermove: handlePointerMove,
+            onPointerleave: handlePointerLeave,
+            onPointerdown: handlePointerDown,
+            onBlur: handleBlur,
+          }),
+    }),
+    () => ({ state: context.stateAttribute.value, delayed: context.isDelayed.value }),
+  )
+}
+
+/**
+ * The content surface, derived purely from the root context — shared by
+ * `useTooltip().content` and `TooltipContentImpl.vue`. State only
+ * (`data-state` + `data-delayed`): the `PopperContent` positioning props, the
+ * `--reka-tooltip-*` CSS variables, the `DismissableLayer` wrapper and the
+ * scroll / `TOOLTIP_OPEN` listeners stay in the SFC.
+ */
+export function getTooltipContentSurface(
+  context: Pick<TooltipContext, 'stateAttribute' | 'isDelayed'>,
+): PartSurface<TooltipContentState> {
+  return createPartSurface<TooltipContentState>(
+    () => ({}),
+    () => ({ state: context.stateAttribute.value, delayed: context.isDelayed.value }),
+  )
+}
+
+/**
+ * The a11y label surface: the `role="tooltip"` element carrying the id the
+ * trigger's `aria-describedby` points at. `TooltipContentImpl.vue` binds it on
+ * its `VisuallyHidden` label; a standalone consumer binds it on whatever
+ * element holds the accessible text. Renders no `data-*`.
+ */
+export function getTooltipLabelSurface(
+  context: Pick<TooltipContext, 'contentId'>,
+): PartSurface<Record<string, never>> {
+  return createPartSurface<Record<string, never>>(
+    () => ({ id: context.contentId, role: 'tooltip' }),
+    () => ({}),
+  )
+}
+
+export interface UseTooltipProps {
+  /**
+   * Controlled open state. A getter/ref resolving to `undefined` is uncontrolled;
+   * a writable `Ref` (with no `emit`/`onUpdate`) is written back ("ref-owned").
+   */
+  open?: MaybeRefOrGetter<boolean | undefined>
+  /** Initial open state when uncontrolled. @defaultValue `false` */
+  defaultOpen?: boolean
+  /**
+   * The delay before a pointer hover opens the tooltip. The SFC resolves it to
+   * the root prop or the `TooltipProvider` value. @defaultValue `700`
+   */
+  delayDuration?: MaybeRefOrGetter<number | undefined>
+  /**
+   * Whether a hover open waits for `delayDuration`. `TooltipProvider` flips it
+   * to `false` for `skipDelayDuration` after a tooltip closes, so moving
+   * between adjacent triggers opens instantly (and without `data-delayed`).
+   * @defaultValue `true`
+   */
+  isOpenDelayed?: MaybeRefOrGetter<boolean | undefined>
+  /**
+   * Whether the pointer is travelling through the grace area between a
+   * trigger and its hoverable content (`useGraceArea`, published on the
+   * provider by `TooltipContentHoverable`). The trigger's `pointermove` does
+   * not open while it is `true`. @defaultValue `false`
+   */
+  isPointerInTransit?: MaybeRefOrGetter<boolean | undefined>
+  /**
+   * When `true`, leaving the trigger closes the tooltip instead of letting the
+   * pointer travel onto the content. @defaultValue `false`
+   */
+  disableHoverableContent?: MaybeRefOrGetter<boolean | undefined>
+  /** When `true`, pressing the trigger does not close the tooltip. @defaultValue `false` */
+  disableClosingTrigger?: MaybeRefOrGetter<boolean | undefined>
+  /** When `true`, the trigger surface renders no listeners. @defaultValue `false` */
+  disabled?: MaybeRefOrGetter<boolean | undefined>
+  /**
+   * When `true`, focus opens the tooltip only if the trigger matches
+   * `:focus-visible` (keyboard focus). @defaultValue `false`
+   */
+  ignoreNonKeyboardFocus?: MaybeRefOrGetter<boolean | undefined>
+  /**
+   * Base id the content id derives from (`<baseId>-content`). Defaults to
+   * `reka-tooltip-<n>` from a per-call counter, which is NOT stable across
+   * server and client: SSR consumers must pass a stable `baseId` (the SFC
+   * hands its `useId(undefined, 'reka-tooltip')`).
+   */
+  baseId?: string
+  /** Component `emit`; receives `beforeUpdate:open` then `update:open`. */
+  emit?: (event: any, ...args: any[]) => void
+  /** Called before a change commits; `details.cancel()` vetoes it. */
+  onBeforeUpdate?: (value: boolean, details: ChangeEventDetails<TooltipOpenChangeReason>) => void
+  /** Called after a change commits. */
+  onUpdate?: (value: boolean, details: ChangeEventDetails<TooltipOpenChangeReason>) => void
+}
+
+export interface UseTooltipReturn {
+  open: ComputedRef<boolean>
+  /** `true` only while open AND that open came from the delay timer; rendered as `data-delayed`. */
+  isDelayed: ComputedRef<boolean>
+  /** Opens instantly (cancelling a pending delayed open). Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onOpen: (reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Closes and cancels a pending delayed open. Returns `false` when the change was a no-op or cancelled via `beforeUpdate:open`. */
+  onClose: (reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event) => boolean
+  /** Pointer entered the trigger: opens with reason `trigger-hover`, delayed unless `isOpenDelayed` is `false`. */
+  onTriggerEnter: (event?: PointerEvent) => void
+  /** Pointer left the trigger: closes with reason `trigger-leave` when hoverable content is disabled, else only cancels a pending delayed open. */
+  onTriggerLeave: (event?: PointerEvent) => void
+  /** Details of the last change attempt; initially `{ reason: 'none' }`. */
+  lastChangeDetails: Readonly<Ref<ChangeEventDetails<TooltipOpenChangeReason>>>
+  isControlled: ComputedRef<boolean>
+  /** `aria-describedby` + `data-grace-area-trigger` + the pointer/focus/click listeners; `data-state` / `data-delayed`. */
+  trigger: PartSurface<TooltipTriggerState>
+  /** State only: `data-state` / `data-delayed`. */
+  content: PartSurface<TooltipContentState>
+  /** `id` / `role="tooltip"` for the accessible label; renders no `data-*`. */
+  label: PartSurface<Record<string, never>>
+  /** The `TooltipContext` value — the SFC provides this verbatim. */
+  context: TooltipContext
+}
+
+/**
+ * Headless Tooltip logic. The `.vue` shells compose this; a standalone consumer
+ * gets the open model (with `beforeUpdate`/`update` details and reasons), the
+ * delayed-open timer, the content id and the trigger/content/label surfaces,
+ * but must still wrap the content in `Presence`, `DismissableLayer` and
+ * `PopperContent` (and the trigger in `PopperAnchor`) — those are component
+ * families a pure composable cannot absorb (see the #2723 recipe's "Overlay
+ * families"). Dismissal reasons (`escape-key`, `outside-press`) therefore
+ * arrive through `onClose(reason, event)` from whatever layer the consumer
+ * composes, and the `TooltipProvider` coordination (skip-delay, closing the
+ * previous tooltip, the grace-area transit flag) is opt-in through the
+ * `isOpenDelayed` / `isPointerInTransit` getters.
+ *
+ * SSR-safe: no `document`/`window` at call scope (`document` is touched only
+ * inside the trigger's `pointerdown` handler).
+ *
+ * @experimental Signatures may change in 3.x minors.
+ * @lifecycle setup — no lifecycle hooks, so it does run outside `setup()`, but
+ * it creates a `watch` (the `data-delayed` reset) and a `useTimeoutFn` timer
+ * that are only disposed when called inside a component or an `effectScope`.
+ */
+export function useTooltip(props: UseTooltipProps = {}): UseTooltipReturn {
+  const baseId = props.baseId ?? `reka-tooltip-${++tooltipCount}`
+
+  // Every write to `open` — hover timer, focus/blur, press, grace-area exit,
+  // dismiss — goes through one `setState`, so `beforeUpdate:open` can cancel any
+  // of them and `update:open` always carries the reason (#2828).
+  const { state: open, setState, lastChangeDetails, isControlled } = useControllableState<boolean, TooltipOpenChangeReason>({
+    prop: props.open,
+    defaultValue: props.defaultOpen ?? false,
+    name: 'open',
+    emit: props.emit,
+    onBeforeUpdate: props.onBeforeUpdate,
+    onUpdate: props.onUpdate,
+  })
+
+  const delayDuration = computed<number>(() => toValue(props.delayDuration) ?? 700)
+  const isOpenDelayed = computed<boolean>(() => toValue(props.isOpenDelayed) ?? true)
+  const isPointerInTransit = computed<boolean>(() => toValue(props.isPointerInTransit) ?? false)
+  const disableHoverableContent = computed<boolean>(() => toValue(props.disableHoverableContent) ?? false)
+  const disableClosingTrigger = computed<boolean>(() => toValue(props.disableClosingTrigger) ?? false)
+  const disabled = computed<boolean>(() => toValue(props.disabled) ?? false)
+  const ignoreNonKeyboardFocus = computed<boolean>(() => toValue(props.ignoreNonKeyboardFocus) ?? false)
+
+  const wasOpenDelayedRef = ref(false)
+  const trigger = ref<HTMLElement>()
+
+  const stateAttribute = computed<DisclosureState>(() => disclosureState(open.value))
+  const isDelayed = computed<boolean>(() => open.value && wasOpenDelayedRef.value)
+
+  // A closed tooltip keeps no "delayed" history: a later parent-driven or
+  // imperative open must not render `data-delayed`. A cancelled close never
+  // flips `open`, so the flag survives it.
+  watch(open, (isOpen) => {
+    if (!isOpen)
+      wasOpenDelayedRef.value = false
+  })
+
+  // The `pointermove` that armed the delay timer, handed to `update:open` when it fires.
+  let delayedOpenEvent: PointerEvent | undefined
+
+  const { start: startTimer, stop: clearTimer } = useTimeoutFn(() => {
+    const event = delayedOpenEvent
+    delayedOpenEvent = undefined
+    // Flag before the write so `isDelayed` is right on the same tick `open` flips;
+    // roll it back when the open was cancelled (or was a no-op).
+    wasOpenDelayedRef.value = true
+    if (!setState(true, 'trigger-hover', event))
+      wasOpenDelayedRef.value = false
+  }, delayDuration, { immediate: false })
+
+  function handleOpen(reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event): boolean {
+    clearTimer()
+    wasOpenDelayedRef.value = false
+    return setState(true, reason, event)
+  }
+  function handleClose(reason?: TooltipOpenChangeReason | BaseChangeReason, event?: Event): boolean {
+    // Cancel a pending delayed open first; a cancelled close then simply stays open.
+    clearTimer()
+    return setState(false, reason, event)
+  }
+  function handleDelayedOpen(event?: PointerEvent) {
+    delayedOpenEvent = event
+    startTimer()
+  }
+  function onTriggerEnter(event?: PointerEvent) {
+    if (isOpenDelayed.value)
+      handleDelayedOpen(event)
+    else handleOpen('trigger-hover', event)
+  }
+  function onTriggerLeave(event?: PointerEvent) {
+    if (disableHoverableContent.value) {
+      handleClose('trigger-leave', event)
+    }
+    else {
+      // Clear the timer in case the pointer leaves the trigger before the tooltip is opened.
+      clearTimer()
+    }
+  }
+
+  const context: TooltipContext = {
+    contentId: `${baseId}-content`,
+    open,
+    stateAttribute,
+    isDelayed,
+    isPointerInTransit,
+    trigger,
+    onTriggerChange(el) {
+      trigger.value = el
+    },
+    onTriggerEnter,
+    onTriggerLeave,
+    onOpen: handleOpen,
+    onClose: handleClose,
+    disableHoverableContent,
+    disableClosingTrigger,
+    disabled,
+    ignoreNonKeyboardFocus,
+  }
+
+  return {
+    open,
+    isDelayed,
+    onOpen: handleOpen,
+    onClose: handleClose,
+    onTriggerEnter,
+    onTriggerLeave,
+    lastChangeDetails,
+    isControlled,
+    trigger: createTooltipTriggerSurface(context),
+    content: getTooltipContentSurface(context),
+    label: getTooltipLabelSurface(context),
+    context,
+  }
+}


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

#2721 (v3 roadmap), #2723 (headless composables), #2823 (the optional Stepper rename from decision item 5), #2828 (change details)

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Three roadmap follow-ups from #2721, one commit each.

**`useTooltip` / `useHoverCard` composables (#2723)** — the two remaining hover overlays follow the overlay contract validated on Menu and applied to Dialog/Popover in #2916: the root SFC is a shell over the composable, which owns the controlled/uncontrolled `open` model with change details, the timers, the ids and the context the SFC provides verbatim; the parts are `get<Part>Surface(context)` derivations shared by the SFCs and the composable, bound with `v-bind="part.attrs.value"`. Popper, Presence, DismissableLayer, the grace area and the portal stay wrappers. Every rendered attribute is unchanged.
- Tooltip: the trigger is a per-instance `createTooltipTriggerSurface` factory (it owns `isPointerDown` / `hasPointerMoveOpened`); content (`data-state` / `data-delayed`) and label (`id` / `role="tooltip"`) are pure. The content id is `<baseId>-content`, populated up-front instead of back-filled by the trigger. The provider coupling stays in the shell: `TooltipRoot.vue` resolves the `TooltipProvider` fallbacks into getters (`delayDuration`, `isOpenDelayed`, `isPointerInTransit`, …) and keeps the provider watcher. `TooltipContext` gains one additive field, `isPointerInTransit`. The recipe records this pattern. The `data-delayed` reset is a `flush: 'sync'` watcher: a pre-flush one coalesces an open and a close in the same tick into "no change" (caught by the new standalone test).
- HoverCard: `openDelay` / `closeDelay` timers move into the composable, still carrying the reason and event of the interaction that armed them; the trigger surface carries `data-grace-area-trigger` and the hover/leave/touch/focus/blur listeners.
- Both export `useX`, `UseXProps` / `UseXReturn` and the part state types (`@experimental`); the builders stay internal. New `useTooltip.test.ts` / `useHoverCard.test.ts` cover the model, timers, surfaces, context and a rendered `@testing-library/vue` + axe fixture.

**Stepper `data-state` rename (#2823 follow-up)** — Stepper keeps its grandfathered three-value machine but drops the two words that read as synonyms of the axes and collided with Tabs' old values: a step is now `completed`, `current` or `upcoming` (`aria-current` follows `current`). The codemod's per-file decision for `active` / `inactive` becomes three-way (Tabs/TagsInput/Rating → `checked`/`unchecked`, Stepper → `current`/`upcoming`, SplitterResizeHandle → kept; mixed or unknown files warn), with tests (27 passing via `node --test`). Migration guide, README, attribute tables, demos, stories and the generated `StepperItem` meta follow.

**`@reka-ui/codemod` publishing** — the package is versioned in lockstep with `reka-ui` (`pnpm bumpp` already covers `packages/*/package.json`), published from the release workflow with provenance, included in the pkg.pr.new preview (`npx https://pkg.pr.new/unovue/reka-ui/@reka-ui/codemod@2917 data-state ./src`), and ships the MIT license. Two things to know: npm trusted publishing needs the package to exist and a trusted-publisher entry pointing at `release.yaml`, so the first `@reka-ui/codemod` publish is a manual step for a maintainer; and with two packages in the pkg.pr.new command the `reka-ui` preview URL takes the long `pkg.pr.new/unovue/reka-ui@<pr>` form until the codemod exists on npm.

BREAKING CHANGE: `StepperItem`, `StepperTrigger` and `StepperSeparator` emit `data-state="current"` / `"upcoming"` instead of `"active"` / `"inactive"` (`StepperState` changes accordingly); the Tooltip content id shape changes from `reka-tooltip-content-<n>` to `reka-tooltip-<n>-content`.

CI (vitest, vue-tsc via the build, size, the `docs-meta` drift check) is green on the current head.

### 📸 Screenshots (if appropriate)

n/a

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjAHnVc7rPjMzA2srYUtiu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added headless Tooltip and HoverCard composables with reusable overlay behavior.
  * Exported the composables and related public types.
  * Published the codemod package through release and preview workflows.

* **Updates**
  * Stepper states now use `completed`, `current`, and `upcoming`, with `aria-current` on the current step.
  * Improved HoverCard and Tooltip timing, interaction handling, and accessibility behavior.
  * Updated Stepper styling, documentation, migration guidance, and codemod mappings.

* **Documentation**
  * Added codemod licensing, versioning, publishing, and migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->