### PR TITLE
fix(Drawer): apply initialFocus and finalFocus on the content

### DIFF
--- a/docs/content/meta/DrawerContent.md
+++ b/docs/content/meta/DrawerContent.md
@@ -25,7 +25,8 @@
     'name': 'finalFocus',
     'description': '<p>Final focus target when the drawer closes.</p>\n<ul>\n<li><code>true</code> / default: focus the trigger</li>\n<li><code>false</code>: do not restore focus</li>\n<li>element ref: focus that specific element</li>\n</ul>\n',
     'type': 'boolean | HTMLElement | null',
-    'required': false
+    'required': false,
+    'default': 'true'
   },
   {
     'name': 'forceMount',
@@ -37,7 +38,8 @@
     'name': 'initialFocus',
     'description': '<p>Initial focus target when the drawer opens.</p>\n<ul>\n<li><code>true</code> / default: focus the first focusable element inside</li>\n<li><code>false</code>: do not focus anything</li>\n<li>element ref: focus that specific element</li>\n</ul>\n',
     'type': 'boolean | HTMLElement | null',
-    'required': false
+    'required': false,
+    'default': 'true'
   }
 ]" />
 
@@ -84,9 +86,9 @@
 | `as` | The element or component this component should render as. Can be overwritten by asChild. | `AsTag \| Component` | No | `"div"` |
 | `asChild` | Change the default rendered element for the one passed as a child, merging their props and behavior. Read our Composition guide for more details. | `boolean` | No | - |
 | `disableOutsidePointerEvents` | When true, hover/focus/click interactions will be disabled on elements outside the DismissableLayer. Users will need to click twice on outside elements to interact with them: once to close the DismissableLayer, and again to trigger the element. | `boolean` | No | - |
-| `finalFocus` | Final focus target when the drawer closes.  true / default: focus the trigger false: do not restore focus element ref: focus that specific element | `boolean \| HTMLElement \| null` | No | - |
+| `finalFocus` | Final focus target when the drawer closes.  true / default: focus the trigger false: do not restore focus element ref: focus that specific element | `boolean \| HTMLElement \| null` | No | `true` |
 | `forceMount` |  | `boolean` | No | - |
-| `initialFocus` | Initial focus target when the drawer opens.  true / default: focus the first focusable element inside false: do not focus anything element ref: focus that specific element | `boolean \| HTMLElement \| null` | No | - |
+| `initialFocus` | Initial focus target when the drawer opens.  true / default: focus the first focusable element inside false: do not focus anything element ref: focus that specific element | `boolean \| HTMLElement \| null` | No | `true` |
 
 **Events**
 

