### PR TITLE
fix(Tooltip): stop pointing at a stale trigger element after it's replaced

### DIFF
--- a/packages/core/src/Tooltip/Tooltip.test.ts
+++ b/packages/core/src/Tooltip/Tooltip.test.ts
@@ -3,6 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 import { defineComponent, ref } from 'vue'
+import { injectPopperRootContext } from '@/Popper'
 import Tooltip from './stories/_Tooltip.vue'
 import TooltipContent from './TooltipContent.vue'
 import TooltipPortal from './TooltipPortal.vue'
@@ -131,8 +132,15 @@ describe('given tooltip within TooltipProvider', () => {
 describe('given a tooltip trigger whose element is replaced after mount', () => {
   let wrapper: VueWrapper
 
+  const AnchorProbe = defineComponent({
+    setup() {
+      return { anchor: injectPopperRootContext().anchor }
+    },
+    template: '<span />',
+  })
+
   const SwappableTrigger = defineComponent({
-    components: { TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger },
+    components: { AnchorProbe, TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger },
     setup() {
       return { tag: ref('button') }
     },
@@ -140,6 +148,7 @@ describe('given a tooltip trigger whose element is replaced after mount', () => 
       <TooltipProvider>
         <TooltipRoot>
           <TooltipTrigger :as="tag">trigger</TooltipTrigger>
+          <AnchorProbe />
           <TooltipPortal>
             <TooltipContent>tooltip content</TooltipContent>
           </TooltipPortal>
@@ -181,5 +190,30 @@ describe('given a tooltip trigger whose element is replaced after mount', () => 
     await flushPromises()
 
     expect(document.body.innerHTML).not.toContain('tooltip content')
+  })
+
+  it('should stop listening on the replaced trigger element', async () => {
+    await wrapper.find('button').trigger('focus')
+    const replacedTrigger = wrapper.find('button').element as HTMLElement
+
+    wrapper.vm.tag = 'a'
+    await flushPromises()
+
+    replacedTrigger.dispatchEvent(pointerEvent('pointerleave', { clientX: 0, clientY: 0 }))
+    await flushPromises()
+    document.body.dispatchEvent(pointerEvent('pointermove', { clientX: 9999, clientY: 9999 }))
+    await flushPromises()
+
+    expect(document.body.innerHTML).toContain('tooltip content')
+  })
+
+  it('should anchor the content to the new trigger element', async () => {
+    const probe = wrapper.findComponent(AnchorProbe)
+    expect(probe.vm.anchor).toBe(wrapper.find('button').element)
+
+    wrapper.vm.tag = 'a'
+    await flushPromises()
+
+    expect(probe.vm.anchor).toBe(wrapper.find('a').element)
   })
 })

--- a/packages/core/src/Tooltip/Tooltip.test.ts
+++ b/packages/core/src/Tooltip/Tooltip.test.ts
@@ -2,9 +2,19 @@ import type { VueWrapper } from '@vue/test-utils'
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
+import { defineComponent, ref } from 'vue'
 import Tooltip from './stories/_Tooltip.vue'
+import TooltipContent from './TooltipContent.vue'
+import TooltipPortal from './TooltipPortal.vue'
 import TooltipProvider from './TooltipProvider.vue'
+import TooltipRoot from './TooltipRoot.vue'
+import TooltipTrigger from './TooltipTrigger.vue'
 import { TOOLTIP_OPEN } from './utils'
+
+function pointerEvent(type: string, init: { clientX?: number, clientY?: number }) {
+  const Ctor = typeof PointerEvent !== 'undefined' ? PointerEvent : MouseEvent
+  return new Ctor(type, { bubbles: true, ...init }) as PointerEvent
+}
 
 describe('given default Tooltip', () => {
   let wrapper: VueWrapper<InstanceType<typeof Tooltip>>
@@ -115,5 +125,59 @@ describe('given tooltip within TooltipProvider', () => {
     })
 
     expect(tooltipContentImpl.html()).toContain('data-side="left"')
+  })
+})
+
+describe('given a tooltip trigger whose element is replaced after mount', () => {
+  let wrapper: VueWrapper
+
+  const SwappableTrigger = defineComponent({
+    components: { TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger },
+    setup() {
+      return { tag: ref('button') }
+    },
+    template: `
+      <TooltipProvider>
+        <TooltipRoot>
+          <TooltipTrigger :as="tag">trigger</TooltipTrigger>
+          <TooltipPortal>
+            <TooltipContent>tooltip content</TooltipContent>
+          </TooltipPortal>
+        </TooltipRoot>
+      </TooltipProvider>
+    `,
+  })
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    wrapper = mount(SwappableTrigger, {
+      global: {
+        stubs: {
+          teleport: { template: '<div><slot /></div>' },
+        },
+      },
+      attachTo: document.body,
+    })
+  })
+
+  afterEach(async () => {
+    wrapper.unmount()
+    await flushPromises()
+  })
+
+  it('still closes on pointerleave after the trigger tag changes', async () => {
+    await wrapper.find('button').trigger('focus')
+    expect(document.body.innerHTML).toContain('tooltip content')
+
+    wrapper.vm.tag = 'a'
+    await flushPromises()
+
+    const trigger = wrapper.find('a').element as HTMLElement
+    trigger.dispatchEvent(pointerEvent('pointerleave', { clientX: 0, clientY: 0 }))
+    await flushPromises()
+    document.body.dispatchEvent(pointerEvent('pointermove', { clientX: 9999, clientY: 9999 }))
+    await flushPromises()
+
+    expect(document.body.innerHTML).not.toContain('tooltip content')
   })
 })

