### PR TITLE
fix(Menu): 在异步焦点处理中保留事件目标

### DIFF
--- a/packages/core/src/DropdownMenu/DropdownMenuFilter.test.ts
+++ b/packages/core/src/DropdownMenu/DropdownMenuFilter.test.ts
@@ -18,6 +18,10 @@ describe('given DropdownMenu with Filter', () => {
     wrapper = mount(DropdownMenuWithFilter, { attachTo: document.body })
   })
 
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
   it('should render trigger button', () => {
     expect(wrapper.find('button').exists()).toBeTruthy()
   })

--- a/packages/core/src/Menu/Menu.test.ts
+++ b/packages/core/src/Menu/Menu.test.ts
@@ -1,7 +1,7 @@
 import type { VueWrapper } from '@vue/test-utils'
 import { findAllByRole } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { nextTick } from 'vue'
 import Menu from './story/_Menu.vue'
@@ -63,6 +63,7 @@ describe('given a default Menu', () => {
 })
 
 describe('given a Menu with submenu', () => {
+  let wrapper: VueWrapper<InstanceType<typeof MenuWithSubmenu>>
   globalThis.ResizeObserver = class ResizeObserver {
     observe() {}
     unobserve() {}
@@ -70,9 +71,16 @@ describe('given a Menu with submenu', () => {
   }
   beforeEach(() => {
     document.body.innerHTML = ''
-    mount(MenuWithSubmenu, {
+    wrapper = mount(MenuWithSubmenu, {
       attachTo: document.body,
     })
+  })
+
+  afterEach(async () => {
+    wrapper.unmount()
+    if (vi.isFakeTimers())
+      await vi.runOnlyPendingTimersAsync()
+    vi.useRealTimers()
   })
 
   it('should highlight sub trigger on pointermove', async () => {
@@ -90,5 +98,28 @@ describe('given a Menu with submenu', () => {
     await nextTick()
 
     expect(subTrigger.hasAttribute('data-highlighted')).toBe(true)
+  })
+
+  it('should keep the submenu open when the pointer moves within its focused trigger', async () => {
+    vi.useFakeTimers()
+    const subTrigger = wrapper.get<HTMLElement>('[aria-haspopup="menu"]').element
+
+    async function movePointer() {
+      // jsdom does not support PointerEvent.
+      const event = new MouseEvent('pointermove', { bubbles: true })
+      Object.defineProperty(event, 'pointerType', { value: 'mouse' })
+      subTrigger.dispatchEvent(event)
+      await nextTick()
+    }
+
+    await movePointer()
+    expect(subTrigger).toHaveFocus()
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(subTrigger).toHaveAttribute('aria-expanded', 'true')
+
+    await movePointer()
+    expect(subTrigger).toHaveAttribute('aria-expanded', 'true')
+    expect(wrapper.find('[role="menu"][aria-labelledby]').exists()).toBe(true)
   })
 })

--- a/packages/core/src/Menu/MenuItemImpl.vue
+++ b/packages/core/src/Menu/MenuItemImpl.vue
@@ -88,10 +88,11 @@ async function handlePointerLeave(event: PointerEvent) {
       @pointerleave="handlePointerLeave"
       @focus="
         async (event: FocusEvent) => {
+          const item = event.currentTarget as HTMLElement;
           await nextTick();
           if (event.defaultPrevented || disabled) return;
           isFocused = true;
-          contentContext.highlightedElement.value = event.currentTarget as HTMLElement
+          contentContext.highlightedElement.value = item
         }
       "
       @blur="


### PR DESCRIPTION
### 🔗 关联 issue

Closes #2929

### ❓ 变更类型

- [x] 🐞 Bug 修复

### 📚 说明

子菜单通过悬停打开后，继续在同一个触发项内移动鼠标，可以使它意外关闭。`MenuItemImpl` 在 pointermove 内调用 `.focus()`；异步 focus 处理器恢复时再读取 `event.currentTarget`，在此路径中会得到 null，并覆盖当前高亮项。

本次在 `await nextTick()` 前保存该元素，随后使用保存的目标更新高亮。保留原有的异步处理、`defaultPrevented` 和 `disabled` 判断；生产代码仅修改这一处处理器。

新增回归测试复用现有 MenuWithSubmenu fixture，覆盖「悬停打开 → 再次在同一触发项内 pointermove → 子菜单保持打开」。该断言在未修复的上游代码上失败，修复后通过。

同时为 Menu 子菜单测试和 DropdownMenuFilter 测试补齐组件卸载。Filter 测试原先仅清空 body，没有卸载组件，导致共享的键盘输入状态跨测试残留：受影响用例单独运行通过，连续运行失败。补齐卸载后，原有断言均通过，没有修改 Filter 的生产逻辑或测试预期。

### 验证

- `pnpm --filter reka-ui exec vitest run --coverage --maxWorkers=4`：97 个测试文件、2042 项测试通过。
- `pnpm --filter reka-ui build`：类型检查和构建通过。
- `pnpm --filter reka-ui size`：包体积检查通过。
- 对三个修改文件执行 ESLint，以及 `git diff --check`：通过。
- Chromium 152：触发项内移动、移向子菜单两条路径，各重复 5 次。上游原版各关闭 5/5 次，修复版各关闭 0/5 次；比较的构建产物仅 MenuItemImpl 的 ESM/CJS 文件不同。
- 浏览器自检覆盖鼠标进入子项并返回、移离子菜单方向后切换父菜单项、ArrowRight / ArrowLeft、Escape 恢复焦点、选择子项和点击外部关闭。

独立复现和环境详情见关联 issue。本次未验证其他浏览器。

### 📝 Checklist

- [x] 已关联包含最小复现的 issue。
- [x] 已检查文档影响：无公开 API 变更，无需更新 API 文档。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved submenu behavior so it remains open when the pointer moves within its focused trigger.
  - Improved focus handling when navigating menu items, ensuring the correct item remains highlighted.

- **Tests**
  - Added coverage for submenu focus and open-state behavior.
  - Improved test cleanup between cases for menus and filtered dropdown menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->