--- a/packages/core/src/Drawer/Drawer.test.ts
+++ b/packages/core/src/Drawer/Drawer.test.ts
@@ -247,8 +247,36 @@ describe('given a Drawer with focus props', () => {
     `,
   })
 
+  const DrawerWithoutFocusProps = defineComponent({
+    components: { DrawerRoot, DrawerTrigger, DrawerPortal, DrawerContent, DrawerTitle, DrawerClose },
+    template: `
+      <DrawerRoot>
+        <DrawerTrigger>Open</DrawerTrigger>
+        <DrawerPortal>
+          <DrawerContent>
+            <DrawerTitle>T</DrawerTitle>
+            <input data-testid="field">
+            <DrawerClose>Close</DrawerClose>
+          </DrawerContent>
+        </DrawerPortal>
+      </DrawerRoot>
+    `,
+  })
+
   beforeEach(() => {
     document.body.innerHTML = ''
+  })
+
+  it('keeps the default focus behaviour when neither prop is bound', async () => {
+    const user = userEvent.setup()
+    const { getByText, getByTestId } = render(DrawerWithoutFocusProps)
+    const trigger = getByText('Open')
+    await user.click(trigger)
+    await nextTick()
+    expect(document.activeElement).toBe(getByTestId('field'))
+    await user.click(getByText('Close'))
+    await nextTick()
+    expect(document.activeElement).toBe(trigger)
   })
 
   it('focuses the first tabbable element on open by default', async () => {

--- a/packages/core/src/Drawer/Drawer.test.ts
+++ b/packages/core/src/Drawer/Drawer.test.ts
@@ -222,3 +222,92 @@ describe('update:open change event details', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false, { reason: 'trigger-press' })
   })
 })
+
+describe('given a Drawer with focus props', () => {
+  const DrawerWithFocusProps = defineComponent({
+    components: { DrawerRoot, DrawerTrigger, DrawerPortal, DrawerContent, DrawerTitle, DrawerClose },
+    props: {
+      initialFocus: { type: [Boolean, Object], default: undefined },
+      finalFocus: { type: [Boolean, Object], default: undefined },
+    },
+    template: `
+      <div>
+        <button data-testid="outside">Outside</button>
+        <DrawerRoot>
+          <DrawerTrigger>Open</DrawerTrigger>
+          <DrawerPortal>
+            <DrawerContent :initial-focus="initialFocus" :final-focus="finalFocus">
+              <DrawerTitle>T</DrawerTitle>
+              <input data-testid="field">
+              <DrawerClose>Close</DrawerClose>
+            </DrawerContent>
+          </DrawerPortal>
+        </DrawerRoot>
+      </div>
+    `,
+  })
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('focuses the first tabbable element on open by default', async () => {
+    const user = userEvent.setup()
+    const { getByText, getByTestId } = render(DrawerWithFocusProps)
+    await user.click(getByText('Open'))
+    await nextTick()
+    expect(document.activeElement).toBe(getByTestId('field'))
+  })
+
+  it('does not move focus on open when initialFocus is false', async () => {
+    const user = userEvent.setup()
+    const { getByText, getByTestId } = render(DrawerWithFocusProps, { props: { initialFocus: false } })
+    const trigger = getByText('Open')
+    await user.click(trigger)
+    await nextTick()
+    expect(document.activeElement).not.toBe(getByTestId('field'))
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('focuses the given element on open when initialFocus is an element', async () => {
+    const user = userEvent.setup()
+    const { getByText, getByTestId, rerender } = render(DrawerWithFocusProps)
+    await rerender({ initialFocus: getByTestId('outside') })
+    await user.click(getByText('Open'))
+    await nextTick()
+    expect(document.activeElement).toBe(getByTestId('outside'))
+  })
+
+  it('restores focus to the trigger on close by default', async () => {
+    const user = userEvent.setup()
+    const { getByText } = render(DrawerWithFocusProps)
+    const trigger = getByText('Open')
+    await user.click(trigger)
+    await nextTick()
+    await user.click(getByText('Close'))
+    await nextTick()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('does not restore focus on close when finalFocus is false', async () => {
+    const user = userEvent.setup()
+    const { getByText } = render(DrawerWithFocusProps, { props: { finalFocus: false } })
+    const trigger = getByText('Open')
+    await user.click(trigger)
+    await nextTick()
+    await user.click(getByText('Close'))
+    await nextTick()
+    expect(document.activeElement).not.toBe(trigger)
+  })
+
+  it('focuses the given element on close when finalFocus is an element', async () => {
+    const user = userEvent.setup()
+    const { getByText, getByTestId, rerender } = render(DrawerWithFocusProps)
+    await rerender({ finalFocus: getByTestId('outside') })
+    await user.click(getByText('Open'))
+    await nextTick()
+    await user.click(getByText('Close'))
+    await nextTick()
+    expect(document.activeElement).toBe(getByTestId('outside'))
+  })
+})

--- a/packages/core/src/Drawer/DrawerContent.vue
+++ b/packages/core/src/Drawer/DrawerContent.vue
@@ -14,7 +14,10 @@ import { useEmitAsProps, useForwardExpose, useHideOthers } from '@/shared'
 import DrawerContentImpl from './DrawerContentImpl.vue'
 import { injectDrawerRootContext } from './DrawerRoot.vue'
 
-const props = defineProps<DrawerContentProps>()
+const props = withDefaults(defineProps<DrawerContentProps>(), {
+  initialFocus: true,
+  finalFocus: true,
+})
 const emits = defineEmits<DrawerContentEmits>()
 
 const rootContext = injectDrawerRootContext()

--- a/packages/core/src/Drawer/DrawerContent.vue
+++ b/packages/core/src/Drawer/DrawerContent.vue
@@ -33,12 +33,20 @@ const shouldTrapFocus = computed(() => (isFullModal.value || isTrapFocusOnly.val
 const shouldHideOthers = computed(() => isFullModal.value ? currentElement.value : undefined)
 useHideOthers(shouldHideOthers)
 
+function finalFocusElement() {
+  if (props.finalFocus === false)
+    return undefined
+  if (props.finalFocus instanceof HTMLElement)
+    return props.finalFocus
+  return rootContext.triggerElement.value
+}
+
 // Non-modal handlers defined as named functions so the refs are accessed via
 // `.value` explicitly and the reads/writes are unambiguous.
 function onCloseAutoFocusNonModal(e: Event) {
   if (!e.defaultPrevented) {
     if (!hasInteractedOutside.value)
-      rootContext.triggerElement.value?.focus()
+      finalFocusElement()?.focus()
     e.preventDefault()
   }
   hasInteractedOutside.value = false
@@ -70,7 +78,7 @@ function onInteractOutsideNonModal(e: any) {
       @close-auto-focus="(e: Event) => {
         if (!e.defaultPrevented) {
           e.preventDefault()
-          rootContext.triggerElement.value?.focus()
+          finalFocusElement()?.focus()
         }
       }"
       @pointer-down-outside="(e: any) => {

--- a/packages/core/src/Drawer/DrawerContentImpl.vue
+++ b/packages/core/src/Drawer/DrawerContentImpl.vue
@@ -41,7 +41,10 @@ import { useSwipeDismiss } from './composables/useSwipeDismiss'
 import { injectDrawerRootContext } from './DrawerRoot.vue'
 import { computeSwipeReleaseScalar, DRAWER_CSS_VARS, getDisplacement, registerDrawerCssProperties } from './utils'
 
-const props = defineProps<DrawerContentImplProps>()
+const props = withDefaults(defineProps<DrawerContentImplProps>(), {
+  initialFocus: true,
+  finalFocus: true,
+})
 const emits = defineEmits<DrawerContentImplEmits>()
 
 const rootContext = injectDrawerRootContext()

--- a/packages/core/src/Drawer/DrawerContentImpl.vue
+++ b/packages/core/src/Drawer/DrawerContentImpl.vue
@@ -34,6 +34,7 @@ import { useResizeObserver } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, watch } from 'vue'
 import { DismissableLayer } from '@/DismissableLayer'
 import { FocusScope } from '@/FocusScope'
+import { focus } from '@/FocusScope/utils'
 import { useForwardExpose } from '@/shared'
 import { useDrawerSnapPoints } from './composables/useDrawerSnapPoints'
 import { useSwipeDismiss } from './composables/useSwipeDismiss'
@@ -255,6 +256,19 @@ function onInteractOutside(event: any) {
   emits('interactOutside', event)
 }
 
+function onMountAutoFocus(event: Event) {
+  emits('openAutoFocus', event)
+  if (event.defaultPrevented)
+    return
+  if (props.initialFocus === false) {
+    event.preventDefault()
+  }
+  else if (props.initialFocus instanceof HTMLElement) {
+    event.preventDefault()
+    focus(props.initialFocus, { select: true })
+  }
+}
+
 // --- update:openComplete wiring ---
 // Fire `update:openComplete` on the popup's own transitionend/animationend,
 // not on a microtask — consumers rely on this marker to know the enter/exit
@@ -361,7 +375,7 @@ if (process.env.NODE_ENV !== 'production') {
     as-child
     loop
     :trapped="props.trapFocus"
-    @mount-auto-focus="emits('openAutoFocus', $event)"
+    @mount-auto-focus="onMountAutoFocus"
     @unmount-auto-focus="emits('closeAutoFocus', $event)"
   >
     <DismissableLayer


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Fixes #2934

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`DrawerContent` declares and documents `initialFocus` and `finalFocus`, but nothing ever reads them, so a drawer always focuses its first tabbable element on open and always sends focus back to the trigger on close.

`initialFocus` is now read in `DrawerContentImpl`'s `mount-auto-focus` handler: `false` cancels the event so `FocusScope` skips its default focus, an element cancels it and focuses that element instead. `finalFocus` is read in `DrawerContent`, where the close handlers already decide what to restore focus to — `false` restores nothing, an element gets the focus the trigger would have had. Both keep the current behaviour when unset or `true`, and a consumer that calls `preventDefault()` on `openAutoFocus`/`closeAutoFocus` still wins.

### 📸 Screenshots (if appropriate)

n/a

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable focus behavior when opening drawers, including disabling automatic focus or selecting a specific element.
  - Added configurable focus behavior when closing drawers, including restoring focus to a chosen element, the trigger, or nowhere.
  - Drawer focus options now default to focusing on open and returning focus on close.

- **Bug Fixes**
  - Improved focus handling for modal and non-modal drawers.
  - Added support for selecting text when focusing an element on open.

- **Documentation**
  - Documented the default focus behavior for drawer props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->