--- a/packages/core/src/Tooltip/Tooltip.test.ts
+++ b/packages/core/src/Tooltip/Tooltip.test.ts
@@ -165,12 +165,14 @@ describe('given a tooltip trigger whose element is replaced after mount', () => 
     await flushPromises()
   })
 
-  it('still closes on pointerleave after the trigger tag changes', async () => {
+  it('should still close on pointerleave after the trigger element is replaced', async () => {
     await wrapper.find('button').trigger('focus')
     expect(document.body.innerHTML).toContain('tooltip content')
 
     wrapper.vm.tag = 'a'
     await flushPromises()
+
+    expect(document.body.innerHTML).toContain('tooltip content')
 
     const trigger = wrapper.find('a').element as HTMLElement
     trigger.dispatchEvent(pointerEvent('pointerleave', { clientX: 0, clientY: 0 }))

--- a/packages/core/src/Tooltip/TooltipTrigger.vue
+++ b/packages/core/src/Tooltip/TooltipTrigger.vue
@@ -11,7 +11,7 @@ export interface TooltipTriggerProps extends PopperAnchorProps {}
 
 <script setup lang="ts">
 import type { PopperAnchorProps } from '@/Popper'
-import { computed, onMounted, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { PopperAnchor } from '@/Popper'
 import {
   Primitive,
@@ -46,9 +46,9 @@ const tooltipListeners = computed(() => {
   }
 })
 
-onMounted(() => {
-  rootContext.onTriggerChange(triggerElement.value)
-})
+watch(triggerElement, (el) => {
+  rootContext.onTriggerChange(el)
+}, { immediate: true })
 
 function handlePointerUp() {
   setTimeout(() => {

--- a/packages/core/src/Tooltip/TooltipTrigger.vue
+++ b/packages/core/src/Tooltip/TooltipTrigger.vue
@@ -103,7 +103,7 @@ function handleClick() {
 <template>
   <PopperAnchor
     as-child
-    :reference="reference"
+    :reference="reference ?? triggerElement"
   >
     <Primitive
       :ref="forwardRef"

--- a/packages/core/src/shared/useGraceArea.ts
+++ b/packages/core/src/shared/useGraceArea.ts
@@ -36,15 +36,17 @@ export function useGraceArea(triggerElement: Ref<HTMLElement | undefined>, conta
 
   watchEffect((cleanupFn) => {
     if (triggerElement.value && containerElement.value) {
-      const handleTriggerLeave = (event: PointerEvent) => handleCreateGraceArea(event, containerElement.value)
-      const handleContentLeave = (event: PointerEvent) => handleCreateGraceArea(event, triggerElement.value)
+      const trigger = triggerElement.value
+      const container = containerElement.value
+      const handleTriggerLeave = (event: PointerEvent) => handleCreateGraceArea(event, container)
+      const handleContentLeave = (event: PointerEvent) => handleCreateGraceArea(event, trigger)
 
-      triggerElement.value.addEventListener('pointerleave', handleTriggerLeave)
-      containerElement.value.addEventListener('pointerleave', handleContentLeave)
+      trigger.addEventListener('pointerleave', handleTriggerLeave)
+      container.addEventListener('pointerleave', handleContentLeave)
 
       cleanupFn(() => {
-        triggerElement.value?.removeEventListener('pointerleave', handleTriggerLeave)
-        containerElement.value?.removeEventListener('pointerleave', handleContentLeave)
+        trigger.removeEventListener('pointerleave', handleTriggerLeave)
+        container.removeEventListener('pointerleave', handleContentLeave)
       })
     }
   })
@@ -69,9 +71,10 @@ export function useGraceArea(triggerElement: Ref<HTMLElement | undefined>, conta
           pointerExit.trigger()
         }
       }
-      triggerElement.value?.ownerDocument.addEventListener('pointermove', handleTrackPointerGrace)
+      const ownerDocument = triggerElement.value?.ownerDocument
+      ownerDocument?.addEventListener('pointermove', handleTrackPointerGrace)
 
-      cleanupFn(() => triggerElement.value?.ownerDocument.removeEventListener('pointermove', handleTrackPointerGrace))
+      cleanupFn(() => ownerDocument?.removeEventListener('pointermove', handleTrackPointerGrace))
     }
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

Refs #2920

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`TooltipTrigger` published its DOM node to `TooltipRoot` once, in `onMounted`. When the rendered element changed afterwards (a `button` that becomes an `a` through `:as`), `rootContext.trigger` kept pointing at the removed node. `useGraceArea` binds its `pointerleave` listener to that node, so the listener never fired again, no grace polygon was built, and in hoverable mode the grace area is the only path that closes the tooltip. The tooltip stayed open until the pointer crossed the content or the user clicked away. The positioning anchor went stale the same way, so the content kept measuring against the removed node.

The trigger element is now watched and re-published on every change, and it is passed to `PopperAnchor` as the reference.

An `as-child` trigger whose child component swaps its own root element is not covered. `useForwardExpose` re-reads the element only in its own component's `onUpdated`, and that hook does not run when a descendant re-renders, so `PopperAnchor` and every other consumer of the composable have the same gap. That needs a fix in the shared composable, so I left #2920 open.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tooltip behavior when the trigger element changes type after mounting.
  - Tooltips now correctly re-anchor to the updated trigger and respond to pointer-leave events on the new element.
  - Removed stale event handling from replaced trigger elements.
  - Improved pointer interaction cleanup to ensure listeners remain reliable when tooltip triggers or content elements change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
