### PR TITLE
feat(v3): add Colors headless composables

### DIFF
--- a/docs/content/docs/components/color-area.md
+++ b/docs/content/docs/components/color-area.md
@@ -62,6 +62,43 @@ import {
 </template>
 ```
 
+## Headless composable
+
+These composables are experimental. Reactive options accept refs or getters. Pass a writable `modelValue` ref for ref-owned state, or use `onUpdate` to handle controlled updates. `onBeforeUpdate(value, details)` can synchronously call `details.cancel()` to prevent a change. Component users can use `@before-update:model-value` for the same behavior.
+
+`useColorArea()` exposes the model, exact channel values, background styles, and shared root and thumb surfaces. Call it in component setup (or an effect scope) so its synchronization watchers are disposed. Create one area surface per element and assign `thumbRef` to the thumb so pointer interaction can focus it.
+
+```vue
+<script setup>
+import { useColorArea } from 'reka-ui'
+import { ref } from 'vue'
+
+const areaElement = ref()
+const { root, thumb, thumbRef, areaStyles, createAreaSurface, updateValues } = useColorArea({
+  defaultValue: '#ff0000',
+  xChannel: 'saturation',
+  yChannel: 'lightness',
+})
+const area = createAreaSurface(areaElement)
+// Programmatic changes use the same cancellable update path.
+updateValues(75, 50)
+</script>
+
+<template>
+  <div v-bind="root.attrs.value">
+    <div
+      ref="areaElement"
+      v-bind="area.attrs.value"
+      :style="[areaStyles, { position: 'relative', width: '200px', height: '200px' }]"
+    >
+      <span ref="thumbRef" v-bind="thumb.attrs.value" />
+    </div>
+  </div>
+</template>
+```
+
+Hidden form inputs remain part of `ColorAreaRoot`; add them yourself when rendering the composable directly.
+
 ## API Reference
 
 ### ColorAreaRoot

--- a/docs/content/docs/components/color-field.md
+++ b/docs/content/docs/components/color-field.md
@@ -61,6 +61,31 @@ import {
 </template>
 ```
 
+## Headless composable
+
+These composables are experimental. Reactive options accept refs or getters. Pass a writable `modelValue` ref for ref-owned state, or use `onUpdate` to handle controlled updates. `onBeforeUpdate(value, details)` can synchronously call `details.cancel()` to prevent a change. Component users can use `@before-update:model-value` for the same behavior.
+
+`useColorField()` exposes parsing, channel stepping, the editable input value, and a root surface. Call it in setup (or an effect scope). Call `createInputSurface()` once per input to keep focus and IME composition state independent.
+
+```vue
+<script setup>
+import { useColorField } from 'reka-ui'
+import { ref } from 'vue'
+
+const modelValue = ref('#ff0000')
+const { root, createInputSurface } = useColorField({ modelValue })
+const input = createInputSurface()
+</script>
+
+<template>
+  <div v-bind="root.attrs.value">
+    <input aria-label="Color" v-bind="input.attrs.value">
+  </div>
+</template>
+```
+
+The return also exposes `updateValue`, `commit`, `increment`, `decrement`, page stepping, and min/max actions. Hidden form input rendering remains in `ColorFieldRoot`.
+
 ## API Reference
 
 ### ColorFieldRoot

--- a/docs/content/docs/components/color-slider.md
+++ b/docs/content/docs/components/color-slider.md
@@ -63,6 +63,33 @@ import {
 </template>
 ```
 
+## Headless composable
+
+These composables are experimental. Reactive options accept refs or getters. Pass a writable `modelValue` ref for ref-owned state, or use `onUpdate` to handle controlled updates. `onBeforeUpdate(value, details)` can synchronously call `details.cancel()` to prevent a change. Component users can use `@before-update:model-value` for the same behavior.
+
+`useColorSlider()` exposes precise channel state and root, track, and thumb surfaces. Call it in setup (or an effect scope). The surfaces compose with `SliderRoot`, `SliderTrack`, and `SliderThumb`, which supply pointer interaction, keyboard navigation, and positioning.
+
+```vue
+<script setup>
+import { SliderRoot, SliderThumb, SliderTrack, useColorSlider } from 'reka-ui'
+
+const { root, track, thumb, setValue } = useColorSlider({
+  channel: 'hue',
+  defaultValue: '#ff0000',
+})
+setValue([120])
+</script>
+
+<template>
+  <SliderRoot v-bind="root.attrs.value">
+    <SliderTrack v-bind="track.attrs.value" />
+    <SliderThumb v-bind="thumb.attrs.value" />
+  </SliderRoot>
+</template>
+```
+
+Binding these surfaces to plain elements does not supply Slider interactions. Delegated updates have the `slider` reason; Slider's model event does not supply a native event. Hidden color form inputs remain in `ColorSliderRoot`.
+
 ## API Reference
 
 ### ColorSliderRoot

--- a/docs/content/docs/components/color-swatch-picker.md
+++ b/docs/content/docs/components/color-swatch-picker.md
@@ -71,6 +71,38 @@ import {
 </template>
 ```
 
+## Headless composable
+
+These composables are experimental. Reactive options accept refs or getters. Pass a writable `modelValue` ref for ref-owned state, or use `onUpdate` to handle controlled updates. `onBeforeUpdate(value, details)` can synchronously call `details.cancel()` to prevent a change. Component users can use `@before-update:model-value` for the same behavior.
+
+`useColorSwatchPicker()` is pure and exposes the model, `setValue`, programmatic `select`, and color-specific part surfaces. Compose them with the Listbox components for collection registration, selection interactions, keyboard navigation, focus, and indicator presence.
+
+```vue
+<script setup>
+import { ListboxContent, ListboxItem, ListboxRoot, useColorSwatchPicker } from 'reka-ui'
+
+const colors = ['#ff0000', '#00ff00', '#0000ff']
+const { root, getItemSurface } = useColorSwatchPicker({ defaultValue: '#ff0000' })
+</script>
+
+<template>
+  <ListboxRoot v-bind="root.attrs.value">
+    <ListboxContent aria-label="Color">
+      <ListboxItem
+        v-for="color in colors"
+        :key="color"
+        :value="color"
+        v-bind="getItemSurface(color).attrs.value"
+      >
+        {{ color }}
+      </ListboxItem>
+    </ListboxContent>
+  </ListboxRoot>
+</template>
+```
+
+`getItemSwatchSurface(color)` supplies props for `ColorSwatch`; `itemIndicator` composes with `ListboxItemIndicator`. These surfaces do not implement Listbox behavior on plain elements. Delegated model updates have the `selection` reason; Listbox's model event does not supply a native event.
+
 ## API Reference
 
 ### ColorSwatchPickerRoot

--- a/docs/content/docs/components/color-swatch.md
+++ b/docs/content/docs/components/color-swatch.md
@@ -53,6 +53,24 @@ import {
 </template>
 ```
 
+## Headless composable
+
+`useColorSwatch()` is a pure composable exposing the color string, alpha, accessible label, contrast, and a root surface. It accepts refs or getters and can be called outside component setup.
+
+```vue
+<script setup>
+import { useColorSwatch } from 'reka-ui'
+
+const { root } = useColorSwatch({ color: '#16a372', label: 'Brand green' })
+</script>
+
+<template>
+  <div v-bind="root.attrs.value" />
+</template>
+```
+
+Use the `--reka-color-swatch-color` and `--reka-color-swatch-alpha` CSS variables to style the swatch, as with the component.
+
 ## API Reference
 
 ### ColorSwatch

--- a/docs/content/meta/ColorAreaRoot.md
+++ b/docs/content/meta/ColorAreaRoot.md
@@ -85,7 +85,7 @@
 <EmitsTable :data="[
   {
     'name': 'beforeUpdate:modelValue',
-    'description': '',
+    'description': '<p>Event handler called before the color value changes; <code>details.cancel()</code> vetoes the change.</p>\n',
     'type': '[value: string, details: ChangeEventDetails&lt;ColorAreaChangeReason, Event&gt;]'
   },
   {
@@ -105,7 +105,7 @@
   },
   {
     'name': 'update:modelValue',
-    'description': '',
+    'description': '<p>Event handler called when the color value changes.</p>\n',
     'type': '[value: string, details: ChangeEventDetails&lt;ColorAreaChangeReason, Event&gt;]'
   }
 ]" />
@@ -142,11 +142,11 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `beforeUpdate:modelValue` |  | `[value: string, details: ChangeEventDetails<ColorAreaChangeReason, Event>]` |
+| `beforeUpdate:modelValue` | Event handler called before the color value changes; details.cancel() vetoes the change. | `[value: string, details: ChangeEventDetails<ColorAreaChangeReason, Event>]` |
 | `change` |  | `[value: string]` |
 | `changeEnd` |  | `[value: string]` |
 | `update:color` |  | `[value: Color]` |
-| `update:modelValue` |  | `[value: string, details: ChangeEventDetails<ColorAreaChangeReason, Event>]` |
+| `update:modelValue` | Event handler called when the color value changes. | `[value: string, details: ChangeEventDetails<ColorAreaChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/ColorAreaRoot.md
+++ b/docs/content/meta/ColorAreaRoot.md
@@ -84,6 +84,11 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:modelValue',
+    'description': '',
+    'type': '[value: string, details: ChangeEventDetails&lt;ColorAreaChangeReason, Event&gt;]'
+  },
+  {
     'name': 'change',
     'description': '',
     'type': '[value: string]'
@@ -100,8 +105,8 @@
   },
   {
     'name': 'update:modelValue',
-    'description': '<p>Event handler called when the value of the checkbox changes.</p>\n',
-    'type': '[value: string]'
+    'description': '',
+    'type': '[value: string, details: ChangeEventDetails&lt;ColorAreaChangeReason, Event&gt;]'
   }
 ]" />
 
@@ -137,10 +142,11 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
+| `beforeUpdate:modelValue` |  | `[value: string, details: ChangeEventDetails<ColorAreaChangeReason, Event>]` |
 | `change` |  | `[value: string]` |
 | `changeEnd` |  | `[value: string]` |
 | `update:color` |  | `[value: Color]` |
-| `update:modelValue` | Event handler called when the value of the checkbox changes. | `[value: string]` |
+| `update:modelValue` |  | `[value: string, details: ChangeEventDetails<ColorAreaChangeReason, Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/ColorFieldRoot.md
+++ b/docs/content/meta/ColorFieldRoot.md
@@ -96,14 +96,19 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:modelValue',
+    'description': '',
+    'type': '[value: string, details: ChangeEventDetails&lt;ColorFieldChangeReason, Event&gt;]'
+  },
+  {
     'name': 'update:color',
     'description': '',
     'type': '[value: Color]'
   },
   {
     'name': 'update:modelValue',
-    'description': '<p>Event handler called when the value of the checkbox changes.</p>\n',
-    'type': '[value: string]'
+    'description': '',
+    'type': '[value: string, details: ChangeEventDetails&lt;ColorFieldChangeReason, Event&gt;]'
   }
 ]" />
 </llm-exclude>
@@ -133,7 +138,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
+| `beforeUpdate:modelValue` |  | `[value: string, details: ChangeEventDetails<ColorFieldChangeReason, Event>]` |
 | `update:color` |  | `[value: Color]` |
-| `update:modelValue` | Event handler called when the value of the checkbox changes. | `[value: string]` |
+| `update:modelValue` |  | `[value: string, details: ChangeEventDetails<ColorFieldChangeReason, Event>]` |
 
 </llm-only>

--- a/docs/content/meta/ColorFieldRoot.md
+++ b/docs/content/meta/ColorFieldRoot.md
@@ -97,7 +97,7 @@
 <EmitsTable :data="[
   {
     'name': 'beforeUpdate:modelValue',
-    'description': '',
+    'description': '<p>Event handler called before the color value changes; <code>details.cancel()</code> vetoes the change.</p>\n',
     'type': '[value: string, details: ChangeEventDetails&lt;ColorFieldChangeReason, Event&gt;]'
   },
   {
@@ -107,7 +107,7 @@
   },
   {
     'name': 'update:modelValue',
-    'description': '',
+    'description': '<p>Event handler called when the color value changes.</p>\n',
     'type': '[value: string, details: ChangeEventDetails&lt;ColorFieldChangeReason, Event&gt;]'
   }
 ]" />
@@ -138,8 +138,8 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `beforeUpdate:modelValue` |  | `[value: string, details: ChangeEventDetails<ColorFieldChangeReason, Event>]` |
+| `beforeUpdate:modelValue` | Event handler called before the color value changes; details.cancel() vetoes the change. | `[value: string, details: ChangeEventDetails<ColorFieldChangeReason, Event>]` |
 | `update:color` |  | `[value: Color]` |
-| `update:modelValue` |  | `[value: string, details: ChangeEventDetails<ColorFieldChangeReason, Event>]` |
+| `update:modelValue` | Event handler called when the color value changes. | `[value: string, details: ChangeEventDetails<ColorFieldChangeReason, Event>]` |
 
 </llm-only>

--- a/docs/content/meta/ColorSliderRoot.md
+++ b/docs/content/meta/ColorSliderRoot.md
@@ -70,7 +70,7 @@
   {
     'name': 'orientation',
     'description': '<p>The orientation of the slider.</p>\n',
-    'type': '\'vertical\' | \'horizontal\'',
+    'type': '\'horizontal\' | \'vertical\'',
     'required': false,
     'default': '\'horizontal\''
   },
@@ -90,6 +90,11 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:modelValue',
+    'description': '',
+    'type': '[value: string | Color, details: ChangeEventDetails&lt;\'slider\', Event&gt;]'
+  },
+  {
     'name': 'change',
     'description': '',
     'type': '[value: string]'
@@ -106,8 +111,8 @@
   },
   {
     'name': 'update:modelValue',
-    'description': '<p>Event handler called when the value of the checkbox changes.</p>\n',
-    'type': '[value: string | Color]'
+    'description': '',
+    'type': '[value: string | Color, details: ChangeEventDetails&lt;\'slider\', Event&gt;]'
   }
 ]" />
 </llm-exclude>
@@ -128,7 +133,7 @@
 | `inverted` | Whether the slider is visually inverted. | `boolean` | No | `false` |
 | `modelValue` | The color value (controlled). Can be a hex string or Color object. | `string \| Color` | No | - |
 | `name` | The name of the field. Submitted with its owning form as part of a name/value pair. | `string` | No | - |
-| `orientation` | The orientation of the slider. | `"vertical" \| "horizontal"` | No | `"horizontal"` |
+| `orientation` | The orientation of the slider. | `"horizontal" \| "vertical"` | No | `"horizontal"` |
 | `required` | When true, indicates that the user must set the value before the owning form can be submitted. | `boolean` | No | - |
 | `step` | Custom step value for increment/decrement. Defaults to the channel's natural step. | `number` | No | - |
 
@@ -136,9 +141,10 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
+| `beforeUpdate:modelValue` |  | `[value: string \| Color, details: ChangeEventDetails<"slider", Event>]` |
 | `change` |  | `[value: string]` |
 | `changeEnd` |  | `[value: string]` |
 | `update:color` |  | `[value: Color]` |
-| `update:modelValue` | Event handler called when the value of the checkbox changes. | `[value: string \| Color]` |
+| `update:modelValue` |  | `[value: string \| Color, details: ChangeEventDetails<"slider", Event>]` |
 
 </llm-only>

--- a/docs/content/meta/ColorSliderRoot.md
+++ b/docs/content/meta/ColorSliderRoot.md
@@ -70,7 +70,7 @@
   {
     'name': 'orientation',
     'description': '<p>The orientation of the slider.</p>\n',
-    'type': '\'horizontal\' | \'vertical\'',
+    'type': '\'vertical\' | \'horizontal\'',
     'required': false,
     'default': '\'horizontal\''
   },
@@ -91,7 +91,7 @@
 <EmitsTable :data="[
   {
     'name': 'beforeUpdate:modelValue',
-    'description': '',
+    'description': '<p>Event handler called before the color value changes; <code>details.cancel()</code> vetoes the change.</p>\n',
     'type': '[value: string | Color, details: ChangeEventDetails&lt;\'slider\', Event&gt;]'
   },
   {
@@ -111,7 +111,7 @@
   },
   {
     'name': 'update:modelValue',
-    'description': '',
+    'description': '<p>Event handler called when the color value changes.</p>\n',
     'type': '[value: string | Color, details: ChangeEventDetails&lt;\'slider\', Event&gt;]'
   }
 ]" />
@@ -133,7 +133,7 @@
 | `inverted` | Whether the slider is visually inverted. | `boolean` | No | `false` |
 | `modelValue` | The color value (controlled). Can be a hex string or Color object. | `string \| Color` | No | - |
 | `name` | The name of the field. Submitted with its owning form as part of a name/value pair. | `string` | No | - |
-| `orientation` | The orientation of the slider. | `"horizontal" \| "vertical"` | No | `"horizontal"` |
+| `orientation` | The orientation of the slider. | `"vertical" \| "horizontal"` | No | `"horizontal"` |
 | `required` | When true, indicates that the user must set the value before the owning form can be submitted. | `boolean` | No | - |
 | `step` | Custom step value for increment/decrement. Defaults to the channel's natural step. | `number` | No | - |
 
@@ -141,10 +141,10 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `beforeUpdate:modelValue` |  | `[value: string \| Color, details: ChangeEventDetails<"slider", Event>]` |
+| `beforeUpdate:modelValue` | Event handler called before the color value changes; details.cancel() vetoes the change. | `[value: string \| Color, details: ChangeEventDetails<"slider", Event>]` |
 | `change` |  | `[value: string]` |
 | `changeEnd` |  | `[value: string]` |
 | `update:color` |  | `[value: Color]` |
-| `update:modelValue` |  | `[value: string \| Color, details: ChangeEventDetails<"slider", Event>]` |
+| `update:modelValue` | Event handler called when the color value changes. | `[value: string \| Color, details: ChangeEventDetails<"slider", Event>]` |
 
 </llm-only>

--- a/docs/content/meta/ColorSwatchPickerRoot.md
+++ b/docs/content/meta/ColorSwatchPickerRoot.md
@@ -62,7 +62,7 @@
   {
     'name': 'orientation',
     'description': '<p>The orientation of the listbox. &lt;br&gt;Mainly so arrow navigation is done accordingly (left &amp; right vs. up &amp; down)</p>\n',
-    'type': '\'vertical\' | \'horizontal\'',
+    'type': '\'horizontal\' | \'vertical\'',
     'required': false,
     'default': '\'horizontal\''
   },
@@ -82,6 +82,11 @@
 
 <EmitsTable :data="[
   {
+    'name': 'beforeUpdate:modelValue',
+    'description': '',
+    'type': '[value: string | string[], details: ChangeEventDetails&lt;\'selection\', Event&gt;]'
+  },
+  {
     'name': 'entryFocus',
     'description': '<p>Event handler called when container is being focused. Can be prevented.</p>\n',
     'type': '[event: CustomEvent&lt;any&gt;]'
@@ -99,7 +104,7 @@
   {
     'name': 'update:modelValue',
     'description': '<p>Event handler called when the value changes.</p>\n',
-    'type': '[value: AcceptableValue]'
+    'type': '[value: AcceptableValue, details: ChangeEventDetails&lt;\'selection\', Event&gt;]'
   }
 ]" />
 
@@ -127,7 +132,7 @@
 | `modelValue` | The controlled value of the listbox. Can be binded with v-model. | `string \| string[]` | No | - |
 | `multiple` | Whether multiple options can be selected or not. | `boolean` | No | - |
 | `name` | The name of the field. Submitted with its owning form as part of a name/value pair. | `string` | No | - |
-| `orientation` | The orientation of the listbox. <br>Mainly so arrow navigation is done accordingly (left & right vs. up & down) | `"vertical" \| "horizontal"` | No | `"horizontal"` |
+| `orientation` | The orientation of the listbox. <br>Mainly so arrow navigation is done accordingly (left & right vs. up & down) | `"horizontal" \| "vertical"` | No | `"horizontal"` |
 | `required` | When true, indicates that the user must set the value before the owning form can be submitted. | `boolean` | No | - |
 | `selectionBehavior` | How multiple selection should behave in the collection. | `"replace" \| "toggle"` | No | - |
 
@@ -135,10 +140,11 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
+| `beforeUpdate:modelValue` |  | `[value: string \| string[], details: ChangeEventDetails<"selection", Event>]` |
 | `entryFocus` | Event handler called when container is being focused. Can be prevented. | `[event: CustomEvent<any>]` |
 | `highlight` | Event handler when highlighted element changes. | `[payload: { ref: HTMLElement; value: AcceptableValue; }]` |
 | `leave` | Event handler called when the mouse leave the container | `[event: Event]` |
-| `update:modelValue` | Event handler called when the value changes. | `[value: AcceptableValue]` |
+| `update:modelValue` | Event handler called when the value changes. | `[value: AcceptableValue, details: ChangeEventDetails<"selection", Event>]` |
 
 **Slots**
 

--- a/docs/content/meta/ColorSwatchPickerRoot.md
+++ b/docs/content/meta/ColorSwatchPickerRoot.md
@@ -62,7 +62,7 @@
   {
     'name': 'orientation',
     'description': '<p>The orientation of the listbox. &lt;br&gt;Mainly so arrow navigation is done accordingly (left &amp; right vs. up &amp; down)</p>\n',
-    'type': '\'horizontal\' | \'vertical\'',
+    'type': '\'vertical\' | \'horizontal\'',
     'required': false,
     'default': '\'horizontal\''
   },
@@ -83,7 +83,7 @@
 <EmitsTable :data="[
   {
     'name': 'beforeUpdate:modelValue',
-    'description': '',
+    'description': '<p>Event handler called before the color value changes; <code>details.cancel()</code> vetoes the change.</p>\n',
     'type': '[value: string | string[], details: ChangeEventDetails&lt;\'selection\', Event&gt;]'
   },
   {
@@ -132,7 +132,7 @@
 | `modelValue` | The controlled value of the listbox. Can be binded with v-model. | `string \| string[]` | No | - |
 | `multiple` | Whether multiple options can be selected or not. | `boolean` | No | - |
 | `name` | The name of the field. Submitted with its owning form as part of a name/value pair. | `string` | No | - |
-| `orientation` | The orientation of the listbox. <br>Mainly so arrow navigation is done accordingly (left & right vs. up & down) | `"horizontal" \| "vertical"` | No | `"horizontal"` |
+| `orientation` | The orientation of the listbox. <br>Mainly so arrow navigation is done accordingly (left & right vs. up & down) | `"vertical" \| "horizontal"` | No | `"horizontal"` |
 | `required` | When true, indicates that the user must set the value before the owning form can be submitted. | `boolean` | No | - |
 | `selectionBehavior` | How multiple selection should behave in the collection. | `"replace" \| "toggle"` | No | - |
 
@@ -140,7 +140,7 @@
 
 | Name | Description | Type |
 | --- | --- | --- |
-| `beforeUpdate:modelValue` |  | `[value: string \| string[], details: ChangeEventDetails<"selection", Event>]` |
+| `beforeUpdate:modelValue` | Event handler called before the color value changes; details.cancel() vetoes the change. | `[value: string \| string[], details: ChangeEventDetails<"selection", Event>]` |
 | `entryFocus` | Event handler called when container is being focused. Can be prevented. | `[event: CustomEvent<any>]` |
 | `highlight` | Event handler when highlighted element changes. | `[payload: { ref: HTMLElement; value: AcceptableValue; }]` |
 | `leave` | Event handler called when the mouse leave the container | `[event: Event]` |

--- a/packages/core/src/ColorArea/ColorAreaArea.vue
+++ b/packages/core/src/ColorArea/ColorAreaArea.vue
@@ -5,10 +5,9 @@ export interface ColorAreaAreaProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { ref } from 'vue'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
 import { injectColorAreaRootContext } from './ColorAreaRoot.vue'
-import { linearScale } from './utils'
+import { createColorAreaAreaSurface } from './useColorArea'
 
 const props = withDefaults(defineProps<ColorAreaAreaProps>(), {
   as: 'div',
@@ -16,111 +15,7 @@ const props = withDefaults(defineProps<ColorAreaAreaProps>(), {
 
 const rootContext = injectColorAreaRootContext()
 const { primitiveElement, currentElement: areaElement } = usePrimitiveElement()
-
-const isDragging = ref(false)
-
-// Convert pointer position to channel values
-function getValuesFromPointer(event: PointerEvent) {
-  const rect = areaElement.value!.getBoundingClientRect()
-
-  const xInput: [number, number] = [0, rect.width]
-  const xOutput: [number, number] = [rootContext.xRange.value.min, rootContext.xRange.value.max]
-  const xScale = linearScale(xInput, xOutput)
-  const xValue = xScale(event.clientX - rect.left)
-
-  // Y is inverted (top is max, bottom is min for most channels)
-  const yInput: [number, number] = [0, rect.height]
-  const yOutput: [number, number] = [rootContext.yRange.value.max, rootContext.yRange.value.min]
-  const yScale = linearScale(yInput, yOutput)
-  const yValue = yScale(event.clientY - rect.top)
-
-  return { x: xValue, y: yValue }
-}
-
-function handlePointerDown(event: PointerEvent) {
-  if (rootContext.disabled.value)
-    return
-
-  const target = event.target as HTMLElement
-  target.setPointerCapture(event.pointerId)
-  event.preventDefault()
-
-  isDragging.value = true
-  const { x, y } = getValuesFromPointer(event)
-  rootContext.updateValues(x, y)
-
-  // Focus the thumb when dragging starts
-  rootContext.thumbRef.value?.focus()
-}
-
-function handlePointerMove(event: PointerEvent) {
-  if (!isDragging.value || rootContext.disabled.value)
-    return
-
-  const target = event.target as HTMLElement
-  if (target.hasPointerCapture(event.pointerId)) {
-    const { x, y } = getValuesFromPointer(event)
-    rootContext.updateValues(x, y)
-  }
-}
-
-function handlePointerUp(event: PointerEvent) {
-  if (!isDragging.value)
-    return
-
-  const target = event.target as HTMLElement
-  target.releasePointerCapture(event.pointerId)
-  isDragging.value = false
-  rootContext.commitValues()
-}
-
-// Keyboard navigation
-function handleKeyDown(event: KeyboardEvent) {
-  if (rootContext.disabled.value)
-    return
-
-  const stepMultiplier = event.shiftKey ? 10 : 1
-  const xStepSize = rootContext.xRange.value.step * stepMultiplier
-  const yStepSize = rootContext.yRange.value.step * stepMultiplier
-
-  let xDelta = 0
-  let yDelta = 0
-
-  switch (event.key) {
-    case 'ArrowLeft':
-      xDelta = -xStepSize
-      break
-    case 'ArrowRight':
-      xDelta = xStepSize
-      break
-    case 'ArrowUp':
-      yDelta = yStepSize
-      break
-    case 'ArrowDown':
-      yDelta = -yStepSize
-      break
-    case 'PageUp':
-      yDelta = yStepSize * 10
-      break
-    case 'PageDown':
-      yDelta = -yStepSize * 10
-      break
-    case 'Home':
-      xDelta = -xStepSize * 10
-      break
-    case 'End':
-      xDelta = xStepSize * 10
-      break
-    default:
-      return
-  }
-
-  event.preventDefault()
-  rootContext.updateValues(
-    rootContext.xValue.value + xDelta,
-    rootContext.yValue.value + yDelta,
-  )
-}
+const area = createColorAreaAreaSurface(rootContext, areaElement)
 </script>
 
 <template>
@@ -128,17 +23,7 @@ function handleKeyDown(event: KeyboardEvent) {
     ref="primitiveElement"
     :as-child="asChild"
     :as="as"
-    role="application"
-    aria-roledescription="Color picker"
-    :aria-disabled="rootContext.disabled.value ? 'true' : undefined"
-    :data-disabled="rootContext.disabled.value ? '' : undefined"
-    :style="{
-      touchAction: 'none',
-    }"
-    @keydown="handleKeyDown"
-    @pointerdown="handlePointerDown"
-    @pointermove="handlePointerMove"
-    @pointerup="handlePointerUp"
+    v-bind="area.attrs.value"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/ColorArea/ColorAreaRoot.vue
+++ b/packages/core/src/ColorArea/ColorAreaRoot.vue
@@ -27,7 +27,9 @@ export interface ColorAreaRootProps extends PrimitiveProps, FormFieldProps {
 }
 
 export type ColorAreaRootEmits = {
+  /** Event handler called before the color value changes; `details.cancel()` vetoes the change. */
   'beforeUpdate:modelValue': [value: string, details: ChangeEventDetails<ColorAreaChangeReason>]
+  /** Event handler called when the color value changes. */
   'update:modelValue': [value: string, details: ChangeEventDetails<ColorAreaChangeReason>]
   'update:color': [value: Color]
   'change': [value: string]

--- a/packages/core/src/ColorArea/ColorAreaRoot.vue
+++ b/packages/core/src/ColorArea/ColorAreaRoot.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
 import type { ComputedRef, CSSProperties, Ref } from 'vue'
+import type { ColorAreaChangeReason } from './useColorArea'
 import type { PrimitiveProps } from '@/Primitive'
+import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
 import type { Color, ColorChannel, ColorSpace } from '@/shared/color'
 import type { FormFieldProps } from '@/shared/types'
 import { createContext, useFormControl, useForwardExpose } from '@/shared'
@@ -25,7 +27,8 @@ export interface ColorAreaRootProps extends PrimitiveProps, FormFieldProps {
 }
 
 export type ColorAreaRootEmits = {
-  'update:modelValue': [value: string]
+  'beforeUpdate:modelValue': [value: string, details: ChangeEventDetails<ColorAreaChangeReason>]
+  'update:modelValue': [value: string, details: ChangeEventDetails<ColorAreaChangeReason>]
   'update:color': [value: Color]
   'change': [value: string]
   'changeEnd': [value: string]
@@ -42,7 +45,7 @@ export interface ColorAreaRootContext {
   xRange: ComputedRef<{ min: number, max: number, step: number }>
   yRange: ComputedRef<{ min: number, max: number, step: number }>
   thumbRef: Ref<HTMLElement | undefined>
-  updateValues: (x: number, y: number) => void
+  updateValues: (x: number, y: number, reason?: ColorAreaChangeReason | BaseChangeReason, event?: Event) => void
   commitValues: () => void
 }
 
@@ -51,20 +54,9 @@ export const [injectColorAreaRootContext, provideColorAreaRootContext]
 </script>
 
 <script setup lang="ts">
-import { useVModel } from '@vueuse/core'
-import { computed, nextTick, ref, toRefs, watch } from 'vue'
 import { Primitive } from '@/Primitive'
-import {
-  colorToString,
-  convertToHsb,
-  convertToHsl,
-  getAreaBackgroundStyle,
-  getChannelRange,
-  getChannelValue,
-  normalizeColor,
-  setChannelValues,
-} from '@/shared/color'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
+import { useColorArea } from './useColorArea'
 
 const props = withDefaults(defineProps<ColorAreaRootProps>(), {
   colorSpace: 'hsl',
@@ -84,142 +76,20 @@ defineSlots<{
   }) => any
 }>()
 
-const { colorSpace, xChannel, yChannel, disabled } = toRefs(props)
 const { forwardRef, currentElement } = useForwardExpose()
 const isFormControl = useFormControl(currentElement)
 
-// Normalize the model value to a Color object
-const modelValue = useVModel(props, 'modelValue', emits, {
-  defaultValue: props.defaultValue,
-  passive: (props.modelValue === undefined) as false,
+const { root, context, areaStyles, xValue, yValue } = useColorArea({
+  colorSpace: () => props.colorSpace,
+  xChannel: () => props.xChannel,
+  yChannel: () => props.yChannel,
+  disabled: () => props.disabled,
+  modelValue: () => props.modelValue,
+  defaultValue: () => props.defaultValue,
+  emit: emits,
 })
 
-// The actual color object for rendering
-const color = computed({
-  get: () => normalizeColor(modelValue.value ?? '#000000'),
-  set: (newColor: Color) => {
-    const hexString = colorToString(newColor, 'hex')
-    modelValue.value = hexString
-    emits('update:color', newColor)
-  },
-})
-
-// Get channel ranges
-const xRange = computed(() => getChannelRange(xChannel.value))
-const yRange = computed(() => getChannelRange(yChannel.value))
-
-// Store exact channel values as refs to avoid floating-point drift
-// Initialize from the color value (rounded to nearest integer)
-const xValue = ref(Math.round(getChannelValue(color.value, xChannel.value)))
-const yValue = ref(Math.round(getChannelValue(color.value, yChannel.value)))
-
-// Store the hue separately to preserve it when saturation is 0 (grayscale)
-const hueValue = ref(colorSpace.value === 'hsl'
-  ? convertToHsl(color.value).h
-  : colorSpace.value === 'hsb'
-    ? convertToHsb(color.value).h
-    : 0)
-
-// Track when we're in the middle of an update to prevent circular sync
-let isUpdating = false
-
-// Sync channel values when color changes externally
-watch(() => color.value, (newColor) => {
-  // Skip if we just triggered this update ourselves
-  if (isUpdating)
-    return
-
-  const newX = Math.round(getChannelValue(newColor, xChannel.value))
-  const newY = Math.round(getChannelValue(newColor, yChannel.value))
-
-  // Only update if the rounded value meaningfully changed.
-  // During drag, xValue/yValue store exact floats (e.g. 80.45).
-  // External updates (e.g. hue slider) should not snap these to integers.
-  if (Math.round(xValue.value) !== newX)
-    xValue.value = newX
-  if (Math.round(yValue.value) !== newY)
-    yValue.value = newY
-
-  // Update hue if saturation is not 0 (to preserve hue for grayscale colors)
-  if (colorSpace.value === 'hsl') {
-    const hsl = convertToHsl(newColor)
-    if (hsl.s > 0)
-      hueValue.value = hsl.h
-  }
-  else if (colorSpace.value === 'hsb') {
-    const hsb = convertToHsb(newColor)
-    if (hsb.s > 0)
-      hueValue.value = hsb.h
-  }
-}, { immediate: true })
-
-// Background styles for the color area
-// Use preserved hue to ensure background doesn't change when saturation is 0
-const areaStyles = computed(() => {
-  // Create a color with the preserved hue for background computation
-  let bgColor = color.value
-  if (colorSpace.value === 'hsl' || colorSpace.value === 'hsb') {
-    if (colorSpace.value === 'hsl') {
-      bgColor = { space: 'hsl', h: hueValue.value, s: 100, l: 50, alpha: 1 }
-    }
-    else {
-      bgColor = { space: 'hsb', h: hueValue.value, s: 100, b: 100, alpha: 1 }
-    }
-  }
-  return getAreaBackgroundStyle(bgColor, xChannel.value, yChannel.value, colorSpace.value)
-})
-
-function updateValues(x: number, y: number) {
-  const clampedX = Math.max(xRange.value.min, Math.min(xRange.value.max, x))
-  const clampedY = Math.max(yRange.value.min, Math.min(yRange.value.max, y))
-
-  // Update exact values
-  xValue.value = clampedX
-  yValue.value = clampedY
-
-  // Prevent watch from syncing back to xValue/yValue
-  isUpdating = true
-
-  // Update color from exact values (with preserved hue)
-  const channels: Array<{ channel: ColorChannel, value: number }> = [
-    { channel: xChannel.value, value: clampedX },
-    { channel: yChannel.value, value: clampedY },
-  ]
-
-  // Preserve hue only when it is NOT directly controlled by an axis
-  const usesHueAxis = xChannel.value === 'hue' || yChannel.value === 'hue'
-  if (!usesHueAxis && (colorSpace.value === 'hsl' || colorSpace.value === 'hsb')) {
-    channels.push({ channel: 'hue', value: hueValue.value })
-  }
-
-  color.value = setChannelValues(color.value, channels)
-
-  // Re-enable watch sync after Vue has processed the update
-  nextTick(() => {
-    isUpdating = false
-  })
-}
-
-function commitValues() {
-  emits('changeEnd', colorToString(color.value, 'hex'))
-}
-
-const thumbRef = ref<HTMLElement>()
-
-provideColorAreaRootContext({
-  color: computed(() => color.value) as Ref<Color>,
-  xValue,
-  yValue,
-  xChannel,
-  yChannel,
-  colorSpace,
-  disabled,
-  xRange,
-  yRange,
-  thumbRef,
-  updateValues,
-  commitValues,
-})
+provideColorAreaRootContext(context)
 </script>
 
 <template>
@@ -227,9 +97,7 @@ provideColorAreaRootContext({
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"
-    role="group"
-    :aria-disabled="disabled ? 'true' : undefined"
-    :data-disabled="disabled ? '' : undefined"
+    v-bind="root.attrs.value"
   >
     <slot :style="areaStyles" />
 

--- a/packages/core/src/ColorArea/ColorAreaThumb.vue
+++ b/packages/core/src/ColorArea/ColorAreaThumb.vue
@@ -5,11 +5,10 @@ export interface ColorAreaThumbProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { onMounted } from 'vue'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
-import { getChannelName } from '@/shared/color'
 import { injectColorAreaRootContext } from './ColorAreaRoot.vue'
-import { convertValueToPercentage } from './utils'
+import { getColorAreaThumbSurface } from './useColorArea'
 
 const props = withDefaults(defineProps<ColorAreaThumbProps>(), {
   as: 'span',
@@ -17,58 +16,18 @@ const props = withDefaults(defineProps<ColorAreaThumbProps>(), {
 
 const rootContext = injectColorAreaRootContext()
 const { primitiveElement, currentElement } = usePrimitiveElement()
-
 onMounted(() => {
   rootContext.thumbRef.value = currentElement.value
 })
-
-const xPercent = computed(() =>
-  convertValueToPercentage(
-    rootContext.xValue.value,
-    rootContext.xRange.value.min,
-    rootContext.xRange.value.max,
-  ),
-)
-
-const yPercent = computed(() =>
-  convertValueToPercentage(
-    rootContext.yValue.value,
-    rootContext.yRange.value.min,
-    rootContext.yRange.value.max,
-  ),
-)
-
-const ariaLabel = computed(() => {
-  return `${getChannelName(rootContext.xChannel.value)}, ${getChannelName(rootContext.yChannel.value)}`
-})
-
-const ariaValueText = computed(() => {
-  return `${getChannelName(rootContext.xChannel.value)} ${Math.round(rootContext.xValue.value)}, ${getChannelName(rootContext.yChannel.value)} ${Math.round(rootContext.yValue.value)}`
-})
+const thumb = getColorAreaThumbSurface(rootContext)
 </script>
 
 <template>
   <Primitive
     ref="primitiveElement"
-    role="slider"
-    :tabindex="rootContext.disabled.value ? undefined : 0"
-    :aria-label="ariaLabel"
-    aria-roledescription="Color thumb"
-    :aria-valuemin="rootContext.xRange.value.min"
-    :aria-valuemax="rootContext.xRange.value.max"
-    :aria-valuenow="rootContext.xValue.value"
-    :aria-valuetext="ariaValueText"
-    aria-orientation="horizontal"
-    :data-disabled="rootContext.disabled.value ? '' : undefined"
     :as-child="asChild"
     :as="as"
-    :style="{
-      position: 'absolute',
-      left: `${xPercent}%`,
-      top: `${100 - yPercent}%`,
-      transform: 'translate(-50%, -50%)',
-      touchAction: 'none',
-    }"
+    v-bind="thumb.attrs.value"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/ColorArea/index.ts
+++ b/packages/core/src/ColorArea/index.ts
@@ -12,3 +12,7 @@ export {
   default as ColorAreaThumb,
   type ColorAreaThumbProps,
 } from './ColorAreaThumb.vue'
+
+export { useColorArea } from './useColorArea'
+export type { ColorAreaChangeReason, ColorAreaRootState, UseColorAreaProps, UseColorAreaReturn } from './useColorArea'
+export type { ColorAreaAreaState, ColorAreaThumbState } from './useColorArea'

--- a/packages/core/src/ColorArea/useColorArea.test.ts
+++ b/packages/core/src/ColorArea/useColorArea.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+import { useColorArea } from './useColorArea'
+
+describe('useColorArea', () => {
+  const scopes: ReturnType<typeof effectScope>[] = []
+  function setup(props: Parameters<typeof useColorArea>[0] = {}) {
+    const scope = effectScope()
+    scopes.push(scope)
+    return scope.run(() => useColorArea(props))!
+  }
+  afterEach(() => scopes.splice(0).forEach(scope => scope.stop()))
+
+  it('exposes reactive surfaces and clamps channel values without rounding precision', async () => {
+    const disabled = ref(false)
+    const area = setup({ disabled, xChannel: 'saturation', yChannel: 'lightness', defaultValue: '#bf40bf' })
+    area.updateValues(80.45, 120)
+    await nextTick()
+    expect(area.xValue.value).toBe(80.45)
+    expect(area.yValue.value).toBe(100)
+    expect(area.thumb.props.value['aria-label']).toBe('Saturation, Lightness')
+    expect(area.thumb.props.value.style.left).toBe('80.45%')
+    expect(area.root.props.value).not.toHaveProperty('data-disabled')
+    disabled.value = true
+    expect(area.root.attrs.value['data-disabled']).toBe('')
+    expect(area.thumb.props.value.tabindex).toBeUndefined()
+  })
+
+  it('cancels a keyboard change before exact coordinates or color events are written', () => {
+    const emit = vi.fn()
+    const area = setup({ emit, onBeforeUpdate: (_, details) => details.cancel() })
+    const surface = area.createAreaSurface(ref())
+    const event = new KeyboardEvent('keydown', { key: 'ArrowRight', cancelable: true })
+    surface.props.value.onKeydown(event)
+    expect(event.defaultPrevented).toBe(true)
+    expect(area.xValue.value).toBe(0)
+    expect(area.modelValue.value).toBe('#ff0000')
+    expect(area.lastChangeDetails.value).toMatchObject({ reason: 'keyboard', event, isCanceled: true })
+    expect(emit.mock.calls.map(call => call[0])).toEqual(['beforeUpdate:modelValue'])
+  })
+
+  it('keeps controlled ownership and writes a standalone ref-owned model', async () => {
+    const model = ref('#ff0000')
+    const onUpdate = vi.fn()
+    const controlled = setup({ modelValue: model, onUpdate })
+    controlled.updateValues(120, 100)
+    expect(model.value).toBe('#ff0000')
+    expect(onUpdate.mock.calls[0][0]).toBe('#00ff00')
+    model.value = '#0000ff'
+    await nextTick()
+    await nextTick()
+    expect(controlled.color.value).toMatchObject({ b: 255 })
+    const owned = setup({ modelValue: model })
+    owned.updateValues(120, 100)
+    expect(model.value).toBe('#00ff00')
+  })
+
+  it('runs cancellation even when different channel coordinates serialize to the same hex', () => {
+    const before = vi.fn((_, details) => details.cancel())
+    const area = setup({ defaultValue: '#808080', onBeforeUpdate: before })
+    area.updateValues(120, 0)
+    expect(before).toHaveBeenCalledOnce()
+    expect(area.xValue.value).toBe(0)
+  })
+
+  it('maps captured pointer coordinates, focuses the thumb, and commits on release', () => {
+    const emit = vi.fn()
+    const area = setup({ emit })
+    const element = document.createElement('div')
+    element.getBoundingClientRect = () => ({ left: 10, top: 20, width: 100, height: 100 }) as DOMRect
+    element.setPointerCapture = vi.fn()
+    element.hasPointerCapture = () => true
+    element.releasePointerCapture = vi.fn()
+    area.thumbRef.value = document.createElement('span')
+    const focus = vi.spyOn(area.thumbRef.value, 'focus')
+    const surface = area.createAreaSurface(ref(element))
+    const event = { target: element, pointerId: 1, clientX: 60, clientY: 45, preventDefault: vi.fn() }
+    surface.props.value.onPointerdown(event)
+    expect(area.xValue.value).toBe(180)
+    expect(area.yValue.value).toBe(75)
+    expect(focus).toHaveBeenCalledOnce()
+    surface.props.value.onPointermove({ ...event, clientX: 85 })
+    expect(area.xValue.value).toBe(270)
+    surface.props.value.onPointerup(event)
+    expect(emit.mock.calls.at(-1)?.[0]).toBe('changeEnd')
+  })
+})

--- a/packages/core/src/ColorArea/useColorArea.ts
+++ b/packages/core/src/ColorArea/useColorArea.ts
@@ -1,0 +1,368 @@
+import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { ColorAreaRootContext, ColorAreaRootProps } from './ColorAreaRoot.vue'
+import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
+import type { Color, ColorChannel } from '@/shared/color'
+import { computed, nextTick, ref, toValue, watch } from 'vue'
+import { createPartSurface, useControllableState } from '@/shared'
+import { colorToString, convertToHsb, convertToHsl, getAreaBackgroundStyle, getChannelName, getChannelRange, getChannelValue, normalizeColor, setChannelValues } from '@/shared/color'
+import { convertValueToPercentage, linearScale } from './utils'
+
+type Inputs = Pick<ColorAreaRootProps, 'colorSpace' | 'xChannel' | 'yChannel' | 'disabled' | 'modelValue' | 'defaultValue'>
+export type ColorAreaChangeReason = 'pointer' | 'keyboard'
+export type UseColorAreaProps = { [K in keyof Inputs]: MaybeRefOrGetter<Inputs[K]> } & {
+  emit?: (event: any, ...args: any[]) => void
+  onBeforeUpdate?: (value: string | Color, details: ChangeEventDetails<ColorAreaChangeReason>) => void
+  onUpdate?: (value: string | Color, details: ChangeEventDetails<ColorAreaChangeReason>) => void
+}
+
+export type ColorAreaRootState = { disabled: boolean }
+export type UseColorAreaReturn = ReturnType<typeof useColorArea>
+
+/**
+ * Headless ColorArea state. Call in setup or an effect scope to dispose synchronization watchers.
+ *
+ * @experimental
+ * @lifecycle setup
+ */
+export function useColorArea(props: UseColorAreaProps = {}) {
+  const colorSpace = computed(() => toValue(props.colorSpace) ?? 'hsl')
+  const xChannel = computed(() => toValue(props.xChannel) ?? 'hue')
+  const yChannel = computed(() => toValue(props.yChannel) ?? 'saturation')
+  const disabled = computed(() => toValue(props.disabled) ?? false)
+
+  // Normalize the model value to a Color object
+  const { state: modelValue, setState, lastChangeDetails, isControlled } = useControllableState<string | Color, ColorAreaChangeReason>({
+    prop: props.modelValue,
+    defaultValue: () => toValue(props.defaultValue) ?? '#ff0000',
+    // Distinct channel values can serialize to the same hex (grayscale hue or
+    // sub-byte precision). Each color action must still pass the cancellation gate.
+    isEqual: () => false,
+    name: 'modelValue',
+    emit: props.emit,
+    onBeforeUpdate: props.onBeforeUpdate,
+    onUpdate: props.onUpdate,
+  })
+
+  // The actual color object for rendering
+  const color = computed(() => normalizeColor(modelValue.value ?? '#000000'))
+
+  function setColor(newColor: Color, reason: ColorAreaChangeReason | BaseChangeReason = 'imperative-action', event?: Event) {
+    const hexString = colorToString(newColor, 'hex')
+    const changed = setState(hexString, reason, event)
+    if (!changed)
+      return false
+
+    props.emit?.('update:color', newColor)
+    return true
+  }
+
+  // Get channel ranges
+  const xRange = computed(() => getChannelRange(xChannel.value))
+  const yRange = computed(() => getChannelRange(yChannel.value))
+
+  // Store exact channel values as refs to avoid floating-point drift
+  // Initialize from the color value (rounded to nearest integer)
+  const xValue = ref(Math.round(getChannelValue(color.value, xChannel.value)))
+  const yValue = ref(Math.round(getChannelValue(color.value, yChannel.value)))
+
+  // Store the hue separately to preserve it when saturation is 0 (grayscale)
+  const hueValue = ref(colorSpace.value === 'hsl'
+    ? convertToHsl(color.value).h
+    : colorSpace.value === 'hsb'
+      ? convertToHsb(color.value).h
+      : 0)
+
+  // Track when we're in the middle of an update to prevent circular sync
+  let isUpdating = false
+
+  // Sync channel values when color changes externally
+  watch(() => color.value, (newColor) => {
+    // Skip if we just triggered this update ourselves
+    if (isUpdating)
+      return
+
+    const newX = Math.round(getChannelValue(newColor, xChannel.value))
+    const newY = Math.round(getChannelValue(newColor, yChannel.value))
+
+    // Only update if the rounded value meaningfully changed.
+    // During drag, xValue/yValue store exact floats (e.g. 80.45).
+    // External updates (e.g. hue slider) should not snap these to integers.
+    if (Math.round(xValue.value) !== newX)
+      xValue.value = newX
+    if (Math.round(yValue.value) !== newY)
+      yValue.value = newY
+
+    // Update hue if saturation is not 0 (to preserve hue for grayscale colors)
+    if (colorSpace.value === 'hsl') {
+      const hsl = convertToHsl(newColor)
+      if (hsl.s > 0)
+        hueValue.value = hsl.h
+    }
+    else if (colorSpace.value === 'hsb') {
+      const hsb = convertToHsb(newColor)
+      if (hsb.s > 0)
+        hueValue.value = hsb.h
+    }
+  }, { immediate: true })
+
+  // Background styles for the color area
+  // Use preserved hue to ensure background doesn't change when saturation is 0
+  const areaStyles = computed(() => {
+    // Create a color with the preserved hue for background computation
+    let bgColor = color.value
+    if (colorSpace.value === 'hsl' || colorSpace.value === 'hsb') {
+      if (colorSpace.value === 'hsl') {
+        bgColor = { space: 'hsl', h: hueValue.value, s: 100, l: 50, alpha: 1 }
+      }
+      else {
+        bgColor = { space: 'hsb', h: hueValue.value, s: 100, b: 100, alpha: 1 }
+      }
+    }
+    return getAreaBackgroundStyle(bgColor, xChannel.value, yChannel.value, colorSpace.value)
+  })
+
+  function updateValues(x: number, y: number, reason: ColorAreaChangeReason | BaseChangeReason = 'imperative-action', event?: Event) {
+    const clampedX = Math.max(xRange.value.min, Math.min(xRange.value.max, x))
+    const clampedY = Math.max(yRange.value.min, Math.min(yRange.value.max, y))
+
+    // Prevent watch from syncing back to xValue/yValue
+    isUpdating = true
+
+    // Update color from exact values (with preserved hue)
+    const channels: Array<{ channel: ColorChannel, value: number }> = [
+      { channel: xChannel.value, value: clampedX },
+      { channel: yChannel.value, value: clampedY },
+    ]
+
+    // Preserve hue only when it is NOT directly controlled by an axis
+    const usesHueAxis = xChannel.value === 'hue' || yChannel.value === 'hue'
+    if (!usesHueAxis && (colorSpace.value === 'hsl' || colorSpace.value === 'hsb')) {
+      channels.push({ channel: 'hue', value: hueValue.value })
+    }
+
+    if (setColor(setChannelValues(color.value, channels), reason, event)) {
+      xValue.value = clampedX
+      yValue.value = clampedY
+    }
+
+    // Re-enable watch sync after Vue has processed the update
+    nextTick(() => {
+      isUpdating = false
+    })
+  }
+
+  function commitValues() {
+    props.emit?.('changeEnd', colorToString(color.value, 'hex'))
+  }
+
+  const thumbRef = ref<HTMLElement>()
+
+  const context: ColorAreaRootContext = {
+    color: computed(() => color.value) as Ref<Color>,
+    xValue,
+    yValue,
+    xChannel,
+    yChannel,
+    colorSpace,
+    disabled,
+    xRange,
+    yRange,
+    thumbRef,
+    updateValues,
+    commitValues,
+  }
+
+  const root = createPartSurface<ColorAreaRootState>(() => ({ 'role': 'group', 'aria-disabled': disabled.value ? 'true' : undefined }), () => ({ disabled: disabled.value }))
+  return {
+    modelValue,
+    color,
+    disabled,
+    setColor,
+    lastChangeDetails,
+    isControlled,
+    root,
+    context,
+    thumb: getColorAreaThumbSurface(context),
+    createAreaSurface: (element: Ref<HTMLElement | undefined>) => createColorAreaAreaSurface(context, element),
+    areaStyles,
+    xValue,
+    yValue,
+    updateValues,
+    commitValues,
+    thumbRef,
+  }
+}
+
+export type ColorAreaAreaState = { disabled: boolean }
+export type ColorAreaThumbState = { disabled: boolean }
+
+/**
+ * Once per interactive area; owns pointer capture state.
+ * @internal
+ */
+export function createColorAreaAreaSurface(rootContext: ColorAreaRootContext, areaElement: Ref<HTMLElement | undefined>) {
+  const isDragging = ref(false)
+
+  // Convert pointer position to channel values
+  function getValuesFromPointer(event: PointerEvent) {
+    const rect = areaElement.value!.getBoundingClientRect()
+
+    const xInput: [number, number] = [0, rect.width]
+    const xOutput: [number, number] = [rootContext.xRange.value.min, rootContext.xRange.value.max]
+    const xScale = linearScale(xInput, xOutput)
+    const xValue = xScale(event.clientX - rect.left)
+
+    // Y is inverted (top is max, bottom is min for most channels)
+    const yInput: [number, number] = [0, rect.height]
+    const yOutput: [number, number] = [rootContext.yRange.value.max, rootContext.yRange.value.min]
+    const yScale = linearScale(yInput, yOutput)
+    const yValue = yScale(event.clientY - rect.top)
+
+    return { x: xValue, y: yValue }
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (rootContext.disabled.value)
+      return
+
+    const target = event.target as HTMLElement
+    target.setPointerCapture(event.pointerId)
+    event.preventDefault()
+
+    isDragging.value = true
+    const { x, y } = getValuesFromPointer(event)
+    rootContext.updateValues(x, y, 'pointer', event)
+
+    // Focus the thumb when dragging starts
+    rootContext.thumbRef.value?.focus()
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (!isDragging.value || rootContext.disabled.value)
+      return
+
+    const target = event.target as HTMLElement
+    if (target.hasPointerCapture(event.pointerId)) {
+      const { x, y } = getValuesFromPointer(event)
+      rootContext.updateValues(x, y, 'pointer', event)
+    }
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    if (!isDragging.value)
+      return
+
+    const target = event.target as HTMLElement
+    target.releasePointerCapture(event.pointerId)
+    isDragging.value = false
+    rootContext.commitValues()
+  }
+
+  // Keyboard navigation
+  function handleKeyDown(event: KeyboardEvent) {
+    if (rootContext.disabled.value)
+      return
+
+    const stepMultiplier = event.shiftKey ? 10 : 1
+    const xStepSize = rootContext.xRange.value.step * stepMultiplier
+    const yStepSize = rootContext.yRange.value.step * stepMultiplier
+
+    let xDelta = 0
+    let yDelta = 0
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        xDelta = -xStepSize
+        break
+      case 'ArrowRight':
+        xDelta = xStepSize
+        break
+      case 'ArrowUp':
+        yDelta = yStepSize
+        break
+      case 'ArrowDown':
+        yDelta = -yStepSize
+        break
+      case 'PageUp':
+        yDelta = yStepSize * 10
+        break
+      case 'PageDown':
+        yDelta = -yStepSize * 10
+        break
+      case 'Home':
+        xDelta = -xStepSize * 10
+        break
+      case 'End':
+        xDelta = xStepSize * 10
+        break
+      default:
+        return
+    }
+
+    event.preventDefault()
+    rootContext.updateValues(
+      rootContext.xValue.value + xDelta,
+      rootContext.yValue.value + yDelta,
+      'keyboard',
+      event,
+    )
+  }
+  return createPartSurface<ColorAreaAreaState>(() => ({
+    'role': 'application',
+    'aria-roledescription': 'Color picker',
+    'aria-disabled': rootContext.disabled.value ? 'true' : undefined,
+    'style': { touchAction: 'none' },
+    'onKeydown': handleKeyDown,
+    'onPointerdown': handlePointerDown,
+    'onPointermove': handlePointerMove,
+    'onPointerup': handlePointerUp,
+  }), () => ({ disabled: rootContext.disabled.value }))
+}
+
+/**
+ * Context-pure thumb surface shared by the shell and standalone consumers.
+ * @internal
+ */
+export function getColorAreaThumbSurface(rootContext: ColorAreaRootContext) {
+  const xPercent = computed(() =>
+    convertValueToPercentage(
+      rootContext.xValue.value,
+      rootContext.xRange.value.min,
+      rootContext.xRange.value.max,
+    ),
+  )
+
+  const yPercent = computed(() =>
+    convertValueToPercentage(
+      rootContext.yValue.value,
+      rootContext.yRange.value.min,
+      rootContext.yRange.value.max,
+    ),
+  )
+
+  const ariaLabel = computed(() => {
+    return `${getChannelName(rootContext.xChannel.value)}, ${getChannelName(rootContext.yChannel.value)}`
+  })
+
+  const ariaValueText = computed(() => {
+    return `${getChannelName(rootContext.xChannel.value)} ${Math.round(rootContext.xValue.value)}, ${getChannelName(rootContext.yChannel.value)} ${Math.round(rootContext.yValue.value)}`
+  })
+  return createPartSurface<ColorAreaThumbState>(() => ({
+    'role': 'slider',
+    'tabindex': rootContext.disabled.value ? undefined : 0,
+    'aria-label': ariaLabel.value,
+    'aria-roledescription': 'Color thumb',
+    'aria-valuemin': rootContext.xRange.value.min,
+    'aria-valuemax': rootContext.xRange.value.max,
+    'aria-valuenow': rootContext.xValue.value,
+    'aria-valuetext': ariaValueText.value,
+    'aria-orientation': 'horizontal',
+    'style': {
+      position: 'absolute',
+      left: `${xPercent.value}%`,
+      top: `${100 - yPercent.value}%`,
+      transform: 'translate(-50%, -50%)',
+      touchAction: 'none',
+    },
+  }), () => ({ disabled: rootContext.disabled.value }))
+}

--- a/packages/core/src/ColorField/ColorFieldInput.vue
+++ b/packages/core/src/ColorField/ColorFieldInput.vue
@@ -1,145 +1,26 @@
 <script lang="ts">
 import type { PrimitiveProps } from '@/Primitive'
 
-const ALLOWED_INPUT_RE = /[\d.-]/
-
 export interface ColorFieldInputProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
 import { Primitive } from '@/Primitive'
-import { useComposing } from '@/shared'
 import { injectColorFieldRootContext } from './ColorFieldRoot.vue'
+import { createColorFieldInputSurface } from './useColorField'
 
 const props = withDefaults(defineProps<ColorFieldInputProps>(), {
   as: 'input',
 })
 
-const rootContext = injectColorFieldRootContext()
-
-const isFocused = ref(false)
-const { isComposing, handleCompositionStart, handleCompositionEnd } = useComposing()
-
-const inputType = computed(() => {
-  return rootContext.channel.value ? 'text' : 'text'
-})
-
-const inputMode = computed(() => {
-  return rootContext.channel.value ? 'numeric' : 'text'
-})
-
-function handleInput(event: Event) {
-  const target = event.target as HTMLInputElement
-  rootContext.updateValue(target.value)
-}
-
-function handleBlur() {
-  isFocused.value = false
-  rootContext.commit()
-}
-
-function handleFocus() {
-  isFocused.value = true
-}
-
-function handleWheel(event: WheelEvent) {
-  if (!isFocused.value)
-    return
-  rootContext.handleWheel(event)
-}
-
-function handleKeydown(event: KeyboardEvent) {
-  // Don't step/commit mid-composition, keys are used for IME candidate navigation and commit.
-  // `isComposing` stays true until the tick after `compositionend`, so the commit keydown
-  // (which can report `event.isComposing === false`) is still skipped.
-  if (isComposing.value || event.isComposing)
-    return
-  switch (event.key) {
-    case 'ArrowUp':
-      event.preventDefault()
-      rootContext.increment()
-      break
-    case 'ArrowDown':
-      event.preventDefault()
-      rootContext.decrement()
-      break
-    case 'PageUp':
-      event.preventDefault()
-      rootContext.incrementPage()
-      break
-    case 'PageDown':
-      event.preventDefault()
-      rootContext.decrementPage()
-      break
-    case 'Home':
-      event.preventDefault()
-      rootContext.decrementToMin()
-      break
-    case 'End':
-      event.preventDefault()
-      rootContext.incrementToMax()
-      break
-    case 'Enter':
-      event.preventDefault()
-      rootContext.commit()
-      break
-  }
-}
-
-// Handle numeric key validation for channel mode
-function handleBeforeInput(event: InputEvent) {
-  if (event.isComposing)
-    return
-  if (!rootContext.channel.value)
-    return // No validation for hex mode
-
-  const target = event.target as HTMLInputElement
-  const data = event.data
-
-  // Allow numbers, decimal point, minus sign
-  if (data && !ALLOWED_INPUT_RE.test(data)) {
-    event.preventDefault()
-    return
-  }
-
-  // Check the resulting value would be valid
-  const nextValue = target.value.slice(0, target.selectionStart ?? undefined)
-    + (data ?? '')
-    + target.value.slice(target.selectionEnd ?? undefined)
-
-  // Allow empty or partial values while typing
-  if (nextValue === '-' || nextValue === '.' || nextValue === '-.')
-    return
-
-  const numValue = parseFloat(nextValue)
-  if (isNaN(numValue)) {
-    event.preventDefault()
-  }
-}
+const input = createColorFieldInputSurface(injectColorFieldRootContext())
 </script>
 
 <template>
   <Primitive
     :as-child="asChild"
     :as="as"
-    :type="inputType"
-    :inputmode="inputMode"
-    :value="rootContext.inputValue.value"
-    :placeholder="rootContext.placeholder.value"
-    :disabled="rootContext.disabled.value"
-    :readonly="rootContext.readonly.value"
-    :data-disabled="rootContext.disabled.value ? '' : undefined"
-    :data-readonly="rootContext.readonly.value ? '' : undefined"
-    :aria-invalid="!rootContext.channel.value ? undefined : undefined"
-    @input="handleInput"
-    @blur="handleBlur"
-    @focus="handleFocus"
-    @keydown="handleKeydown"
-    @wheel="handleWheel"
-    @beforeinput="handleBeforeInput"
-    @compositionstart="handleCompositionStart"
-    @compositionend="handleCompositionEnd"
+    v-bind="input.attrs.value"
   >
     <slot />
   </Primitive>

--- a/packages/core/src/ColorField/ColorFieldRoot.vue
+++ b/packages/core/src/ColorField/ColorFieldRoot.vue
@@ -31,7 +31,9 @@ export interface ColorFieldRootProps extends PrimitiveProps, FormFieldProps {
 }
 
 export type ColorFieldRootEmits = {
+  /** Event handler called before the color value changes; `details.cancel()` vetoes the change. */
   'beforeUpdate:modelValue': [value: string, details: ChangeEventDetails<ColorFieldChangeReason>]
+  /** Event handler called when the color value changes. */
   'update:modelValue': [value: string, details: ChangeEventDetails<ColorFieldChangeReason>]
   'update:color': [value: Color]
 }

--- a/packages/core/src/ColorField/ColorFieldRoot.vue
+++ b/packages/core/src/ColorField/ColorFieldRoot.vue
@@ -1,9 +1,11 @@
 <script lang="ts">
 import type { Ref } from 'vue'
+import type { ColorFieldChangeReason } from './useColorField'
 import type { PrimitiveProps } from '@/Primitive'
+import type { ChangeEventDetails } from '@/shared'
 import type { Color, ColorChannel, ColorSpace } from '@/shared/color'
 import type { FormFieldProps } from '@/shared/types'
-import { createContext, useFormControl, useForwardExpose, useLocale } from '@/shared'
+import { createContext, useFormControl, useForwardExpose } from '@/shared'
 
 export interface ColorFieldRootProps extends PrimitiveProps, FormFieldProps {
   /** The color value (controlled). Can be a hex string or Color object. */
@@ -29,7 +31,8 @@ export interface ColorFieldRootProps extends PrimitiveProps, FormFieldProps {
 }
 
 export type ColorFieldRootEmits = {
-  'update:modelValue': [value: string]
+  'beforeUpdate:modelValue': [value: string, details: ChangeEventDetails<ColorFieldChangeReason>]
+  'update:modelValue': [value: string, details: ChangeEventDetails<ColorFieldChangeReason>]
   'update:color': [value: Color]
 }
 
@@ -43,13 +46,13 @@ export interface ColorFieldRootContext {
   disableWheelChange: Ref<boolean>
   placeholder: Ref<string | undefined>
   updateValue: (value: string) => void
-  commit: () => void
-  increment: () => void
-  decrement: () => void
-  incrementToMax: () => void
-  decrementToMin: () => void
-  incrementPage: () => void
-  decrementPage: () => void
+  commit: (event?: Event) => void
+  increment: (event?: Event) => void
+  decrement: (event?: Event) => void
+  incrementToMax: (event?: Event) => void
+  decrementToMin: (event?: Event) => void
+  incrementPage: (event?: Event) => void
+  decrementPage: (event?: Event) => void
   handleWheel: (event: WheelEvent) => void
 }
 
@@ -58,20 +61,10 @@ export const [injectColorFieldRootContext, provideColorFieldRootContext]
 </script>
 
 <script setup lang="ts">
-import { useVModel } from '@vueuse/core'
-import { computed, ref, toRefs, watch } from 'vue'
 import { Primitive } from '@/Primitive'
-import {
-  colorToString,
-  convertToRgb,
-  getChannelRange,
-  getChannelValue,
-  isValidColor,
-  normalizeColor,
-  parseColor,
-  setChannelValue,
-} from '@/shared/color'
+import { colorToString } from '@/shared/color'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
+import { useColorField } from './useColorField'
 
 const props = withDefaults(defineProps<ColorFieldRootProps>(), {
   colorSpace: 'hsl',
@@ -84,219 +77,23 @@ const props = withDefaults(defineProps<ColorFieldRootProps>(), {
 
 const emits = defineEmits<ColorFieldRootEmits>()
 
-const { colorSpace, channel, disabled, readonly, disableWheelChange, placeholder, locale: propLocale, step: stepProp } = toRefs(props)
 const { forwardRef, currentElement } = useForwardExpose()
 const isFormControl = useFormControl(currentElement)
-const locale = useLocale(propLocale)
 
-// Normalize the model value
-const modelValue = useVModel(props, 'modelValue', emits, {
-  defaultValue: props.defaultValue,
-  passive: (props.modelValue === undefined) as false,
+const { root, context, color, disabled } = useColorField({
+  colorSpace: () => props.colorSpace,
+  channel: () => props.channel,
+  disabled: () => props.disabled,
+  readonly: () => props.readonly,
+  disableWheelChange: () => props.disableWheelChange,
+  placeholder: () => props.placeholder,
+  step: () => props.step,
+  modelValue: () => props.modelValue,
+  defaultValue: () => props.defaultValue,
+  emit: emits,
 })
 
-const color = computed({
-  get: () => normalizeColor(modelValue.value ?? '#000000'),
-  set: (newColor: Color) => {
-    const hexString = colorToString(newColor, 'hex')
-    modelValue.value = hexString
-    emits('update:color', newColor)
-  },
-})
-
-// Input value for the text field
-const inputValue = ref('')
-const isEditing = ref(false)
-
-// Update input value when color changes (unless user is editing)
-watch(() => color.value, (newColor) => {
-  if (!isEditing.value) {
-    inputValue.value = formatValue(newColor)
-  }
-}, { immediate: true })
-
-function formatValue(c: Color): string {
-  if (channel.value) {
-    const value = getChannelValue(c, channel.value)
-    if (channel.value === 'alpha') {
-      return String(Math.round(value))
-    }
-    return String(Math.round(value))
-  }
-  // Hex mode
-  return colorToString(c, 'hex')
-}
-
-// The effective step size
-const MIN_HEX_INT = 0x000000
-const MAX_HEX_INT = 0xFFFFFF
-const PAGE_STEP_MULTIPLIER = 10
-
-function getStep(): number {
-  if (stepProp.value != null)
-    return stepProp.value
-  if (channel.value)
-    return getChannelRange(channel.value).step
-  // Hex mode: step by 1 in the integer space (like react-spectrum)
-  return 1
-}
-
-function updateValue(value: string) {
-  inputValue.value = value
-}
-
-function commit() {
-  isEditing.value = false
-
-  if (channel.value) {
-    // Channel mode - parse as number
-    const numValue = parseFloat(inputValue.value)
-    if (!isNaN(numValue)) {
-      const range = getChannelRange(channel.value)
-      const clamped = Math.max(range.min, Math.min(range.max, numValue))
-      color.value = setChannelValue(color.value, channel.value, clamped)
-    }
-    // Reset to formatted value
-    inputValue.value = formatValue(color.value)
-  }
-  else {
-    // Hex mode - parse as color
-    const trimmed = inputValue.value.trim()
-    if (isValidColor(trimmed)) {
-      color.value = parseColor(trimmed)
-    }
-    // Reset to formatted value
-    inputValue.value = formatValue(color.value)
-  }
-}
-
-function addHexValue(delta: number) {
-  const intDelta = Math.trunc(delta)
-  const hexInt = color.value.space === 'rgb'
-    ? ((Math.round((color.value as any).r) << 16) | (Math.round((color.value as any).g) << 8) | Math.round((color.value as any).b))
-    : (() => {
-        const rgb = convertToRgb(color.value)
-        return (Math.round(rgb.r) << 16) | (Math.round(rgb.g) << 8) | Math.round(rgb.b)
-      })()
-  const clamped = Math.min(Math.max(hexInt + intDelta, MIN_HEX_INT), MAX_HEX_INT)
-  const hex = `#${clamped.toString(16).padStart(6, '0')}`
-  color.value = parseColor(hex)
-  inputValue.value = formatValue(color.value)
-}
-
-function increment() {
-  if (disabled.value || readonly.value)
-    return
-  const step = getStep()
-  if (channel.value) {
-    const currentValue = getChannelValue(color.value, channel.value)
-    color.value = setChannelValue(color.value, channel.value, currentValue + step)
-    inputValue.value = formatValue(color.value)
-  }
-  else {
-    addHexValue(step)
-  }
-}
-
-function decrement() {
-  if (disabled.value || readonly.value)
-    return
-  const step = getStep()
-  if (channel.value) {
-    const currentValue = getChannelValue(color.value, channel.value)
-    color.value = setChannelValue(color.value, channel.value, currentValue - step)
-    inputValue.value = formatValue(color.value)
-  }
-  else {
-    addHexValue(-step)
-  }
-}
-
-function incrementPage() {
-  if (disabled.value || readonly.value)
-    return
-  const step = getStep() * PAGE_STEP_MULTIPLIER
-  if (channel.value) {
-    const currentValue = getChannelValue(color.value, channel.value)
-    color.value = setChannelValue(color.value, channel.value, currentValue + step)
-    inputValue.value = formatValue(color.value)
-  }
-  else {
-    addHexValue(step)
-  }
-}
-
-function decrementPage() {
-  if (disabled.value || readonly.value)
-    return
-  const step = getStep() * PAGE_STEP_MULTIPLIER
-  if (channel.value) {
-    const currentValue = getChannelValue(color.value, channel.value)
-    color.value = setChannelValue(color.value, channel.value, currentValue - step)
-    inputValue.value = formatValue(color.value)
-  }
-  else {
-    addHexValue(-step)
-  }
-}
-
-function incrementToMax() {
-  if (disabled.value || readonly.value)
-    return
-  if (channel.value) {
-    const range = getChannelRange(channel.value)
-    color.value = setChannelValue(color.value, channel.value, range.max)
-    inputValue.value = formatValue(color.value)
-  }
-  else {
-    addHexValue(MAX_HEX_INT)
-  }
-}
-
-function decrementToMin() {
-  if (disabled.value || readonly.value)
-    return
-  if (channel.value) {
-    const range = getChannelRange(channel.value)
-    color.value = setChannelValue(color.value, channel.value, range.min)
-    inputValue.value = formatValue(color.value)
-  }
-  else {
-    addHexValue(-MAX_HEX_INT)
-  }
-}
-
-function handleWheel(event: WheelEvent) {
-  if (disableWheelChange.value || disabled.value || readonly.value)
-    return
-
-  event.preventDefault()
-
-  if (event.deltaY > 0)
-    decrement()
-  else
-    increment()
-}
-
-provideColorFieldRootContext({
-  color: computed(() => color.value) as Ref<Color>,
-  inputValue,
-  channel,
-  colorSpace,
-  disabled,
-  readonly,
-  disableWheelChange,
-  placeholder,
-  updateValue,
-  commit,
-  increment,
-  decrement,
-  incrementToMax,
-  decrementToMin,
-  incrementPage,
-  decrementPage,
-  handleWheel,
-})
+provideColorFieldRootContext(context)
 </script>
 
 <template>
@@ -304,9 +101,7 @@ provideColorFieldRootContext({
     :ref="forwardRef"
     :as="as"
     :as-child="asChild"
-    role="group"
-    :data-disabled="disabled ? '' : undefined"
-    :data-readonly="readonly ? '' : undefined"
+    v-bind="root.attrs.value"
   >
     <slot />
 

--- a/packages/core/src/ColorField/index.ts
+++ b/packages/core/src/ColorField/index.ts
@@ -8,3 +8,7 @@ export {
   type ColorFieldRootProps,
   injectColorFieldRootContext,
 } from './ColorFieldRoot.vue'
+
+export { useColorField } from './useColorField'
+export type { ColorFieldChangeReason, ColorFieldRootState, UseColorFieldProps, UseColorFieldReturn } from './useColorField'
+export type { ColorFieldInputState } from './useColorField'

--- a/packages/core/src/ColorField/useColorField.test.ts
+++ b/packages/core/src/ColorField/useColorField.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+import { useColorField } from './useColorField'
+
+describe('useColorField', () => {
+  const scopes: ReturnType<typeof effectScope>[] = []
+  function setup(props: Parameters<typeof useColorField>[0] = {}) {
+    const scope = effectScope()
+    scopes.push(scope)
+    return scope.run(() => useColorField(props))!
+  }
+  afterEach(() => scopes.splice(0).forEach(scope => scope.stop()))
+
+  it('steps and commits a ref-owned model, resetting invalid input', () => {
+    const modelValue = ref('#000000')
+    const field = setup({ modelValue })
+    field.increment()
+    expect(modelValue.value).toBe('#000001')
+    field.updateValue('invalid')
+    field.commit()
+    expect(field.inputValue.value).toBe('#000001')
+    field.updateValue('#123456')
+    field.commit()
+    expect(modelValue.value).toBe('#123456')
+  })
+
+  it('cancels keyboard and blur commits and preserves the native event', () => {
+    const onUpdate = vi.fn()
+    const field = setup({ onUpdate, onBeforeUpdate: (_, details) => details.cancel() })
+    const input = field.createInputSurface()
+    const event = new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true })
+    input.props.value.onKeydown(event)
+    expect(field.modelValue.value).toBe('#000000')
+    expect(field.lastChangeDetails.value).toMatchObject({ reason: 'keyboard', event, isCanceled: true })
+    field.updateValue('#ffffff')
+    input.props.value.onBlur(new FocusEvent('blur'))
+    expect(field.inputValue.value).toBe('#000000')
+    expect(field.lastChangeDetails.value.reason).toBe('blur')
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('keeps per-input focus and composition state independent', async () => {
+    const field = setup()
+    const first = field.createInputSurface()
+    const second = field.createInputSurface()
+    const wheel = new WheelEvent('wheel', { deltaY: -1, cancelable: true })
+    first.props.value.onFocus()
+    second.props.value.onWheel(wheel)
+    expect(field.modelValue.value).toBe('#000000')
+    first.props.value.onWheel(wheel)
+    expect(field.modelValue.value).toBe('#000001')
+    expect(field.lastChangeDetails.value.reason).toBe('wheel')
+    first.props.value.onCompositionstart()
+    const key = new KeyboardEvent('keydown', { key: 'ArrowUp' })
+    first.props.value.onKeydown(key)
+    expect(field.modelValue.value).toBe('#000001')
+    first.props.value.onCompositionend(new CompositionEvent('compositionend'))
+    first.props.value.onKeydown(key)
+    expect(field.modelValue.value).toBe('#000001')
+    await nextTick()
+    first.props.value.onKeydown(key)
+    expect(field.modelValue.value).toBe('#000002')
+  })
+
+  it('reacts to disabled, readonly and step inputs and synchronizes external values', async () => {
+    const disabled = ref(false)
+    const readonly = ref(false)
+    const step = ref(2)
+    const model = ref('#000000')
+    const field = setup({ modelValue: model, disabled, readonly, step, channel: 'red' })
+    const input = field.createInputSurface()
+    field.increment()
+    expect(model.value).toBe('#020000')
+    step.value = 3
+    field.increment()
+    expect(model.value).toBe('#050000')
+    disabled.value = true
+    field.increment()
+    expect(model.value).toBe('#050000')
+    expect(input.attrs.value['data-disabled']).toBe('')
+    disabled.value = false
+    readonly.value = true
+    field.increment()
+    expect(model.value).toBe('#050000')
+    expect(input.attrs.value['data-readonly']).toBe('')
+    model.value = '#ff0000'
+    await nextTick()
+    expect(field.inputValue.value).toBe('255')
+  })
+})

--- a/packages/core/src/ColorField/useColorField.test.ts
+++ b/packages/core/src/ColorField/useColorField.test.ts
@@ -24,6 +24,20 @@ describe('useColorField', () => {
     expect(modelValue.value).toBe('#123456')
   })
 
+  it('preserves a draft during external updates and resumes synchronization after commit', async () => {
+    const modelValue = ref('#000000')
+    const field = setup({ modelValue })
+    field.updateValue('#123')
+    modelValue.value = '#ffffff'
+    await nextTick()
+    expect(field.inputValue.value).toBe('#123')
+    field.commit()
+    expect(modelValue.value).toBe('#112233')
+    modelValue.value = '#ff0000'
+    await nextTick()
+    expect(field.inputValue.value).toBe('#ff0000')
+  })
+
   it('cancels keyboard and blur commits and preserves the native event', () => {
     const onUpdate = vi.fn()
     const field = setup({ onUpdate, onBeforeUpdate: (_, details) => details.cancel() })

--- a/packages/core/src/ColorField/useColorField.ts
+++ b/packages/core/src/ColorField/useColorField.ts
@@ -1,0 +1,403 @@
+import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { ColorFieldRootContext, ColorFieldRootProps } from './ColorFieldRoot.vue'
+import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
+import type { Color } from '@/shared/color'
+import { computed, ref, toValue, watch } from 'vue'
+import { createPartSurface, useComposing, useControllableState } from '@/shared'
+import { colorToString, convertToRgb, getChannelRange, getChannelValue, isValidColor, normalizeColor, parseColor, setChannelValue } from '@/shared/color'
+
+type Inputs = Pick<ColorFieldRootProps, 'colorSpace' | 'channel' | 'disabled' | 'readonly' | 'disableWheelChange' | 'placeholder' | 'step' | 'modelValue' | 'defaultValue'>
+export type ColorFieldChangeReason = 'keyboard' | 'wheel' | 'blur'
+export type UseColorFieldProps = { [K in keyof Inputs]: MaybeRefOrGetter<Inputs[K]> } & {
+  emit?: (event: any, ...args: any[]) => void
+  onBeforeUpdate?: (value: string | Color, details: ChangeEventDetails<ColorFieldChangeReason>) => void
+  onUpdate?: (value: string | Color, details: ChangeEventDetails<ColorFieldChangeReason>) => void
+}
+
+export type ColorFieldRootState = { disabled: boolean, readonly: boolean }
+export type UseColorFieldReturn = ReturnType<typeof useColorField>
+
+/**
+ * Headless ColorField state. Call in setup or an effect scope to dispose synchronization watchers.
+ *
+ * @experimental
+ * @lifecycle setup
+ */
+export function useColorField(props: UseColorFieldProps = {}) {
+  const colorSpace = computed(() => toValue(props.colorSpace) ?? 'hsl')
+  const channel = computed(() => toValue(props.channel))
+  const disabled = computed(() => toValue(props.disabled) ?? false)
+  const readonly = computed(() => toValue(props.readonly) ?? false)
+  const disableWheelChange = computed(() => toValue(props.disableWheelChange) ?? false)
+  const placeholder = computed(() => toValue(props.placeholder))
+  const stepProp = computed(() => toValue(props.step))
+
+  // Normalize the model value
+  const { state: modelValue, setState, lastChangeDetails, isControlled } = useControllableState<string | Color, ColorFieldChangeReason>({
+    prop: props.modelValue,
+    defaultValue: () => toValue(props.defaultValue) ?? '#000000',
+    name: 'modelValue',
+    emit: props.emit,
+    onBeforeUpdate: props.onBeforeUpdate,
+    onUpdate: props.onUpdate,
+  })
+
+  const color = computed(() => normalizeColor(modelValue.value ?? '#000000'))
+
+  function reasonFromEvent(event?: Event): ColorFieldChangeReason | BaseChangeReason {
+    return event?.type === 'wheel' ? 'wheel' : event?.type === 'blur' ? 'blur' : event ? 'keyboard' : 'imperative-action'
+  }
+
+  function setColor(newColor: Color, reason: ColorFieldChangeReason | BaseChangeReason = 'imperative-action', event?: Event) {
+    const hexString = colorToString(newColor, 'hex')
+    const changed = setState(hexString, reason, event)
+    if (!changed)
+      return false
+
+    props.emit?.('update:color', newColor)
+    return true
+  }
+
+  // Input value for the text field
+  const inputValue = ref('')
+  const isEditing = ref(false)
+
+  // Update input value when color changes (unless user is editing)
+  watch(() => color.value, (newColor) => {
+    if (!isEditing.value) {
+      inputValue.value = formatValue(newColor)
+    }
+  }, { immediate: true })
+
+  function formatValue(c: Color): string {
+    if (channel.value) {
+      const value = getChannelValue(c, channel.value)
+      if (channel.value === 'alpha') {
+        return String(Math.round(value))
+      }
+      return String(Math.round(value))
+    }
+    // Hex mode
+    return colorToString(c, 'hex')
+  }
+
+  // The effective step size
+  const MIN_HEX_INT = 0x000000
+  const MAX_HEX_INT = 0xFFFFFF
+  const PAGE_STEP_MULTIPLIER = 10
+
+  function getStep(): number {
+    if (stepProp.value != null)
+      return stepProp.value
+    if (channel.value)
+      return getChannelRange(channel.value).step
+    // Hex mode: step by 1 in the integer space (like react-spectrum)
+    return 1
+  }
+
+  function updateValue(value: string) {
+    inputValue.value = value
+  }
+
+  function commit(event?: Event) {
+    isEditing.value = false
+
+    if (channel.value) {
+      // Channel mode - parse as number
+      const numValue = parseFloat(inputValue.value)
+      if (!isNaN(numValue)) {
+        const range = getChannelRange(channel.value)
+        const clamped = Math.max(range.min, Math.min(range.max, numValue))
+        setColor(setChannelValue(color.value, channel.value, clamped), reasonFromEvent(event), event)
+      }
+      // Reset to formatted value
+      inputValue.value = formatValue(color.value)
+    }
+    else {
+      // Hex mode - parse as color
+      const trimmed = inputValue.value.trim()
+      if (isValidColor(trimmed)) {
+        setColor(parseColor(trimmed), reasonFromEvent(event), event)
+      }
+      // Reset to formatted value
+      inputValue.value = formatValue(color.value)
+    }
+  }
+
+  function addHexValue(delta: number, event?: Event) {
+    const intDelta = Math.trunc(delta)
+    const hexInt = color.value.space === 'rgb'
+      ? ((Math.round((color.value as any).r) << 16) | (Math.round((color.value as any).g) << 8) | Math.round((color.value as any).b))
+      : (() => {
+          const rgb = convertToRgb(color.value)
+          return (Math.round(rgb.r) << 16) | (Math.round(rgb.g) << 8) | Math.round(rgb.b)
+        })()
+    const clamped = Math.min(Math.max(hexInt + intDelta, MIN_HEX_INT), MAX_HEX_INT)
+    const hex = `#${clamped.toString(16).padStart(6, '0')}`
+    setColor(parseColor(hex), reasonFromEvent(event), event)
+    inputValue.value = formatValue(color.value)
+  }
+
+  function increment(event?: Event) {
+    if (disabled.value || readonly.value)
+      return
+    const step = getStep()
+    if (channel.value) {
+      const currentValue = getChannelValue(color.value, channel.value)
+      setColor(setChannelValue(color.value, channel.value, currentValue + step), reasonFromEvent(event), event)
+      inputValue.value = formatValue(color.value)
+    }
+    else {
+      addHexValue(step, event)
+    }
+  }
+
+  function decrement(event?: Event) {
+    if (disabled.value || readonly.value)
+      return
+    const step = getStep()
+    if (channel.value) {
+      const currentValue = getChannelValue(color.value, channel.value)
+      setColor(setChannelValue(color.value, channel.value, currentValue - step), reasonFromEvent(event), event)
+      inputValue.value = formatValue(color.value)
+    }
+    else {
+      addHexValue(-step, event)
+    }
+  }
+
+  function incrementPage(event?: Event) {
+    if (disabled.value || readonly.value)
+      return
+    const step = getStep() * PAGE_STEP_MULTIPLIER
+    if (channel.value) {
+      const currentValue = getChannelValue(color.value, channel.value)
+      setColor(setChannelValue(color.value, channel.value, currentValue + step), reasonFromEvent(event), event)
+      inputValue.value = formatValue(color.value)
+    }
+    else {
+      addHexValue(step, event)
+    }
+  }
+
+  function decrementPage(event?: Event) {
+    if (disabled.value || readonly.value)
+      return
+    const step = getStep() * PAGE_STEP_MULTIPLIER
+    if (channel.value) {
+      const currentValue = getChannelValue(color.value, channel.value)
+      setColor(setChannelValue(color.value, channel.value, currentValue - step), reasonFromEvent(event), event)
+      inputValue.value = formatValue(color.value)
+    }
+    else {
+      addHexValue(-step, event)
+    }
+  }
+
+  function incrementToMax(event?: Event) {
+    if (disabled.value || readonly.value)
+      return
+    if (channel.value) {
+      const range = getChannelRange(channel.value)
+      setColor(setChannelValue(color.value, channel.value, range.max), reasonFromEvent(event), event)
+      inputValue.value = formatValue(color.value)
+    }
+    else {
+      addHexValue(MAX_HEX_INT, event)
+    }
+  }
+
+  function decrementToMin(event?: Event) {
+    if (disabled.value || readonly.value)
+      return
+    if (channel.value) {
+      const range = getChannelRange(channel.value)
+      setColor(setChannelValue(color.value, channel.value, range.min), reasonFromEvent(event), event)
+      inputValue.value = formatValue(color.value)
+    }
+    else {
+      addHexValue(-MAX_HEX_INT, event)
+    }
+  }
+
+  function handleWheel(event: WheelEvent) {
+    if (disableWheelChange.value || disabled.value || readonly.value)
+      return
+
+    event.preventDefault()
+
+    if (event.deltaY > 0)
+      decrement(event)
+    else
+      increment(event)
+  }
+
+  const context: ColorFieldRootContext = {
+    color: computed(() => color.value) as Ref<Color>,
+    inputValue,
+    channel,
+    colorSpace,
+    disabled,
+    readonly,
+    disableWheelChange,
+    placeholder,
+    updateValue,
+    commit,
+    increment,
+    decrement,
+    incrementToMax,
+    decrementToMin,
+    incrementPage,
+    decrementPage,
+    handleWheel,
+  }
+
+  const root = createPartSurface<ColorFieldRootState>(() => ({ role: 'group' }), () => ({ disabled: disabled.value, readonly: readonly.value }))
+  return {
+    modelValue,
+    color,
+    disabled,
+    setColor,
+    lastChangeDetails,
+    isControlled,
+    root,
+    context,
+    createInputSurface: () => createColorFieldInputSurface(context),
+    inputValue,
+    updateValue,
+    commit,
+    increment,
+    decrement,
+    incrementPage,
+    decrementPage,
+    incrementToMax,
+    decrementToMin,
+    handleWheel,
+  }
+}
+
+export type ColorFieldInputState = { disabled: boolean, readonly: boolean }
+
+const ALLOWED_INPUT_RE = /[\d.-]/
+
+/**
+ * Once per input; owns focus and IME composition state.
+ * @internal
+ */
+export function createColorFieldInputSurface(rootContext: ColorFieldRootContext) {
+  const isFocused = ref(false)
+  const { isComposing, handleCompositionStart, handleCompositionEnd } = useComposing()
+
+  const inputType = computed(() => {
+    return rootContext.channel.value ? 'text' : 'text'
+  })
+
+  const inputMode = computed(() => {
+    return rootContext.channel.value ? 'numeric' : 'text'
+  })
+
+  function handleInput(event: Event) {
+    const target = event.target as HTMLInputElement
+    rootContext.updateValue(target.value)
+  }
+
+  function handleBlur(event: FocusEvent) {
+    isFocused.value = false
+    rootContext.commit(event)
+  }
+
+  function handleFocus() {
+    isFocused.value = true
+  }
+
+  function handleWheel(event: WheelEvent) {
+    if (!isFocused.value)
+      return
+    rootContext.handleWheel(event)
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    // Don't step/commit mid-composition, keys are used for IME candidate navigation and commit.
+    // `isComposing` stays true until the tick after `compositionend`, so the commit keydown
+    // (which can report `event.isComposing === false`) is still skipped.
+    if (isComposing.value || event.isComposing)
+      return
+    switch (event.key) {
+      case 'ArrowUp':
+        event.preventDefault()
+        rootContext.increment(event)
+        break
+      case 'ArrowDown':
+        event.preventDefault()
+        rootContext.decrement(event)
+        break
+      case 'PageUp':
+        event.preventDefault()
+        rootContext.incrementPage(event)
+        break
+      case 'PageDown':
+        event.preventDefault()
+        rootContext.decrementPage(event)
+        break
+      case 'Home':
+        event.preventDefault()
+        rootContext.decrementToMin(event)
+        break
+      case 'End':
+        event.preventDefault()
+        rootContext.incrementToMax(event)
+        break
+      case 'Enter':
+        event.preventDefault()
+        rootContext.commit(event)
+        break
+    }
+  }
+
+  // Handle numeric key validation for channel mode
+  function handleBeforeInput(event: InputEvent) {
+    if (event.isComposing)
+      return
+    if (!rootContext.channel.value)
+      return // No validation for hex mode
+
+    const target = event.target as HTMLInputElement
+    const data = event.data
+
+    // Allow numbers, decimal point, minus sign
+    if (data && !ALLOWED_INPUT_RE.test(data)) {
+      event.preventDefault()
+      return
+    }
+
+    // Check the resulting value would be valid
+    const nextValue = target.value.slice(0, target.selectionStart ?? undefined)
+      + (data ?? '')
+      + target.value.slice(target.selectionEnd ?? undefined)
+
+    // Allow empty or partial values while typing
+    if (nextValue === '-' || nextValue === '.' || nextValue === '-.')
+      return
+
+    const numValue = parseFloat(nextValue)
+    if (isNaN(numValue)) {
+      event.preventDefault()
+    }
+  }
+  return createPartSurface<ColorFieldInputState>(() => ({
+    type: inputType.value,
+    inputmode: inputMode.value,
+    value: rootContext.inputValue.value,
+    placeholder: rootContext.placeholder.value,
+    disabled: rootContext.disabled.value,
+    readonly: rootContext.readonly.value,
+    onInput: handleInput,
+    onBlur: handleBlur,
+    onFocus: handleFocus,
+    onKeydown: handleKeydown,
+    onWheel: handleWheel,
+    onBeforeinput: handleBeforeInput,
+    onCompositionstart: handleCompositionStart,
+    onCompositionend: handleCompositionEnd,
+  }), () => ({ disabled: rootContext.disabled.value, readonly: rootContext.readonly.value }))
+}

--- a/packages/core/src/ColorField/useColorField.ts
+++ b/packages/core/src/ColorField/useColorField.ts
@@ -96,6 +96,7 @@ export function useColorField(props: UseColorFieldProps = {}) {
   }
 
   function updateValue(value: string) {
+    isEditing.value = true
     inputValue.value = value
   }
 

--- a/packages/core/src/ColorSlider/ColorSliderRoot.vue
+++ b/packages/core/src/ColorSlider/ColorSliderRoot.vue
@@ -1,7 +1,9 @@
 <script lang="ts">
 import type { ComputedRef, Ref } from 'vue'
+import type { ColorSliderChangeReason } from './useColorSlider'
 import type { PrimitiveProps } from '@/Primitive'
-import type { Color, ColorChannel, ColorChannel as ColorChannelType, ColorSpace } from '@/shared/color'
+import type { ChangeEventDetails } from '@/shared'
+import type { Color, ColorChannel, ColorSpace } from '@/shared/color'
 import type { DataOrientation, Direction, FormFieldProps } from '@/shared/types'
 import { createContext, useDirection, useFormControl, useForwardExpose } from '@/shared'
 
@@ -27,7 +29,8 @@ export interface ColorSliderRootProps extends PrimitiveProps, FormFieldProps {
 }
 
 export type ColorSliderRootEmits = {
-  'update:modelValue': [value: string | Color]
+  'beforeUpdate:modelValue': [value: string | Color, details: ChangeEventDetails<ColorSliderChangeReason>]
+  'update:modelValue': [value: string | Color, details: ChangeEventDetails<ColorSliderChangeReason>]
   'update:color': [value: Color]
   'change': [value: string]
   'changeEnd': [value: string]
@@ -51,15 +54,13 @@ export const [injectColorSliderRootContext, provideColorSliderRootContext]
 </script>
 
 <script setup lang="ts">
-import { useVModel } from '@vueuse/core'
-import { computed, ref, toRefs, watch } from 'vue'
-import { colorToString, convertToHsb, convertToHsl, convertToRgb, getChannelRange, getChannelValue, normalizeColor, setChannelValue } from '@/shared/color'
+import { mergeProps, toRefs } from 'vue'
+import { colorToString } from '@/shared/color'
 import { SliderRoot } from '@/Slider'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
+import { useColorSlider } from './useColorSlider'
 
-defineOptions({
-  inheritAttrs: false,
-})
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<ColorSliderRootProps>(), {
   colorSpace: 'hsl',
@@ -72,143 +73,33 @@ const props = withDefaults(defineProps<ColorSliderRootProps>(), {
 
 const emits = defineEmits<ColorSliderRootEmits>()
 
-const { orientation, disabled, inverted, dir: propDir, channel, colorSpace, step: stepProp } = toRefs(props)
-const dir = useDirection(propDir)
 const { forwardRef, currentElement } = useForwardExpose()
 const isFormControl = useFormControl(currentElement)
+const { dir: propDir } = toRefs(props)
+const dir = useDirection(propDir)
 
-// Normalize the model value to a Color object
-const modelValue = useVModel(props, 'modelValue', emits, {
-  defaultValue: props.defaultValue,
-  passive: (props.modelValue === undefined) as false,
+const { root, context, color, disabled } = useColorSlider({
+  orientation: () => props.orientation,
+  disabled: () => props.disabled,
+  inverted: () => props.inverted,
+  channel: () => props.channel,
+  colorSpace: () => props.colorSpace,
+  step: () => props.step,
+  modelValue: () => props.modelValue,
+  defaultValue: () => props.defaultValue,
+  emit: emits,
 })
 
-// Convert a color to the native color space for the given channel.
-// This ensures setChannelValue/getChannelValue operate without cross-space round-trips.
-function toNativeSpace(color: Color, ch: ColorChannelType, space: ColorSpace): Color {
-  switch (ch) {
-    case 'hue':
-    case 'lightness':
-      return convertToHsl(color)
-    case 'saturation':
-      return space === 'hsb' ? convertToHsb(color) : convertToHsl(color)
-    case 'brightness':
-      return convertToHsb(color)
-    case 'red':
-    case 'green':
-    case 'blue':
-      return convertToRgb(color)
-    case 'alpha':
-      return color
-    default:
-      return color
-  }
-}
-
-// Internal color ref that preserves color space precision.
-// Convert to the channel's native space to avoid cross-space round-trips during drag.
-const internalColor = ref<Color>(toNativeSpace(normalizeColor(modelValue.value ?? props.defaultValue ?? '#000000'), channel.value, colorSpace.value))
-
-// Check if a color is achromatic (hue information is lost in hex round-trips)
-function isAchromatic(color: Color): boolean {
-  const hsl = convertToHsl(color)
-  return hsl.s === 0 || hsl.l === 0 || hsl.l >= 100
-}
-
-// Sync internal color from external modelValue changes (e.g. parent updates)
-watch(() => modelValue.value, (newVal) => {
-  if (newVal == null)
-    return
-  const parsed = normalizeColor(newVal)
-  const currentHex = colorToString(internalColor.value, 'hex')
-  const newHex = colorToString(parsed, 'hex')
-  // Only update if the external value actually changed (avoid overwriting
-  // precision during our own drag updates)
-  if (currentHex !== newHex) {
-    const nativeColor = toNativeSpace(parsed, channel.value, colorSpace.value)
-    const currentChannelVal = getChannelValue(internalColor.value, channel.value)
-    const newChannelVal = getChannelValue(nativeColor, channel.value)
-
-    // Preserve this slider's channel value when:
-    // 1. Color is achromatic (hue completely lost in hex round-trip)
-    // 2. Channel value diff is within 2% of range (8-bit RGB quantization drift)
-    // We still update the rest of the color so the track gradient stays correct.
-    const range = channelRange.value.max - channelRange.value.min
-    const shouldPreserve = (channel.value === 'hue' && isAchromatic(parsed))
-      || Math.abs(currentChannelVal - newChannelVal) < range * 0.02
-
-    if (shouldPreserve) {
-      internalColor.value = setChannelValue(nativeColor, channel.value, currentChannelVal)
-    }
-    else {
-      internalColor.value = nativeColor
-    }
-  }
-})
-
-const color = computed({
-  get: () => internalColor.value,
-  set: (newColor: Color) => {
-    internalColor.value = newColor
-    const hexString = colorToString(newColor, 'hex')
-    modelValue.value = hexString
-    emits('update:color', newColor)
-  },
-})
-
-// Get channel range
-const channelRange = computed(() => getChannelRange(channel.value))
-const min = computed(() => channelRange.value.min)
-const max = computed(() => channelRange.value.max)
-const step = computed(() => stepProp.value ?? channelRange.value.step)
-
-// Current channel value
-const channelValue = computed(() => getChannelValue(color.value, channel.value))
-
-// Convert channel value to array format for SliderRoot
-const sliderValue = computed({
-  get: () => [channelValue.value],
-  set: (newValue: number[]) => {
-    const clamped = Math.max(min.value, Math.min(max.value, newValue[0]))
-    const newColor = setChannelValue(color.value, channel.value, clamped)
-    color.value = newColor
-    emits('change', colorToString(newColor, 'hex'))
-  },
-})
-
-function handleValueCommit(values: number[]) {
-  emits('changeEnd', colorToString(color.value, 'hex'))
-}
-
-provideColorSliderRootContext({
-  color: computed(() => color.value) as Ref<Color>,
-  channelValue,
-  channel,
-  colorSpace,
-  orientation,
-  disabled,
-  inverted,
-  min,
-  max,
-  step,
-})
+provideColorSliderRootContext(context)
 </script>
 
 <template>
   <SliderRoot
-    v-bind="$attrs"
+    v-bind="mergeProps(root.attrs.value, $attrs)"
     :ref="forwardRef"
-    v-model="sliderValue"
-    :orientation="orientation"
     :dir="dir"
-    :disabled="disabled"
-    :inverted="inverted"
-    :min="min"
-    :max="max"
-    :step="step"
     :as="as"
     :as-child="asChild"
-    @value-commit="handleValueCommit"
   >
     <slot />
 

--- a/packages/core/src/ColorSlider/ColorSliderRoot.vue
+++ b/packages/core/src/ColorSlider/ColorSliderRoot.vue
@@ -29,7 +29,9 @@ export interface ColorSliderRootProps extends PrimitiveProps, FormFieldProps {
 }
 
 export type ColorSliderRootEmits = {
+  /** Event handler called before the color value changes; `details.cancel()` vetoes the change. */
   'beforeUpdate:modelValue': [value: string | Color, details: ChangeEventDetails<ColorSliderChangeReason>]
+  /** Event handler called when the color value changes. */
   'update:modelValue': [value: string | Color, details: ChangeEventDetails<ColorSliderChangeReason>]
   'update:color': [value: Color]
   'change': [value: string]

--- a/packages/core/src/ColorSlider/ColorSliderThumb.vue
+++ b/packages/core/src/ColorSlider/ColorSliderThumb.vue
@@ -5,10 +5,9 @@ export interface ColorSliderThumbProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { getChannelName } from '@/shared/color'
 import { SliderThumb } from '@/Slider'
 import { injectColorSliderRootContext } from './ColorSliderRoot.vue'
+import { getColorSliderThumbSurface } from './useColorSlider'
 
 const props = withDefaults(defineProps<ColorSliderThumbProps>(), {
   as: 'span',
@@ -24,30 +23,17 @@ defineSlots<{
 }>()
 
 const rootContext = injectColorSliderRootContext()
-
-const ariaLabel = computed(() => {
-  return getChannelName(rootContext.channel.value)
-})
-
-const ariaValueText = computed(() => {
-  const value = rootContext.channelValue.value
-  const channel = rootContext.channel.value
-  if (channel === 'alpha') {
-    return `${Math.round(value)}%`
-  }
-  return String(Math.round(value))
-})
+const thumb = getColorSliderThumbSurface(rootContext)
 </script>
 
 <template>
   <SliderThumb
     :as="as"
     :as-child="asChild"
-    :aria-label="ariaLabel"
-    :aria-valuetext="ariaValueText"
+    v-bind="thumb.attrs.value"
   >
     <slot
-      :channel-name="ariaLabel"
+      :channel-name="thumb.props.value['aria-label']"
       :channel-value="rootContext.channelValue.value"
     />
   </SliderThumb>

--- a/packages/core/src/ColorSlider/ColorSliderTrack.vue
+++ b/packages/core/src/ColorSlider/ColorSliderTrack.vue
@@ -5,31 +5,23 @@ export interface ColorSliderTrackProps extends PrimitiveProps {}
 </script>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { getSliderBackgroundStyle } from '@/shared/color'
 import { SliderTrack } from '@/Slider'
 import { injectColorSliderRootContext } from './ColorSliderRoot.vue'
+import { getColorSliderTrackSurface } from './useColorSlider'
 
 const props = withDefaults(defineProps<ColorSliderTrackProps>(), {
   as: 'span',
 })
 
 const rootContext = injectColorSliderRootContext()
-
-const backgroundStyle = computed(() => {
-  return getSliderBackgroundStyle(
-    rootContext.color.value,
-    rootContext.channel.value,
-    rootContext.colorSpace.value,
-  )
-})
+const track = getColorSliderTrackSurface(rootContext)
 </script>
 
 <template>
   <SliderTrack
     :as="as"
     :as-child="asChild"
-    :style="backgroundStyle"
+    v-bind="track.attrs.value"
   >
     <slot />
   </SliderTrack>

--- a/packages/core/src/ColorSlider/index.ts
+++ b/packages/core/src/ColorSlider/index.ts
@@ -12,3 +12,7 @@ export {
   default as ColorSliderTrack,
   type ColorSliderTrackProps,
 } from './ColorSliderTrack.vue'
+
+export { useColorSlider } from './useColorSlider'
+export type { ColorSliderChangeReason, ColorSliderRootState, UseColorSliderProps, UseColorSliderReturn } from './useColorSlider'
+export type { ColorSliderThumbState, ColorSliderTrackState } from './useColorSlider'

--- a/packages/core/src/ColorSlider/useColorSlider.test.ts
+++ b/packages/core/src/ColorSlider/useColorSlider.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, ref } from 'vue'
+import { useColorSlider } from './useColorSlider'
+
+describe('useColorSlider', () => {
+  const scopes: ReturnType<typeof effectScope>[] = []
+  function setup(props: Parameters<typeof useColorSlider>[0] = { channel: 'red' }) {
+    const scope = effectScope()
+    scopes.push(scope)
+    return scope.run(() => useColorSlider(props))!
+  }
+  afterEach(() => scopes.splice(0).forEach(scope => scope.stop()))
+
+  it('exposes shared slider surfaces and retains fractional channel precision', async () => {
+    const slider = setup({ channel: 'hue', defaultValue: '#ff0000' })
+    slider.setValue([120.45])
+    await nextTick()
+    expect(slider.channelValue.value).toBe(120.45)
+    expect(slider.thumb.props.value['aria-label']).toBe('Hue')
+    expect(slider.thumb.props.value['aria-valuetext']).toBe('120')
+    expect(slider.track.props.value.style).toBeTruthy()
+    slider.setValue([999])
+    expect(slider.channelValue.value).toBe(360)
+  })
+
+  it('cancels delegated slider updates before precision state and change events mutate', () => {
+    const emit = vi.fn()
+    const slider = setup({ channel: 'red', emit, onBeforeUpdate: (_, details) => details.cancel() })
+    slider.root.props.value['onUpdate:modelValue']([100])
+    expect(slider.channelValue.value).toBe(0)
+    expect(slider.lastChangeDetails.value).toMatchObject({ reason: 'slider', isCanceled: true })
+    expect(emit.mock.calls.map(call => call[0])).toEqual(['beforeUpdate:modelValue'])
+  })
+
+  it('cancels hue changes that serialize to the same achromatic color', () => {
+    const slider = setup({ channel: 'hue', onBeforeUpdate: (_, details) => details.cancel() })
+    slider.setValue([120])
+    expect(slider.channelValue.value).toBe(0)
+    expect(slider.modelValue.value).toBe('#000000')
+  })
+
+  it('supports controlled and ref-owned models, reactive ranges and commit events', async () => {
+    const modelValue = ref('#000000')
+    const onUpdate = vi.fn()
+    const controlled = setup({ channel: 'red', modelValue, onUpdate })
+    controlled.setValue([200])
+    expect(modelValue.value).toBe('#000000')
+    expect(onUpdate.mock.calls[0][0]).toBe('#c80000')
+    const channel = ref<'red' | 'alpha'>('red')
+    const emit = vi.fn()
+    const owned = setup({ channel, modelValue })
+    owned.setValue([255])
+    expect(modelValue.value).toBe('#ff0000')
+    channel.value = 'alpha'
+    expect(owned.max.value).toBe(100)
+    expect(owned.thumb.props.value['aria-label']).toBe('Alpha')
+    const committed = setup({ channel: 'red', emit })
+    committed.setValue([255])
+    committed.root.props.value.onValueCommit([255])
+    expect(emit.mock.calls.at(-1)).toEqual(['changeEnd', '#ff0000'])
+    await nextTick()
+  })
+})

--- a/packages/core/src/ColorSlider/useColorSlider.ts
+++ b/packages/core/src/ColorSlider/useColorSlider.ts
@@ -1,0 +1,228 @@
+import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { ColorSliderRootContext, ColorSliderRootProps } from './ColorSliderRoot.vue'
+import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
+import type { Color, ColorChannel as ColorChannelType, ColorSpace } from '@/shared/color'
+import { computed, ref, toValue, watch } from 'vue'
+import { createPartSurface, useControllableState } from '@/shared'
+import { colorToString, convertToHsb, convertToHsl, convertToRgb, getChannelName, getChannelRange, getChannelValue, getSliderBackgroundStyle, normalizeColor, setChannelValue } from '@/shared/color'
+
+type Inputs = Pick<ColorSliderRootProps, 'orientation' | 'disabled' | 'inverted' | 'channel' | 'colorSpace' | 'step' | 'modelValue' | 'defaultValue'>
+export type ColorSliderChangeReason = 'slider'
+export type UseColorSliderProps = { [K in keyof Inputs]: MaybeRefOrGetter<Inputs[K]> } & {
+  emit?: (event: any, ...args: any[]) => void
+  onBeforeUpdate?: (value: string | Color, details: ChangeEventDetails<ColorSliderChangeReason>) => void
+  onUpdate?: (value: string | Color, details: ChangeEventDetails<ColorSliderChangeReason>) => void
+}
+
+export type ColorSliderRootState = { disabled: boolean }
+export type UseColorSliderReturn = ReturnType<typeof useColorSlider>
+
+/**
+ * Headless ColorSlider state. Call in setup or an effect scope to dispose synchronization watchers.
+ * Compose SliderRoot/Track/Thumb for pointer and keyboard navigation.
+ * @experimental
+ * @lifecycle setup
+ */
+export function useColorSlider(props: UseColorSliderProps) {
+  const orientation = computed(() => toValue(props.orientation) ?? 'horizontal')
+  const disabled = computed(() => toValue(props.disabled) ?? false)
+  const inverted = computed(() => toValue(props.inverted) ?? false)
+  const channel = computed(() => toValue(props.channel))
+  const colorSpace = computed(() => toValue(props.colorSpace) ?? 'hsl')
+  const stepProp = computed(() => toValue(props.step))
+
+  // Normalize the model value to a Color object
+  const { state: modelValue, setState, lastChangeDetails, isControlled } = useControllableState<string | Color, ColorSliderChangeReason>({
+    prop: props.modelValue,
+    defaultValue: () => toValue(props.defaultValue) ?? '#000000',
+    // Distinct channel values can serialize to the same hex (grayscale hue or
+    // sub-byte precision). Each color action must still pass the cancellation gate.
+    isEqual: () => false,
+    name: 'modelValue',
+    emit: props.emit,
+    onBeforeUpdate: props.onBeforeUpdate,
+    onUpdate: props.onUpdate,
+  })
+
+  // Convert a color to the native color space for the given channel.
+  // This ensures setChannelValue/getChannelValue operate without cross-space round-trips.
+  function toNativeSpace(color: Color, ch: ColorChannelType, space: ColorSpace): Color {
+    switch (ch) {
+      case 'hue':
+      case 'lightness':
+        return convertToHsl(color)
+      case 'saturation':
+        return space === 'hsb' ? convertToHsb(color) : convertToHsl(color)
+      case 'brightness':
+        return convertToHsb(color)
+      case 'red':
+      case 'green':
+      case 'blue':
+        return convertToRgb(color)
+      case 'alpha':
+        return color
+      default:
+        return color
+    }
+  }
+
+  // Internal color ref that preserves color space precision.
+  // Convert to the channel's native space to avoid cross-space round-trips during drag.
+  const internalColor = ref<Color>(toNativeSpace(normalizeColor(modelValue.value ?? toValue(props.defaultValue) ?? '#000000'), channel.value, colorSpace.value))
+
+  // Check if a color is achromatic (hue information is lost in hex round-trips)
+  function isAchromatic(color: Color): boolean {
+    const hsl = convertToHsl(color)
+    return hsl.s === 0 || hsl.l === 0 || hsl.l >= 100
+  }
+
+  const channelRange = computed(() => getChannelRange(channel.value))
+
+  // Sync internal color from external modelValue changes (e.g. parent updates)
+  watch(() => modelValue.value, (newVal) => {
+    if (newVal == null)
+      return
+    const parsed = normalizeColor(newVal)
+    const currentHex = colorToString(internalColor.value, 'hex')
+    const newHex = colorToString(parsed, 'hex')
+    // Only update if the external value actually changed (avoid overwriting
+    // precision during our own drag updates)
+    if (currentHex !== newHex) {
+      const nativeColor = toNativeSpace(parsed, channel.value, colorSpace.value)
+      const currentChannelVal = getChannelValue(internalColor.value, channel.value)
+      const newChannelVal = getChannelValue(nativeColor, channel.value)
+
+      // Preserve this slider's channel value when:
+      // 1. Color is achromatic (hue completely lost in hex round-trip)
+      // 2. Channel value diff is within 2% of range (8-bit RGB quantization drift)
+      // We still update the rest of the color so the track gradient stays correct.
+      const range = channelRange.value.max - channelRange.value.min
+      const shouldPreserve = (channel.value === 'hue' && isAchromatic(parsed))
+        || Math.abs(currentChannelVal - newChannelVal) < range * 0.02
+
+      if (shouldPreserve) {
+        internalColor.value = setChannelValue(nativeColor, channel.value, currentChannelVal)
+      }
+      else {
+        internalColor.value = nativeColor
+      }
+    }
+  })
+
+  const color = computed(() => internalColor.value)
+
+  function setColor(newColor: Color, reason: ColorSliderChangeReason | BaseChangeReason = 'imperative-action', event?: Event) {
+    const hexString = colorToString(newColor, 'hex')
+    const changed = setState(hexString, reason, event)
+    if (!changed)
+      return false
+    internalColor.value = newColor
+    props.emit?.('update:color', newColor)
+    return true
+  }
+
+  // Get channel range
+  const min = computed(() => channelRange.value.min)
+  const max = computed(() => channelRange.value.max)
+  const step = computed(() => stepProp.value ?? channelRange.value.step)
+
+  // Current channel value
+  const channelValue = computed(() => getChannelValue(color.value, channel.value))
+
+  // Convert channel value to array format for SliderRoot
+  const sliderValue = computed(() => [channelValue.value])
+
+  function setValue(newValue: number[], reason: ColorSliderChangeReason | BaseChangeReason = 'imperative-action', event?: Event) {
+    const clamped = Math.max(min.value, Math.min(max.value, newValue[0]))
+    const newColor = setChannelValue(color.value, channel.value, clamped)
+    if (setColor(newColor, reason, event))
+      props.emit?.('change', colorToString(newColor, 'hex'))
+  }
+
+  function handleValueCommit() {
+    props.emit?.('changeEnd', colorToString(color.value, 'hex'))
+  }
+
+  const context: ColorSliderRootContext = {
+    color: computed(() => color.value) as Ref<Color>,
+    channelValue,
+    channel,
+    colorSpace,
+    orientation,
+    disabled,
+    inverted,
+    min,
+    max,
+    step,
+  }
+
+  const root = createPartSurface<ColorSliderRootState>(() => ({
+    'modelValue': sliderValue.value,
+    'onUpdate:modelValue': (value: number[]) => setValue(value, 'slider'),
+    'onValueCommit': handleValueCommit,
+    'orientation': orientation.value,
+    'disabled': disabled.value,
+    'inverted': inverted.value,
+    'min': min.value,
+    'max': max.value,
+    'step': step.value,
+  }), () => ({ disabled: disabled.value }))
+  return {
+    modelValue,
+    color,
+    disabled,
+    setColor,
+    lastChangeDetails,
+    isControlled,
+    root,
+    context,
+    track: getColorSliderTrackSurface(context),
+    thumb: getColorSliderThumbSurface(context),
+    channelValue,
+    min,
+    max,
+    step,
+    sliderValue,
+    handleValueCommit,
+    setValue,
+  }
+}
+
+export type ColorSliderTrackState = Record<string, never>
+
+/**
+ * Context-pure track gradient, layered over SliderTrack.
+ * @internal
+ */
+export function getColorSliderTrackSurface(rootContext: ColorSliderRootContext) {
+  const backgroundStyle = computed(() => {
+    return getSliderBackgroundStyle(
+      rootContext.color.value,
+      rootContext.channel.value,
+      rootContext.colorSpace.value,
+    )
+  })
+  return createPartSurface<ColorSliderTrackState>(() => ({ style: backgroundStyle.value }), () => ({}))
+}
+
+export type ColorSliderThumbState = Record<string, never>
+
+/**
+ * Context-pure channel description, layered over SliderThumb.
+ * @internal
+ */
+export function getColorSliderThumbSurface(rootContext: ColorSliderRootContext) {
+  const ariaLabel = computed(() => {
+    return getChannelName(rootContext.channel.value)
+  })
+
+  const ariaValueText = computed(() => {
+    const value = rootContext.channelValue.value
+    const channel = rootContext.channel.value
+    if (channel === 'alpha') {
+      return `${Math.round(value)}%`
+    }
+    return String(Math.round(value))
+  })
+  return createPartSurface<ColorSliderThumbState>(() => ({ 'aria-label': ariaLabel.value, 'aria-valuetext': ariaValueText.value }), () => ({}))
+}

--- a/packages/core/src/ColorSwatch/ColorSwatch.vue
+++ b/packages/core/src/ColorSwatch/ColorSwatch.vue
@@ -16,78 +16,22 @@ export interface ColorSwatchProps extends PrimitiveProps {
 </script>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import { Primitive } from '@/Primitive'
-import { colorToString, getColorContrast, getColorName, normalizeColor } from '@/shared/color'
+import { useColorSwatch } from './useColorSwatch'
 
 const props = withDefaults(defineProps<ColorSwatchProps>(), { as: 'div', color: '' })
 
-const colorString = computed(() => {
-  if (!props.color)
-    return ''
-  if (typeof props.color === 'string') {
-    return props.color
-  }
-  return colorToString(props.color, 'hex')
-})
-
-const colorObj = computed(() => {
-  if (!props.color)
-    return null
-  try {
-    return normalizeColor(props.color)
-  }
-  catch {
-    return null
-  }
-})
-
-const alpha = computed(() => colorObj.value?.alpha ?? 0)
-const isNoColor = computed(() => !props.color || alpha.value <= 0)
-
-const label = computed(() => {
-  if (props.label)
-    return props.label
-
-  // Match React Aria: transparent colors get "transparent" label
-  if (!colorObj.value || colorObj.value.alpha === 0)
-    return 'transparent'
-
-  try {
-    return getColorName(colorString.value)
-  }
-  catch {
-    return colorString.value || 'transparent'
-  }
-})
-
-const colorContrast = computed(() => {
-  try {
-    return getColorContrast(colorString.value)
-  }
-  catch {
-    if (import.meta.env.DEV) {
-      console.warn(`WARNING: Unable to resolve contrast color for "${colorString.value}".
-           Please check that the color provided is a valid hex color.`)
-    }
-    return undefined
-  }
+const { root, colorString, alpha } = useColorSwatch({
+  color: () => props.color,
+  label: () => props.label,
 })
 </script>
 
 <template>
   <Primitive
-    role="img"
-    :aria-label="label"
-    aria-roledescription="color swatch"
     :as-child="asChild"
     :as="as"
-    :data-color-contrast="colorContrast"
-    :data-no-color="isNoColor ? '' : undefined"
-    :style="{
-      '--reka-color-swatch-color': colorString,
-      '--reka-color-swatch-alpha': String(alpha),
-    }"
+    v-bind="root.attrs.value"
   >
     <slot
       :color="colorString"

--- a/packages/core/src/ColorSwatch/colors.characterization.test.ts
+++ b/packages/core/src/ColorSwatch/colors.characterization.test.ts
@@ -1,0 +1,102 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { h } from 'vue'
+import { ColorAreaArea, ColorAreaRoot, ColorAreaThumb } from '@/ColorArea'
+import { ColorFieldInput, ColorFieldRoot } from '@/ColorField'
+import { ColorSliderRoot, ColorSliderThumb, ColorSliderTrack } from '@/ColorSlider'
+import { ColorSwatch } from '@/ColorSwatch'
+import { ColorSwatchPickerItem, ColorSwatchPickerRoot } from '@/ColorSwatchPicker'
+
+vi.stubGlobal('ResizeObserver', class { observe() {} unobserve() {} disconnect() {} })
+
+describe('color shell characterization', () => {
+  it('chains area keyboard listeners and preserves controlled values and form channels', async () => {
+    const listener = vi.fn()
+    const update = vi.fn()
+    const wrapper = mount(() => h('form', [h(ColorAreaRoot, {
+      'modelValue': '#ff0000',
+      'xName': 'hue',
+      'yName': 'saturation',
+      'onUpdate:modelValue': update,
+    }, () => h(ColorAreaArea, { onKeydown: listener }, () => h(ColorAreaThumb)))]))
+    await wrapper.find('[role=application]').trigger('keydown', { key: 'ArrowRight' })
+    expect(listener).toHaveBeenCalledOnce()
+    expect(update.mock.calls[0][0]).toMatch(/^#/)
+    expect(wrapper.findAll('input').map(i => i.attributes('name'))).toEqual(['hue', 'saturation'])
+    expect(wrapper.find('[role=slider]').attributes('aria-label')).toBe('Hue, Saturation')
+    wrapper.unmount()
+  })
+
+  it('chains field input listeners and preserves disabled/readonly and form bindings', async () => {
+    const listener = vi.fn()
+    const wrapper = mount(() => h('form', [h(ColorFieldRoot, { name: 'color', readonly: true, disabled: true }, () => h(ColorFieldInput, { id: 'color', onInput: listener }))]))
+    const input = wrapper.find('#color')
+    input.element.dispatchEvent(new Event('input', { bubbles: true }))
+    expect(listener).toHaveBeenCalledOnce()
+    expect(input.attributes()).toMatchObject({ 'data-disabled': '', 'data-readonly': '', 'readonly': '', 'disabled': '' })
+    expect(wrapper.find('input[name=color]').element.value).toBe('#000000')
+    wrapper.unmount()
+  })
+
+  it('chains slider keyboard listeners and retains channel labels', async () => {
+    const listener = vi.fn()
+    const update = vi.fn()
+    const wrapper = mount(() => h(ColorSliderRoot, { 'channel': 'red', 'modelValue': '#000000', 'onUpdate:modelValue': update }, () => [h(ColorSliderTrack), h(ColorSliderThumb, { onKeydown: listener })]))
+    await wrapper.find('[role=slider]').trigger('keydown', { key: 'ArrowRight' })
+    expect(listener).toHaveBeenCalledOnce()
+    expect(update.mock.calls[0][0]).toBe('#010000')
+    expect(wrapper.find('[role=slider]').attributes('aria-label')).toBe('Red')
+    wrapper.unmount()
+  })
+
+  it('keeps swatch overrides and transparency state', () => {
+    const wrapper = mount(ColorSwatch, { props: { color: '#00000000', label: 'Clear' } })
+    expect(wrapper.attributes()).toMatchObject({ 'role': 'img', 'aria-label': 'Clear', 'data-no-color': '' })
+    wrapper.unmount()
+  })
+
+  it('chains picker listeners and emits controlled selection', async () => {
+    const listener = vi.fn()
+    const update = vi.fn()
+    const wrapper = mount(() => h(ColorSwatchPickerRoot, { 'modelValue': '#ff0000', 'onUpdate:modelValue': update }, () => h(ColorSwatchPickerItem, { value: '#00ff00', onClick: listener })))
+    await wrapper.find('[role=option]').trigger('click')
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(update).toHaveBeenCalled()
+    expect(update.mock.calls[0][0]).toBe('#00ff00')
+    expect(wrapper.find('[role=option]').attributes('data-color')).toBe('#00ff00')
+    wrapper.unmount()
+  })
+})
+
+// These are additive model-contract checks; the characterization above ran before extraction.
+describe('color shell cancellable updates', () => {
+  it.each(['area', 'field', 'slider', 'picker'])('cancels %s updates at the shell boundary', async (family) => {
+    const before = vi.fn((_: unknown, details: { cancel: () => void }) => details.cancel())
+    const update = vi.fn()
+    const colorUpdate = vi.fn()
+    const modelProps = {
+      'modelValue': '#000000',
+      'onBeforeUpdate:modelValue': before,
+      'onUpdate:modelValue': update,
+      'onUpdate:color': colorUpdate,
+    }
+    const wrapper = mount(() => {
+      switch (family) {
+        case 'area': return h(ColorAreaRoot, { ...modelProps, xChannel: 'red', yChannel: 'green' }, () => h(ColorAreaArea, {}, () => h(ColorAreaThumb)))
+        case 'field': return h(ColorFieldRoot, modelProps, () => h(ColorFieldInput))
+        case 'slider': return h(ColorSliderRoot, { ...modelProps, channel: 'red' }, () => h(ColorSliderThumb))
+        default: return h(ColorSwatchPickerRoot, modelProps, () => h(ColorSwatchPickerItem, { value: '#ffffff' }))
+      }
+    })
+    if (family === 'picker')
+      await wrapper.find('[role=option]').trigger('click')
+    else if (family === 'field')
+      await wrapper.find('input').trigger('keydown', { key: 'ArrowUp' })
+    else
+      await wrapper.find(family === 'area' ? '[role=application]' : '[role=slider]').trigger('keydown', { key: 'ArrowRight' })
+    expect(before).toHaveBeenCalledOnce()
+    expect(update).not.toHaveBeenCalled()
+    expect(colorUpdate).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})

--- a/packages/core/src/ColorSwatch/colors.characterization.test.ts
+++ b/packages/core/src/ColorSwatch/colors.characterization.test.ts
@@ -60,7 +60,7 @@ describe('color shell characterization', () => {
     const update = vi.fn()
     const wrapper = mount(() => h(ColorSwatchPickerRoot, { 'modelValue': '#ff0000', 'onUpdate:modelValue': update }, () => h(ColorSwatchPickerItem, { value: '#00ff00', onClick: listener })))
     await wrapper.find('[role=option]').trigger('click')
-    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener).toHaveBeenCalledOnce()
     expect(update).toHaveBeenCalled()
     expect(update.mock.calls[0][0]).toBe('#00ff00')
     expect(wrapper.find('[role=option]').attributes('data-color')).toBe('#00ff00')

--- a/packages/core/src/ColorSwatch/index.ts
+++ b/packages/core/src/ColorSwatch/index.ts
@@ -2,3 +2,6 @@ export {
   default as ColorSwatch,
   type ColorSwatchProps,
 } from './ColorSwatch.vue'
+
+export { useColorSwatch } from './useColorSwatch'
+export type { ColorSwatchState, UseColorSwatchProps, UseColorSwatchReturn } from './useColorSwatch'

--- a/packages/core/src/ColorSwatch/useColorSwatch.test.ts
+++ b/packages/core/src/ColorSwatch/useColorSwatch.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useColorSwatch } from './useColorSwatch'
+
+describe('useColorSwatch', () => {
+  it('derives reactive accessibility and semantic state separately from props', () => {
+    const color = ref('#ff0000')
+    const label = ref<string>()
+    const swatch = useColorSwatch({ color, label })
+    expect(swatch.root.props.value.role).toBe('img')
+    expect(swatch.root.props.value).not.toHaveProperty('data-color-contrast')
+    expect(swatch.root.attrs.value['data-color-contrast']).toBeTruthy()
+    color.value = '#00000000'
+    expect(swatch.alpha.value).toBe(0)
+    expect(swatch.root.attrs.value['data-no-color']).toBe('')
+    expect(swatch.root.props.value['aria-label']).toBe('transparent')
+    label.value = 'Clear'
+    expect(swatch.root.props.value['aria-label']).toBe('Clear')
+  })
+
+  it('supports color objects, empty values and invalid color fallback', () => {
+    const swatch = useColorSwatch({ color: { space: 'rgb', r: 255, g: 0, b: 0, alpha: 1 } })
+    expect(swatch.colorString.value).toBe('#ff0000')
+    expect(useColorSwatch().label.value).toBe('transparent')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const invalid = useColorSwatch({ color: 'invalid' })
+    expect(invalid.root.attrs.value['data-no-color']).toBe('')
+    expect(invalid.label.value).toBe('transparent')
+    warn.mockRestore()
+  })
+})

--- a/packages/core/src/ColorSwatch/useColorSwatch.test.ts
+++ b/packages/core/src/ColorSwatch/useColorSwatch.test.ts
@@ -18,6 +18,23 @@ describe('useColorSwatch', () => {
     expect(swatch.root.props.value['aria-label']).toBe('Clear')
   })
 
+  it('does not warn for omitted or empty colors but still warns for invalid colors', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      for (const color of [undefined, '']) {
+        const swatch = useColorSwatch({ color })
+        expect(swatch.root.attrs.value['data-no-color']).toBe('')
+        expect(swatch.colorContrast.value).toBeUndefined()
+      }
+      expect(warn).not.toHaveBeenCalled()
+      expect(useColorSwatch({ color: 'invalid' }).colorContrast.value).toBeUndefined()
+      expect(warn).toHaveBeenCalledOnce()
+    }
+    finally {
+      warn.mockRestore()
+    }
+  })
+
   it('supports color objects, empty values and invalid color fallback', () => {
     const swatch = useColorSwatch({ color: { space: 'rgb', r: 255, g: 0, b: 0, alpha: 1 } })
     expect(swatch.colorString.value).toBe('#ff0000')

--- a/packages/core/src/ColorSwatch/useColorSwatch.ts
+++ b/packages/core/src/ColorSwatch/useColorSwatch.ts
@@ -59,6 +59,8 @@ export function useColorSwatch(props: UseColorSwatchProps = {}) {
   })
 
   const colorContrast = computed(() => {
+    if (!colorString.value)
+      return undefined
     try {
       return getColorContrast(colorString.value)
     }

--- a/packages/core/src/ColorSwatch/useColorSwatch.ts
+++ b/packages/core/src/ColorSwatch/useColorSwatch.ts
@@ -1,0 +1,83 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Color } from '@/shared/color'
+import { computed, toValue } from 'vue'
+import { createPartSurface } from '@/shared'
+import { colorToString, getColorContrast, getColorName, normalizeColor } from '@/shared/color'
+
+export interface UseColorSwatchProps {
+  color?: MaybeRefOrGetter<string | Color | undefined>
+  label?: MaybeRefOrGetter<string | undefined>
+}
+export type ColorSwatchState = { colorContrast: string | undefined, noColor: boolean }
+export type UseColorSwatchReturn = ReturnType<typeof useColorSwatch>
+
+/**
+ * Headless color swatch styling and accessible description.
+ * @experimental
+ * @lifecycle pure
+ */
+export function useColorSwatch(props: UseColorSwatchProps = {}) {
+  const color = computed(() => toValue(props.color))
+  const customLabel = computed(() => toValue(props.label))
+  const colorString = computed(() => {
+    if (!color.value)
+      return ''
+    if (typeof color.value === 'string') {
+      return color.value
+    }
+    return colorToString(color.value, 'hex')
+  })
+
+  const colorObj = computed(() => {
+    if (!color.value)
+      return null
+    try {
+      return normalizeColor(color.value)
+    }
+    catch {
+      return null
+    }
+  })
+
+  const alpha = computed(() => colorObj.value?.alpha ?? 0)
+  const isNoColor = computed(() => !color.value || alpha.value <= 0)
+
+  const label = computed(() => {
+    if (customLabel.value)
+      return customLabel.value
+
+    // Match React Aria: transparent colors get "transparent" label
+    if (!colorObj.value || colorObj.value.alpha === 0)
+      return 'transparent'
+
+    try {
+      return getColorName(colorString.value)
+    }
+    catch {
+      return colorString.value || 'transparent'
+    }
+  })
+
+  const colorContrast = computed(() => {
+    try {
+      return getColorContrast(colorString.value)
+    }
+    catch {
+      if (import.meta.env.DEV) {
+        console.warn(`WARNING: Unable to resolve contrast color for "${colorString.value}".
+             Please check that the color provided is a valid hex color.`)
+      }
+      return undefined
+    }
+  })
+  const root = createPartSurface<ColorSwatchState>(() => ({
+    'role': 'img',
+    'aria-label': label.value,
+    'aria-roledescription': 'color swatch',
+    'style': {
+      '--reka-color-swatch-color': colorString.value,
+      '--reka-color-swatch-alpha': String(alpha.value),
+    },
+  }), () => ({ colorContrast: colorContrast.value, noColor: isNoColor.value }))
+  return { colorString, color: colorObj, alpha, isNoColor, label, colorContrast, root }
+}

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItem.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItem.vue
@@ -22,9 +22,9 @@ export const [injectColorSwatchPickerItemContext, provideColorSwatchPickerItemCo
 </script>
 
 <script setup lang="ts">
-import { computed, toRefs } from 'vue'
+import { mergeProps, toRefs } from 'vue'
 import { ListboxItem } from '@/Listbox'
-import { getColorName } from '@/shared/color'
+import { getColorSwatchPickerItemSurface } from './useColorSwatchPicker'
 
 const props = defineProps<ColorSwatchPickerItemProps>()
 
@@ -34,14 +34,7 @@ const { value } = toRefs(props)
 
 const forwarded = useForwardPropsEmits(props, emits)
 
-const colorLabel = computed(() => {
-  try {
-    return getColorName(value.value)
-  }
-  catch {
-    return value.value
-  }
-})
+const item = getColorSwatchPickerItemSurface(value)
 
 provideColorSwatchPickerItemContext({
   color: value,
@@ -50,10 +43,8 @@ provideColorSwatchPickerItemContext({
 
 <template>
   <ListboxItem
-    v-bind="forwarded"
-    :aria-label="colorLabel"
-    :data-color="value"
-    :style="{ '--reka-color-swatch-picker-item-color': value }"
+    v-bind="mergeProps(forwarded, item.attrs.value)"
+    :value="value"
   >
     <slot />
   </ListboxItem>

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItemIndicator.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItemIndicator.vue
@@ -5,13 +5,16 @@ export interface ColorSwatchPickerItemIndicatorProps extends ListboxItemIndicato
 </script>
 
 <script setup lang="ts">
+import { mergeProps } from 'vue'
 import { ListboxItemIndicator } from '@/Listbox'
+import { getColorSwatchPickerItemIndicatorSurface } from './useColorSwatchPicker'
 
 const props = defineProps<ColorSwatchPickerItemIndicatorProps>()
+const part = getColorSwatchPickerItemIndicatorSurface()
 </script>
 
 <template>
-  <ListboxItemIndicator v-bind="props">
+  <ListboxItemIndicator v-bind="mergeProps(props, part.attrs.value)">
     <slot />
   </ListboxItemIndicator>
 </template>

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItemSwatch.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerItemSwatch.vue
@@ -5,17 +5,19 @@ export interface ColorSwatchPickerItemSwatchProps extends Omit<ColorSwatchProps,
 </script>
 
 <script setup lang="ts">
+import { mergeProps } from 'vue'
 import { ColorSwatch } from '@/ColorSwatch'
 import { injectColorSwatchPickerItemContext } from './ColorSwatchPickerItem.vue'
+import { getColorSwatchPickerItemSwatchSurface } from './useColorSwatchPicker'
 
 const props = defineProps<ColorSwatchPickerItemSwatchProps>()
 
 const colorSwatchPickerItemContext = injectColorSwatchPickerItemContext()
+const part = getColorSwatchPickerItemSwatchSurface(colorSwatchPickerItemContext)
 </script>
 
 <template>
   <ColorSwatch
-    v-bind="props"
-    :color="colorSwatchPickerItemContext.color.value"
+    v-bind="mergeProps(props, part.attrs.value)"
   />
 </template>

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
+import type { ColorSwatchPickerChangeReason } from './useColorSwatchPicker'
 import type { ListboxRootEmits, ListboxRootProps } from '@/Listbox'
-import { useVModel } from '@vueuse/core'
+import type { ChangeEventDetails } from '@/shared'
+import type { AcceptableValue } from '@/shared/types'
 import { useForwardPropsEmits } from '@/shared'
 
 export interface ColorSwatchPickerRootProps extends Omit<ListboxRootProps, 'by'> {
@@ -8,11 +10,16 @@ export interface ColorSwatchPickerRootProps extends Omit<ListboxRootProps, 'by'>
   modelValue?: string | string[]
 }
 
-export type ColorSwatchPickerRootEmits = ListboxRootEmits
+export type ColorSwatchPickerRootEmits = Omit<ListboxRootEmits, 'update:modelValue'> & {
+  'beforeUpdate:modelValue': [value: string | string[] | undefined, details: ChangeEventDetails<ColorSwatchPickerChangeReason>]
+  'update:modelValue': [value: AcceptableValue, details: ChangeEventDetails<ColorSwatchPickerChangeReason>]
+}
 </script>
 
 <script setup lang="ts">
+import { computed, mergeProps } from 'vue'
 import { ListboxContent, ListboxRoot } from '@/Listbox'
+import { useColorSwatchPicker } from './useColorSwatchPicker'
 
 const props = withDefaults(defineProps<ColorSwatchPickerRootProps>(), {
   as: 'div',
@@ -25,19 +32,26 @@ const props = withDefaults(defineProps<ColorSwatchPickerRootProps>(), {
 
 const emits = defineEmits<ColorSwatchPickerRootEmits>()
 
-const modelValue = useVModel(props, 'modelValue', emits, {
-  defaultValue: props.defaultValue ?? (props.multiple ? [] : ''),
-  // Cast required for VueUse's passive option type; enables passive sync when modelValue is undefined
-  passive: (props.modelValue === undefined) as false,
+const { modelValue, root } = useColorSwatchPicker({
+  modelValue: () => props.modelValue,
+  defaultValue: () => props.defaultValue,
+  multiple: () => props.multiple,
+  disabled: () => props.disabled,
+  selectionBehavior: () => props.selectionBehavior,
+  emit: emits,
 })
 
-const forwarded = useForwardPropsEmits(props, emits)
+// The model has one update channel so cancellation cannot be bypassed by forwarding.
+const forwardedProps = useForwardPropsEmits(props, emits)
+const forwarded = computed(() => {
+  const { modelValue, defaultValue, 'onUpdate:modelValue': update, 'onBeforeUpdate:modelValue': beforeUpdate, ...rest } = forwardedProps.value
+  return rest
+})
 </script>
 
 <template>
   <ListboxRoot
-    v-bind="forwarded"
-    v-model="modelValue"
+    v-bind="mergeProps(forwarded, root.attrs.value)"
     as-child
   >
     <ListboxContent

--- a/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
+++ b/packages/core/src/ColorSwatchPicker/ColorSwatchPickerRoot.vue
@@ -11,7 +11,9 @@ export interface ColorSwatchPickerRootProps extends Omit<ListboxRootProps, 'by'>
 }
 
 export type ColorSwatchPickerRootEmits = Omit<ListboxRootEmits, 'update:modelValue'> & {
+  /** Event handler called before the color value changes; `details.cancel()` vetoes the change. */
   'beforeUpdate:modelValue': [value: string | string[] | undefined, details: ChangeEventDetails<ColorSwatchPickerChangeReason>]
+  /** Event handler called when the color value changes. */
   'update:modelValue': [value: AcceptableValue, details: ChangeEventDetails<ColorSwatchPickerChangeReason>]
 }
 </script>

--- a/packages/core/src/ColorSwatchPicker/index.ts
+++ b/packages/core/src/ColorSwatchPicker/index.ts
@@ -15,3 +15,6 @@ export {
   type ColorSwatchPickerRootEmits,
   type ColorSwatchPickerRootProps,
 } from './ColorSwatchPickerRoot.vue'
+
+export { useColorSwatchPicker } from './useColorSwatchPicker'
+export type { ColorSwatchPickerChangeReason, ColorSwatchPickerItemIndicatorState, ColorSwatchPickerItemState, ColorSwatchPickerItemSwatchState, ColorSwatchPickerRootState, UseColorSwatchPickerProps, UseColorSwatchPickerReturn } from './useColorSwatchPicker'

--- a/packages/core/src/ColorSwatchPicker/useColorSwatchPicker.test.ts
+++ b/packages/core/src/ColorSwatchPicker/useColorSwatchPicker.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useColorSwatchPicker } from './useColorSwatchPicker'
+
+describe('useColorSwatchPicker', () => {
+  it('supports single and multiple selection with reactive disabled and selection behavior', () => {
+    const disabled = ref(false)
+    const selectionBehavior = ref<'toggle' | 'replace'>('toggle')
+    const picker = useColorSwatchPicker({ multiple: true, disabled, selectionBehavior })
+    picker.select('#ff0000')
+    picker.select('#00ff00')
+    expect(picker.modelValue.value).toEqual(['#ff0000', '#00ff00'])
+    picker.select('#ff0000')
+    expect(picker.modelValue.value).toEqual(['#00ff00'])
+    disabled.value = true
+    picker.select('#ff0000')
+    expect(picker.modelValue.value).toEqual(['#00ff00'])
+    disabled.value = false
+    selectionBehavior.value = 'replace'
+    picker.select('#ff0000')
+    expect(picker.modelValue.value).toEqual(['#ff0000'])
+    const single = useColorSwatchPicker()
+    single.select('#ff0000')
+    single.select('#ff0000')
+    expect(single.modelValue.value).toBeUndefined()
+  })
+
+  it('cancels delegated selection and preserves controlled ownership', () => {
+    const onUpdate = vi.fn()
+    const picker = useColorSwatchPicker({ onUpdate, onBeforeUpdate: (_, details) => details.cancel() })
+    picker.root.props.value['onUpdate:modelValue']('#ff0000')
+    expect(picker.modelValue.value).toBe('')
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(picker.lastChangeDetails.value).toMatchObject({ reason: 'selection', isCanceled: true })
+    const modelValue = ref('#000000')
+    const controlled = useColorSwatchPicker({ modelValue, onUpdate })
+    controlled.select('#ffffff')
+    expect(modelValue.value).toBe('#000000')
+    expect(onUpdate.mock.calls[0][0]).toBe('#ffffff')
+    const owned = useColorSwatchPicker({ modelValue })
+    owned.select('#ffffff')
+    expect(modelValue.value).toBe('#ffffff')
+  })
+
+  it('shares reactive item and swatch surfaces, including invalid label fallback', () => {
+    const picker = useColorSwatchPicker()
+    const value = ref('#ff0000')
+    const item = picker.getItemSurface(value)
+    const swatch = picker.getItemSwatchSurface(value)
+    expect(item.attrs.value['data-color']).toBe('#ff0000')
+    expect(item.props.value).not.toHaveProperty('data-color')
+    expect(swatch.props.value.color).toBe('#ff0000')
+    value.value = 'invalid'
+    expect(item.props.value['aria-label']).toBe('invalid')
+    expect(swatch.props.value.color).toBe('invalid')
+  })
+})

--- a/packages/core/src/ColorSwatchPicker/useColorSwatchPicker.ts
+++ b/packages/core/src/ColorSwatchPicker/useColorSwatchPicker.ts
@@ -1,0 +1,117 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { ColorSwatchPickerItemContext } from './ColorSwatchPickerItem.vue'
+import type { BaseChangeReason, ChangeEventDetails } from '@/shared'
+import { computed, toValue } from 'vue'
+import { createPartSurface, useControllableState } from '@/shared'
+import { getColorName } from '@/shared/color'
+
+export type ColorSwatchPickerChangeReason = 'selection'
+export type ColorSwatchPickerRootState = Record<string, never>
+export type ColorSwatchPickerItemState = { color: string }
+export type ColorSwatchPickerItemIndicatorState = Record<string, never>
+export type ColorSwatchPickerItemSwatchState = Record<string, never>
+
+export interface UseColorSwatchPickerProps {
+  modelValue?: MaybeRefOrGetter<string | string[] | undefined>
+  defaultValue?: MaybeRefOrGetter<string | string[] | undefined>
+  multiple?: MaybeRefOrGetter<boolean | undefined>
+  disabled?: MaybeRefOrGetter<boolean | undefined>
+  selectionBehavior?: MaybeRefOrGetter<'toggle' | 'replace' | undefined>
+  emit?: (event: any, ...args: any[]) => void
+  onBeforeUpdate?: (value: string | string[] | undefined, details: ChangeEventDetails<ColorSwatchPickerChangeReason>) => void
+  onUpdate?: (value: string | string[] | undefined, details: ChangeEventDetails<ColorSwatchPickerChangeReason>) => void
+}
+
+export type UseColorSwatchPickerReturn = ReturnType<typeof useColorSwatchPicker>
+
+/**
+ * Headless picker model and color-specific part surfaces. Compose ListboxRoot,
+ * ListboxContent, ListboxItem and ListboxItemIndicator for collection registration,
+ * selection interactions, roving focus, keyboard navigation and indicator presence.
+ * @experimental
+ * @lifecycle pure
+ */
+export function useColorSwatchPicker(props: UseColorSwatchPickerProps = {}) {
+  const multiple = computed(() => toValue(props.multiple) ?? false)
+  const disabled = computed(() => toValue(props.disabled) ?? false)
+  const { state: modelValue, setState, lastChangeDetails, isControlled } = useControllableState<string | string[] | undefined, ColorSwatchPickerChangeReason>({
+    prop: props.modelValue,
+    defaultValue: () => toValue(props.defaultValue) ?? (multiple.value ? [] : ''),
+    name: 'modelValue',
+    emit: props.emit,
+    onBeforeUpdate: props.onBeforeUpdate,
+    onUpdate: props.onUpdate,
+  })
+
+  function setValue(value: string | string[] | undefined, reason: ColorSwatchPickerChangeReason | BaseChangeReason = 'imperative-action', event?: Event) {
+    return setState(value, reason, event)
+  }
+
+  function select(value: string, event?: Event) {
+    if (disabled.value)
+      return false
+    const toggle = toValue(props.selectionBehavior) !== 'replace'
+    if (multiple.value) {
+      const values = Array.isArray(modelValue.value) ? modelValue.value : []
+      return setValue(toggle ? values.includes(value) ? values.filter(v => v !== value) : [...values, value] : [value], 'selection', event)
+    }
+    return setValue(toggle && modelValue.value === value ? undefined : value, 'selection', event)
+  }
+
+  const root = createPartSurface<ColorSwatchPickerRootState>(() => ({
+    'modelValue': modelValue.value,
+    'multiple': multiple.value,
+    'disabled': disabled.value,
+    'selectionBehavior': toValue(props.selectionBehavior) ?? 'toggle',
+    'onUpdate:modelValue': (value: string | string[] | undefined) => setValue(value, 'selection'),
+  }), () => ({}))
+
+  return {
+    modelValue,
+    multiple,
+    disabled,
+    setValue,
+    select,
+    lastChangeDetails,
+    isControlled,
+    root,
+    getItemSurface: getColorSwatchPickerItemSurface,
+    getItemSwatchSurface: (color: MaybeRefOrGetter<string>) => getColorSwatchPickerItemSwatchSurface({ color: computed(() => toValue(color)) }),
+    itemIndicator: getColorSwatchPickerItemIndicatorSurface(),
+  }
+}
+
+/**
+ * Context-pure color metadata, layered over ListboxItem.
+ * @internal
+ */
+export function getColorSwatchPickerItemSurface(value: MaybeRefOrGetter<string>) {
+  const colorLabel = computed(() => {
+    try {
+      return getColorName(toValue(value))
+    }
+    catch {
+      return toValue(value)
+    }
+  })
+  return createPartSurface<ColorSwatchPickerItemState>(() => ({
+    'aria-label': colorLabel.value,
+    'style': { '--reka-color-swatch-picker-item-color': toValue(value) },
+  }), () => ({ color: toValue(value) }))
+}
+
+/**
+ * Forward the item color; ColorSwatch owns styling and accessibility.
+ * @internal
+ */
+export function getColorSwatchPickerItemSwatchSurface(context: ColorSwatchPickerItemContext) {
+  return createPartSurface<ColorSwatchPickerItemSwatchState>(() => ({ color: context.color.value }), () => ({}))
+}
+
+/**
+ * Selection and presence are supplied by ListboxItemIndicator.
+ * @internal
+ */
+export function getColorSwatchPickerItemIndicatorSurface() {
+  return createPartSurface<ColorSwatchPickerItemIndicatorState>(() => ({}), () => ({}))
+}

--- a/packages/core/src/Listbox/Listbox.test.ts
+++ b/packages/core/src/Listbox/Listbox.test.ts
@@ -538,3 +538,32 @@ describe('given Listbox in a form', async () => {
     })
   })
 })
+
+describe('listboxItem attribute forwarding', () => {
+  it.each([false, true])('chains consumer listeners once (asChild=%s) and preserves attributes', async (asChild) => {
+    const click = vi.fn()
+    const select = vi.fn()
+    const wrapper = mount(() => h(ListboxRoot, {}, () => h(ListboxContent, {}, () => h(ListboxItem, {
+      'value': 'red',
+      asChild,
+      'onClick': click,
+      'onSelect': select,
+      'aria-label': 'Red',
+      'class': 'custom-option',
+      'style': { color: 'red' },
+    }, () => asChild ? h('button', {}, 'Red') : 'Red'))))
+    try {
+      const item = wrapper.find('[role=option]')
+      await item.trigger('click')
+      expect(click).toHaveBeenCalledOnce()
+      expect(select).toHaveBeenCalledOnce()
+      expect(item.attributes('aria-selected')).toBe('true')
+      expect(item.attributes('aria-label')).toBe('Red')
+      expect(item.classes()).toContain('custom-option')
+      expect(item.attributes('style')).toContain('color: red')
+    }
+    finally {
+      wrapper.unmount()
+    }
+  })
+})

--- a/packages/core/src/Listbox/ListboxItem.vue
+++ b/packages/core/src/Listbox/ListboxItem.vue
@@ -34,6 +34,8 @@ import { Primitive } from '..'
 import { injectListboxRootContext } from './ListboxRoot.vue'
 import { valueComparator } from './utils'
 
+defineOptions({ inheritAttrs: false })
+
 const props = withDefaults(defineProps<ListboxItemProps<T>>(), {
   as: 'div',
 })


### PR DESCRIPTION
Progress on #2723

Refactored all "Colors" components to new architecture, following current recepies:
- Implemented five exported composables: `useColorArea`, `useColorField`, `useColorSlider`, `useColorSwatch` and `useColorSwatchPicker`.
- Added shared part surfaces, cancellable updates, thin Vue shells, etc.
- Added test
- Updated docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added experimental headless composables for color areas, fields, sliders, swatches, and swatch pickers.
  - Added callbacks for color updates, changes, and completed changes without requiring component event emitters.
  - Added cancellable model updates through `beforeUpdate:modelValue`.
  - Expanded accessibility attributes, state handling, and public APIs across color controls.
  - Improved precision handling for fractional and equivalent color values.

- **Documentation**
  - Added usage guides and examples covering the new composables, callbacks, read-only state, component integration, and advanced control surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->