### PR TITLE
fix(shared): suppress background with inert instead of aria-hidden alone

### DIFF
--- a/packages/core/src/shared/useHideOthers.ts
+++ b/packages/core/src/shared/useHideOthers.ts
@@ -1,6 +1,6 @@
 import type { MaybeElementRef } from '@vueuse/core'
 import { unrefElement } from '@vueuse/core'
-import { hideOthers } from 'aria-hidden'
+import { suppressOthers } from 'aria-hidden'
 import { onUnmounted, watch } from 'vue'
 
 /**
@@ -11,7 +11,7 @@ import { onUnmounted, watch } from 'vue'
  * to hide other elements when it is clicked or focused.
  */
 export function useHideOthers(target: MaybeElementRef) {
-  let undo: ReturnType<typeof hideOthers>
+  let undo: ReturnType<typeof suppressOthers>
   watch(() => unrefElement(target), (el) => {
     // disable hideOthers on test mode
     if (import.meta.env.MODE === 'test')
@@ -24,7 +24,7 @@ export function useHideOthers(target: MaybeElementRef) {
     }
     catch {}
     if (el && !isInsideClosedPopover)
-      undo = hideOthers(el)
+      undo = suppressOthers(el)
     else if (undo)
       undo()
   })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2922

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`useHideOthers` marks everything outside the open content with `aria-hidden` only, leaving those elements focusable in the DOM. axe-core flags that as `aria-hidden-focus` (**serious**) on every screen where a modal primitive is open:

```
[serious] ARIA hidden element must not be focusable or contain focusable elements
  Selector: #app
  HTML: <div id="app" data-v-app="" data-aria-hidden="true" aria-hidden="true">
```

This switches to `suppressOthers()`, already exported by the `aria-hidden` dependency:

```js
// aria-hidden 1.2.6
export var suppressOthers = function (originalTarget, parentNode, markerName) {
    return (supportsInert() ? inertOthers : hideOthers)(originalTarget, parentNode, markerName);
};
```

It applies `inert` where the browser supports it and falls back to the current behavior otherwise.

**The change** — `packages/core/src/shared/useHideOthers.ts`:

```diff
 import type { MaybeElementRef } from '@vueuse/core'
 import { unrefElement } from '@vueuse/core'
-import { hideOthers } from 'aria-hidden'
+import { suppressOthers } from 'aria-hidden'
 import { onUnmounted, watch } from 'vue'

 export function useHideOthers(target: MaybeElementRef) {
-  let undo: ReturnType<typeof hideOthers>
+  let undo: ReturnType<typeof suppressOthers>
   watch(() => unrefElement(target), (el) => {
@@
     if (el && !isInsideClosedPopover)
-      undo = hideOthers(el)
+      undo = suppressOthers(el)
     else if (undo)
       undo()
   })
```

Both share the `(target, parentNode?, markerName?) => Undo` signature, so the call site, the teardown and the `[popover]:not(:popover-open)` guard are untouched. I kept the composable's name — renaming it would break anyone importing it from the shared entry, and "hide the others" still describes what it does.

**Scope.** Affects the primitives that use it in modal mode: `MenuRootContentModal`, `DialogContentModal`, `DrawerContent`, `PopoverContentModal`, `SelectContentImpl`, `ComboboxContentImpl`. Non-modal variants never called it.

**Compatibility.** No new dependency (`aria-hidden@^1.2.4` already ships both functions), and on browsers without `inert` the emitted attributes are identical to today. Where `inert` is supported, the background also leaves the tab order at the DOM level, so correctness no longer depends on `FocusScope`'s `focusin` listener being attached — the trap itself is unchanged.

**On tests.** I did not add one, and I would like your call on it. `useHideOthers` early-returns when `import.meta.env.MODE === 'test'`, so nothing under `vitest` ever exercises this path — which is also why the current behavior never showed up in the colocated `vitest-axe` assertions. Options I see:

1. Leave as is (manual verification, described below).
2. Narrow the guard so the composable runs in jsdom, then assert the attributes on the background in one colocated test. jsdom does not implement `inert` behavior, but `supportsInert()` checks `HTMLElement.prototype.inert !== undefined`, so the assertion would have to accept either branch.
3. Cover it in a browser-mode test if you have somewhere that fits better.

Tell me which you prefer and I will push it in this PR.

### 📸 Screenshots (if appropriate)

Not applicable — the change is an attribute on the background element. Before/after can be seen by inspecting the app root with any modal primitive open.

**Verified**

Repo checks, on this branch:

| | |
|---|---|
| `pnpm --filter reka-ui build` | passes (7.5s, including the `vue-tsc` step) |
| `pnpm --filter reka-ui exec vitest run` | 97 files, 2041 tests, all passing |
| `eslint` on the changed file | clean |

The suite passing only shows nothing regressed — it does not exercise this path, because of the test-mode early return described above.

So I verified the actual behavior end to end, by building the package and dropping the `dist` into a real Vue 3.5.42 + Vite app, then driving Chromium (Playwright) against a page with an open `DropdownMenu`:

```js
// before (reka-ui 2.10.4 as published)
{ ariaHidden: "true", inert: false }   // axe: 1 serious violation (aria-hidden-focus)

// after (this branch)
{ ariaHidden: null,   inert: true  }   // axe: no violations
```

Worth noting for the review: where `inert` is supported, `inertOthers` does not set `aria-hidden` at all — `inert` already removes the subtree from the accessibility tree and the tab order, so the end state is stronger than today's, not merely equivalent.

**To reproduce the check manually**

1. `pnpm --filter reka-ui build && pnpm docs:dev`
2. Open the DropdownMenu docs page and open the menu.
3. Inspect the app root: it carries `inert` instead of `aria-hidden`.
4. Run `axe.run()` in the console — the `aria-hidden-focus` violation is gone.

One gotcha when auditing by hand: wait for the open animation to finish before running axe. Reading computed styles mid-`fade-in` produces unrelated false positives (I measured a label at ~11% opacity reporting a contrast of 1.25 that reads 16:1 once settled).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- No docs change: the `modal` prop's documented contract ("Supports modal and non-modal modes") does not change — only how the background is suppressed. Happy to add a note to the accessibility section if you want it stated. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility behavior when isolating active interface elements by suppressing other content from assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->